### PR TITLE
add --id parse support comma

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ cover
 
 # Ignore emacs backup files
 *~
+
+# Ignore idea backup files
+.idea

--- a/elliott
+++ b/elliott
@@ -345,7 +345,7 @@ advisory.
               default=['MODIFIED', 'VERIFIED'],
               type=click.Choice(elliottlib.constants.VALID_BUG_STATES),
               help="Status of the bugs")
-@click.option("--id", type=int, metavar='BUGID',
+@click.option("--id", metavar='BUGID', default=None,
               multiple=True, required=False,
               help="Bugzilla IDs to add, conflicts with --auto [MULTIPLE]")
 @click.option("--flag", metavar='FLAG',
@@ -430,7 +430,7 @@ advisory with the --add option.
         click.echo(" {}".format(", ".join([str(b.bug_id) for b in bug_ids])))
     else:
         bzapi = elliottlib.bzutil.get_bzapi(bz_data)
-        bug_ids = [bzapi.getbug(i) for i in id]
+        bug_ids = [bzapi.getbug(i) for i in cli_opts.id_convert(id)]
 
     if len(flag) > 0:
         for bug in bug_ids:
@@ -774,7 +774,7 @@ Example to add standard metadata to a 3.10 images release
               required=False,
               default=False, is_flag=True,
               help="AUTO mode, check all bugs attached to ADVISORY")
-@click.option("--id", type=int, metavar='BUGID',
+@click.option("--id", default=None, metavar='BUGID',
               multiple=True, required=False,
               help="Bugzilla IDs to modify, conflicts with --auto [MULTIPLE]")
 @click.option("--from", "original_state",
@@ -815,7 +815,7 @@ Example to look for bugs that have been moved back to MODIFIED
         e = Erratum(errata_id=advisory)
         attached_bugs = [bzapi.getbug(i) for i in e.errata_bugs]
     else:
-        attached_bugs = [bzapi.getbug(i) for i in id]
+        attached_bugs = [bzapi.getbug(i) for i in cli_opts.id_convert(id)]
 
     for bug in attached_bugs:
         if(bug.status in original_state):

--- a/elliottlib/cli_opts.py
+++ b/elliottlib/cli_opts.py
@@ -16,3 +16,18 @@ CLI_OPTS = {
 CLI_ENV_VARS = {k: v['env'] for (k, v) in CLI_OPTS.iteritems()}
 
 CLI_CONFIG_TEMPLATE = '\n'.join(['#{}\n{}:\n'.format(v['help'], k) for (k, v) in CLI_OPTS.iteritems()])
+
+
+def id_convert(ids):
+    # this function convert string list param --id "1" --id "2" --id "3,4,5"
+    # to int list [1,2,3,4,5]
+    id_str = []
+    for id in ids:
+        # id = "1234,42345,1234,"
+        if ',' in id:
+            for k in [c.strip() for c in id.split(',')]:
+                id_str.append(k)
+        # id = 123  no ','
+        else:
+            id_str.append(id)
+    return [int(s) for s in id_str]

--- a/elliottlib/cli_opts_test.py
+++ b/elliottlib/cli_opts_test.py
@@ -1,0 +1,23 @@
+"""
+Test the cli options functions
+"""
+import unittest
+
+import cli_opts
+
+
+class TestCLI(unittest.TestCase):
+    """
+    Test the methods of the assertion module.
+
+    Each raises an exception if the asserted test fails.
+    """
+    def test_id_convert(self):
+        self.assertEqual(cli_opts.id_convert(["1", "2", "3,4,5"]), [1, 2, 3, 4, 5])
+        self.assertEqual(cli_opts.id_convert(["1,2,3", "4", "5"]), [1, 2, 3, 4, 5])
+        self.assertEqual(cli_opts.id_convert(["1", "2", "3", "4", "5"]), [1, 2, 3, 4, 5])
+        self.assertEqual(cli_opts.id_convert(["1,2,3,4,5"]), [1, 2, 3, 4, 5])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
fixes https://github.com/openshift/elliott/issues/34#issuecomment-484076209

now it supports multiple ways
```
➜  elliott git:(master) ./elliott --group openshift-4.0 find-bugs --id 123,345 --id 1234 --id 123 --id 3,43,3,2,4,6
```