### PR TITLE
Remove all hardcoded bugzilla values

### DIFF
--- a/elliott
+++ b/elliott
@@ -339,17 +339,15 @@ manually. Provide one or more --id's for manual bug addition.
     if auto:
         # Initialization ensures a valid group was provided
         runtime.initialize()
-        # Parse the X component from the group version
-        major = major_from_branch(runtime.group_config.branch)
-        # Parse the Y component from the group version
-        minor = minor_from_branch(runtime.group_config.branch)
-        target_releases = ["{x}.{y}.z".format(x=major, y=minor), "{x}.{y}.0".format(x=major, y=minor)]
+
+        #TODO: Check if this is null
+        bz_data = runtime.gitdata.load_data(key='bugzilla').data
     elif len(id) == 0:
         # No bugs were provided
         raise click.BadParameter("If not using --auto then one or more --id's must be provided")
 
     if auto:
-        bug_ids = elliottlib.bugzilla.search_for_bugs(target_releases, status)
+        bug_ids = elliottlib.bugzilla.search_for_bugs(bz_data, status)
     else:
         bug_ids = [elliottlib.bugzilla.Bug(id=i) for i in id]
 

--- a/elliott
+++ b/elliott
@@ -339,8 +339,6 @@ manually. Provide one or more --id's for manual bug addition.
     if auto:
         # Initialization ensures a valid group was provided
         runtime.initialize()
-
-        #TODO: Check if this is null
         bz_data = runtime.gitdata.load_data(key='bugzilla').data
     elif len(id) == 0:
         # No bugs were provided
@@ -721,7 +719,9 @@ def find_transitions(runtime, current_state, changed_from, changed_to, add_comme
 \b
     $ elliott bugzilla:find-transitions --currently VERIFIED --from ASSIGNED --to ON_QA
 """
-    bug_ids = elliottlib.bugzilla.search_for_bug_transitions(current_state, changed_from, changed_to)
+    bz_data = runtime.gitdata.load_data(key='bugzilla').data
+
+    bug_ids = elliottlib.bugzilla.search_for_bug_transitions(bz_data, current_state, changed_from, changed_to)
 
     click.echo('Found the following bugs matching that transition: {}'.format(bug_ids))
 

--- a/elliottlib/bugzilla.py
+++ b/elliottlib/bugzilla.py
@@ -45,14 +45,17 @@ def search_for_bugs(bz_data, status, verbose=False):
 
     return [Bug(id=i) for i in new_bugs]
 
-def search_for_bug_transitions(current_state, changed_from, changed_to):
-    query_url = SearchURL(constants.BUGZILLA_SERVER)
+def search_for_bug_transitions(bz_data, current_state, changed_from, changed_to):
+    query_url = SearchURL(bz_data)
+
     query_url.addBugStatus(current_state)
+
     query_url.addFilterOperator("AND_G")
+
     query_url.addFilter("bug_status", "changedfrom", changed_from)
     query_url.addFilter("bug_status", "changedto", changed_to)
 
-    for v in constants.DEFAULT_VERSIONS:
+    for v in bz_data.get('version'):
         query_url.addVersion(v)
 
     changed_bugs = check_output(

--- a/elliottlib/bugzilla.py
+++ b/elliottlib/bugzilla.py
@@ -17,28 +17,23 @@ import click
 logger = logutil.getLogger(__name__)
 
 
-def search_for_bugs(target_release, status, verbose=False):
+def search_for_bugs(bz_data, status, verbose=False):
     """Search the provided target_release's for bugs in the specified states
 
     :return: A list of Bug objects
     """
-    # Example output: "target_release=3.4.z&target_release=3.5.z&target_release=3.6.z"
-    target_releases_str = ''
-    for release in target_release:
-        target_releases_str += 'target_release={0}&'.format(release)
+    query_url = SearchURL(bz_data)
 
-    query_url = SearchURL(constants.BUGZILLA_SERVER)
-    query_url.addFilter("component", "notequals", "RFE")
-    query_url.addFilter("component", "notequals", "Documentation")
-    query_url.addFilter("component", "notequals", "Security")
+    for f in bz_data.get('filter'):
+        query_url.addFilter(f.get('field'), f.get('operator'), f.get('value'))
 
-    for v in constants.DEFAULT_VERSIONS:
+    for v in bz_data.get('version'):
         query_url.addVersion(v)
 
     for s in status:
         query_url.addBugStatus(s)
 
-    for r in target_release:
+    for r in bz_data.get('target_release'):
         query_url.addTargetRelease(r)
 
     # TODO: Expose this for debugging
@@ -129,11 +124,11 @@ class SearchURL(object):
 
     url_format = "https://{}/buglist.cgi?"
 
-    def __init__(self, bz_host="bugzilla.redhat.com"):
-        self.bz_host = bz_host
+    def __init__(self, bz_data):
+        self.bz_host = bz_data.get('server')
 
-        self.classification = "Red Hat"
-        self.product = "OpenShift Container Platform"
+        self.classification = bz_data.get('classification')
+        self.product = bz_data.get('product')
         self.bug_status = []
         self.filters = []
         self.filter_operator = ""

--- a/elliottlib/constants.py
+++ b/elliottlib/constants.py
@@ -11,24 +11,6 @@ BREW_HUB = "https://brewhub.engineering.redhat.com/brewhub"
 BREW_IMAGE_HOST = "brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888"
 CGIT_URL = "http://pkgs.devel.redhat.com/cgit"
 
-# For Bugzilla searches
-BUGZILLA_SERVER = "bugzilla.redhat.com"
-DEFAULT_VERSIONS = (
-    "3.0.0",
-    "3.1.0", "3.1.1",
-    "3.2.0", "3.2.1",
-    "3.3.0", "3.3.1",
-    "3.4.0", "3.4.1",
-    "3.5.0", "3.5.1",
-    "3.6.0", "3.6.1",
-    "3.7.0", "3.7.1",
-    "3.8.0", "3.8.1",
-    "3.9.0", "3.9.1",
-    "3.10.0", "3.10.1",
-    "3.11.0", "3.11.1",
-    "4.0", "4.0.1",
-    "unspecified"
-)
 VALID_BUG_STATES = ['NEW', 'ASSIGNED', 'POST', 'MODIFIED', 'ON_QA', 'VERIFIED', 'RELEASE_PENDING', 'CLOSED']
 
 errata_url = "https://errata.devel.redhat.com"


### PR DESCRIPTION
This removes bugzilla values from the source code and into an
ocp-build-data like datastore. In addition to moving everything to
a single source of truth, this will enable non-OpenShift teams to
use the bugzilla functions of elliott in the future.