### PR TITLE
Search for arbitrary status

### DIFF
--- a/elliott
+++ b/elliott
@@ -448,6 +448,12 @@ advisory.
               required=False,
               default=False, is_flag=True,
               help="AUTO mode, adds bugs based on --group")
+@click.option("--status", 'status',
+              multiple=True,
+              required=False,
+              default=['MODIFIED','VERIFIED'],
+              type=click.Choice(elliottlib.constants.VALID_BUG_STATES),
+              help="Status of the bugs")
 @click.option("--id", type=int, metavar='BUGID',
               multiple=True, required=False,
               help="Bugzilla IDs to add, conflicts with --auto [MULTIPLE]")
@@ -455,7 +461,7 @@ advisory.
               required=False, multiple=True,
               help="Optional flag to apply to found bugs [MULTIPLE]")
 @pass_runtime
-def find_bugs(runtime, advisory, auto, id, flag):
+def find_bugs(runtime, advisory, auto, status, id, flag):
     """Find Red Hat Bugzilla bugs or add them to ADVISORY. Bugs can be
 "swept" into the advisory either automatically (--auto), or by
 manually specifying one or more bugs using the --id option. Mixing
@@ -505,7 +511,7 @@ manually. Provide one or more --id's for manual bug addition.
         raise click.BadParameter("If not using --auto then one or more --id's must be provided")
 
     if auto:
-        bug_ids = elliottlib.bugzilla.search_for_bugs(target_releases)
+        bug_ids = elliottlib.bugzilla.search_for_bugs(target_releases, status)
     else:
         bug_ids = [elliottlib.bugzilla.Bug(id=i) for i in id]
 

--- a/elliottlib/bugzilla.py
+++ b/elliottlib/bugzilla.py
@@ -155,7 +155,7 @@ class SearchURL(object):
         return url
 
     def _status_string(self):
-        return "".join(["&bug_status={}".format(i) for i in self.bug_status])
+        return "&".join(["bug_status={}".format(i) for i in self.bug_status])
 
     def _version_string(self):
         return "".join(["&version={}".format(i) for i in self.versions])

--- a/elliottlib/constants.py
+++ b/elliottlib/constants.py
@@ -29,10 +29,9 @@ DEFAULT_VERSIONS = (
     "4.0", "4.0.1",
     "unspecified"
 )
-VALID_BUG_STATES = ['NEW', 'ASSIGNED', 'POST', 'MODIFED', 'ON_QA', 'VERIFIED', 'RELEASE_PENDING', 'CLOSED']
+VALID_BUG_STATES = ['NEW', 'ASSIGNED', 'POST', 'MODIFIED', 'ON_QA', 'VERIFIED', 'RELEASE_PENDING', 'CLOSED']
 
 errata_url = "https://errata.devel.redhat.com"
-bugzilla_query_url = 'https://bugzilla.redhat.com/buglist.cgi?bug_status=MODIFIED&classification=Red%20Hat&f1=component&f2=component&f3=component&f4=cf_verified&keywords=UpcomingRelease&keywords_type=nowords&known_name=All%203.x%20MODIFIED%20Bugs&list_id=8111122&o1=notequals&o2=notequals&o3=notequals&o4=notequals&product=OpenShift%20Container%20Platform&query_format=advanced&short_desc=%5C%5Bfork%5C%5D&short_desc_type=notregexp&{0}&v1=RFE&v2=Documentation&v3=Security&v4=FailedQA&version=3.0.0&version=3.1.0&version=3.1.1&version=3.2.0&version=3.2.1&version=3.3.0&version=3.3.1&version=3.4.0&version=3.4.1&version=3.5.0&version=3.5.1&version=3.6.0&version=3.6.1&version=3.7.0&version=3.7.1&version=3.8.0&version=3.8.1&version=3.9.0&version=3.9.1&version=3.10.0&version=3.10.1&version=3.11.0&version=3.11.1&version=unspecified'
 
 # For new errata
 errata_solution = """Before applying this update, make sure all previously released errata relevant to your system have been applied.


### PR DESCRIPTION
Adds a --status parameter for the find-bugs command. This also sets
the default for bug sweeps to include both MODIFIED and VERIFIED bugs