### PR TITLE
Transition to using python-bugzilla library

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ tedious and error prone.
 
    * [Basics &amp; Terminology](#basics--terminology)
    * [Setup and Installation](#setup-and-installation)
-      * [Additional Softwares](#additional-softwares)
       * [Authenticating](#authenticating)
    * [Tests](#tests)
    * [Usage](#usage)
@@ -69,18 +68,6 @@ software and bug fixes
 # Setup and Installation
 
 `pip install rh-elliott`
-
-## Additional Softwares
-
-Elliott requires additional command line tools to fully function:
-
-1. `brew` - Installation instructions are
-   [available in Mojo](https://mojo.redhat.com/docs/DOC-1071519). Requires
-   an active kerberos ticket to use.
-1. `bugzilla` - Available through DNF repos as the
-   `python-bugzilla-cli` package. **Ensure** that you run `bugzilla
-   login` after installation!
-
 
 ## Authenticating
 

--- a/elliott
+++ b/elliott
@@ -21,7 +21,7 @@ import sys
 from elliottlib import version
 from elliottlib import Runtime
 import elliottlib.constants
-import elliottlib.bugzilla
+import elliottlib.bzutil
 import elliottlib.brew
 import elliottlib.errata
 import elliottlib.exceptions
@@ -31,6 +31,7 @@ from elliottlib.exceptions import ElliottFatalError
 from elliottlib.util import *
 
 # 3rd party
+import bugzilla
 import click
 import requests
 import dotconfig
@@ -353,9 +354,10 @@ manually. Provide one or more --id's for manual bug addition.
         raise click.BadParameter("If not using --auto then one or more --id's must be provided")
 
     if auto:
-        bug_ids = elliottlib.bugzilla.search_for_bugs(bz_data, status)
+        bug_ids = elliottlib.bzutil.search_for_bugs(bz_data, status)
     else:
-        bug_ids = [elliottlib.bugzilla.Bug(id=i) for i in id]
+        bzapi = elliottlib.bzutil.get_bzapi(bz_data)
+        bug_ids = [bzapi.getbug(i) for i in id]
 
     bug_count = len(bug_ids)
 
@@ -377,13 +379,13 @@ manually. Provide one or more --id's for manual bug addition.
 
         if len(flag) > 0:
             for bug in bug_ids:
-                bug.add_flags(flag)
+                bug.update_flags({flag: "+"})
 
         advs.addBugs([bug.id for bug in bug_ids])
         advs.commit()
     else: # Add bug is false (noop)
         green_prefix("Would have added {n} bugs: ".format(n=bug_count))
-        click.echo(", ".join([str(b) for b in bug_ids]))
+        click.echo(", ".join([str(b.bug_id) for b in bug_ids]))
 
 
 #
@@ -698,73 +700,6 @@ Example to add standard metadata to a 3.10 images release
             code=result.status_code))
         exit(1)
 
-
-#
-# Find transitions
-# bugzilla:find-transitions
-#
-@cli.command("find-bug-transitions", short_help="Find bugs that have gone through the specifed transition")
-@click.option("--currently", 'current_state',
-              required=True,
-              type=click.Choice(elliottlib.constants.VALID_BUG_STATES),
-              help="State that the bug is in now")
-@click.option("--from", 'changed_from',
-              required=True,
-              type=click.Choice(elliottlib.constants.VALID_BUG_STATES),
-              help="State that the bug started in")
-@click.option("--to", 'changed_to',
-              required=True,
-              type=click.Choice(elliottlib.constants.VALID_BUG_STATES),
-              help="State that the bug ended in")
-@click.option("--add-comment", "add_comment", is_flag=True, default=False,
-              help="Add the nag comment to found bugs")
-@pass_runtime
-def find_transitions(runtime, current_state, changed_from, changed_to, add_comment):
-    """Find Red Hat Bugzilla bugs that have gone through a specifed state change. This is mainly useful for
-    finding "bad" state transitions to catch bugzilla users operating outside of a specified workflow.
-
-\b
-    $ elliott bugzilla:find-transitions --currently VERIFIED --from ASSIGNED --to ON_QA
-"""
-    bz_data = runtime.gitdata.load_data(key='bugzilla').data
-
-    bug_ids = elliottlib.bugzilla.search_for_bug_transitions(bz_data, current_state, changed_from, changed_to)
-
-    click.echo('Found the following bugs matching that transition: {}'.format(bug_ids))
-
-    if(add_comment):
-        # check if we've already commented
-        for bug in bug_ids:
-            if not bug.has_whiteboard_value('ocp_art_invalid_transition'):
-                bug.add_comment(elliottlib.constants.bugzilla_invalid_transition_comment, is_private=True)
-                click.echo('Added comment to {}'.format(bug.id))
-                bug.add_whiteboard_value('ocp_art_invalid_transition')
-            else:
-                click.echo('Skipping {} because it has already been flagged.'.format(bug))
-
-#
-# Add a comment to a bug
-# bugzilla:add-comment
-#
-@cli.command("add-bug-comment", short_help="Add a comment to a bug")
-@click.option("--id", "bug_ids",
-              multiple=True, required=True,
-              help="Bugzilla ID to add the comment to --auto [MULTIPLE]")
-@click.option("--comment", "-c", "comment",
-              required=True,
-              help="Text of the added comment")
-@click.option("--private", "is_private", is_flag=True, default=False,
-              help="Make the added comment private")
-@pass_runtime
-def add_comment(runtime, bug_ids, comment, is_private):
-    bug_list = [elliottlib.bugzilla.Bug(id=i) for i in bug_ids]
-    click.echo(bug_list)
-
-    for bug in bug_list:
-        click.echo(bug)
-        bug.add_comment(comment, is_private)
-
-    click.echo('Added comment to {}'.format(bug.id))
 
 # -----------------------------------------------------------------------------
 # CLI Entry point

--- a/elliottlib/bzutil_test.py
+++ b/elliottlib/bzutil_test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import unittest
-import bugzilla
+import bzutil
 
 hostname = "bugzilla.redhat.com"
 
@@ -15,7 +15,7 @@ class TestSearchFilter(unittest.TestCase):
         value = "RFE"
         expected = "&f1=component&o1=notequals&v1=RFE"
 
-        sf = bugzilla.SearchFilter(field_name, operator, value)
+        sf = bzutil.SearchFilter(field_name, operator, value)
         self.assertEqual(sf.tostring(1), expected)
 
 # class TestSearchURL(unittest.TestCase):

--- a/elliottlib/constants.py
+++ b/elliottlib/constants.py
@@ -64,10 +64,4 @@ errata_get_comments_url = errata_url + "/api/v1/comments"
 errata_get_erratum_url = errata_url + "/api/v1/erratum/{id}"
 errata_post_erratum_url = errata_url + "/api/v1/erratum"
 
-bugzilla_invalid_transition_comment = """There is a potential issue with this bug that may prevent it from being processed by our automation.
-
-For more information on proper bug management visit:
-https://mojo.redhat.com/docs/DOC-1178565#jive_content_id_How_do_I_get_my_Bugzilla_Bug_to_VERIFIED
-"""
-
 DISTGIT_MAX_FILESIZE = 50000000

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,6 @@ pydotconfig
 pygitdata
 pykwalify
 pyyaml
+python-bugzilla
 requests
 requests_kerberos


### PR DESCRIPTION
Move away from using shell callouts to the python-bugzilla cli and use the actual library. Also remove the deprecated bug transition searches now that we can add VERIFIED bugs regardless of the path they took to get there.