### PR TITLE
Repair-bugs: New options, doc refresh, and speed improvements.

### DIFF
--- a/elliott
+++ b/elliott
@@ -767,7 +767,6 @@ Example to add standard metadata to a 3.10 images release
 #
 @cli.command("repair-bugs", short_help="Move bugs attached to ADVISORY from one state to another")
 @click.option("--advisory", "-a",
-              required=True,
               metavar='ADVISORY',
               help="Repair bugs attached to ADVISORY.")
 @click.option("--auto",
@@ -781,20 +780,60 @@ Example to add standard metadata to a 3.10 images release
               multiple=True,
               default=['MODIFIED'],
               type=click.Choice(elliottlib.constants.VALID_BUG_STATES),
-              help="Status of the bugs")
+              help="Current state of the bugs (default: MODIFIED)")
 @click.option("--to", "new_state",
               default='ON_QA',
               type=click.Choice(elliottlib.constants.VALID_BUG_STATES),
-              help="Status of the bugs")
+              help="Final state of the bugs (default: ON_QA)")
+@click.option("--noop", "--dry-run",
+              required=False,
+              default=False, is_flag=True,
+              help="Check bugs attached, print what would change, but don't change anything")
+@click.option("--use-default-advisory", 'default_advisory_type',
+              metavar='ADVISORY_TYPE',
+              type=click.Choice(['image', 'rpm', 'security']),
+              help="Use the default value from ocp-build-data for ADVISORY_TYPE [image, rpm, security]")
 @pass_runtime
-def repair_bugs(runtime, advisory, auto, id, original_state, new_state):
-    """Move bugs attached to the advisory from one state to another state. This is useful
-if the bugs have changed states *after* they were attached.
+def repair_bugs(runtime, advisory, auto, id, original_state, new_state, noop, default_advisory_type):
+    """Move bugs attached to the advisory from one state to another
+state. This is useful if the bugs have changed states *after* they
+were attached. Similar to `find-bugs` but in reverse. `repair-bugs`
+begins by reading bugs from an advisory, whereas `find-bugs` reads
+from bugzilla.
 
-Example to look for bugs that have been moved back to MODIFIED
+This looks at attached bugs in the provided --from state and moves
+them to the provided --to state.
 
 \b
-    $ elliott --group=openshift-4.0 repair-bugs --from MODIFIED --to ON_QA
+    Background: This is intended for bugs which went to MODIFIED, were
+    attached to advisories, set to ON_QA, and then failed
+    testing. When this happens their state is reset back to ASSIGNED.
+
+Using --use-default-advisory without a value set for the matching key
+in the build-data will cause an error and elliott will exit in a
+non-zero state. Most likely you will only want to use the `rpm` state,
+but that could change in the future. Use of this option silently
+overrides providing an advisory with the -a/--advisory option.
+
+    Move bugs on 123456 FROM the MODIFIED state back TO ON_QA state:
+
+\b
+    $ elliott --group=openshift-4.1 repair-bugs --auto --advisory 123456 --from MODIFIED --to ON_QA
+
+    As above, but using the default RPM advisory defined in ocp-build-data:
+
+\b
+    $ elliott --group=openshift-4.1 repair-bugs --auto --use-default-advisory rpm --from MODIFIED --to ON_QA
+
+    The previous examples could also be ran like this (MODIFIED and ON_QA are both defaults):
+
+\b
+    $ elliott --group=openshift-4.1 repair-bugs --auto --use-default-advisory rpm
+
+    Bug ids may be given manually instead of using --auto:
+
+\b
+    $ elliott --group=openshift-4.1 repair-bugs --id 170899 --id 8675309 --use-default-advisory rpm
 """
     if auto and len(id) > 0:
         raise click.BadParameter("Combining the automatic and manual bug modification options is not supported")
@@ -803,33 +842,78 @@ Example to look for bugs that have been moved back to MODIFIED
         # No bugs were provided
         raise click.BadParameter("If not using --auto then one or more --id's must be provided")
 
+    if len(id) == 0 and advisory is None and default_advisory_type is None:
+        # error, no bugs, advisory, or default selected
+        raise click.BadParameter("No input provided: Must use one of --id, --advisory, or --use-default-advisory")
+
     # Load bugzilla infomation and get a reference to the api
     runtime.initialize()
     bz_data = runtime.gitdata.load_data(key='bugzilla').data
     bzapi = elliottlib.bzutil.get_bzapi(bz_data)
-
     changed_bug_count = 0
     attached_bugs = []
 
-    if auto:
-        e = Erratum(errata_id=advisory)
-        attached_bugs = [bzapi.getbug(i) for i in e.errata_bugs]
-    else:
-        attached_bugs = [bzapi.getbug(i) for i in cli_opts.id_convert(id)]
+    # if --use-default-advisory is set we will override a user
+    # provided advisory
+    if default_advisory_type is not None:
+        default_advisory = runtime.group_config.advisories.get(default_advisory_type, None)
+        if default_advisory is not None:
+            advisory = default_advisory
+            green_prefix("Default advisory detected: ")
+            click.echo(advisory)
+        else:
+            red_prefix("No value defined for default advisory:")
+            click.echo(" The key `advisories.{}` is not defined for group {} in group.yml".format(
+                default_advisory_type, runtime.group))
+            exit(1)
 
+    raw_bug_list = []
+    if auto:
+        click.echo("Fetching Erratum(errata_id={})".format(advisory))
+        e = Erratum(errata_id=advisory)
+        raw_bug_list = e.errata_bugs
+    else:
+        click.echo("Bypassed fetching erratum, using provided BZs")
+        raw_bug_list = cli_opts.id_convert(id)
+
+    green_print("Getting bugs for advisory")
+
+    # Fetch bugs in parallel because it can be really slow doing it
+    # one-by-one when you have hundreds of bugs
+    pbar_header("Fetching data for {} bugs: ".format(len(raw_bug_list)),
+                "Hold on a moment, we have to grab each one",
+                raw_bug_list)
+    pool = ThreadPool(cpu_count())
+    click.secho("[", nl=False)
+
+    attached_bugs = pool.map(
+        lambda bug: progress_func(lambda: bzapi.getbug(bug), '*'),
+        raw_bug_list)
+    # Wait for results
+    pool.close()
+    pool.join()
+    click.echo(']')
+
+    green_print("Got bugs for advisory")
     for bug in attached_bugs:
         if(bug.status in original_state):
             changed_bug_count += 1
-            click.echo("Changing BZ#{bug_id} from {initial} to {final}".format(
-                       bug_id=bug.bug_id,
-                       initial=bug.status,
-                       final=new_state))
+            if noop:
+                click.echo("Would have changed BZ#{bug_id} from {initial} to {final}".format(
+                    bug_id=bug.bug_id,
+                    initial=bug.status,
+                    final=new_state))
+            else:
+                click.echo("Changing BZ#{bug_id} from {initial} to {final}".format(
+                    bug_id=bug.bug_id,
+                    initial=bug.status,
+                    final=new_state))
+                bug.setstatus(status=new_state,
+                              comment="Elliott changed bug status from {initial} to {final}.".format(initial=original_state, final=new_state),
+                              private=True)
 
-            bug.setstatus(status=new_state,
-                          comment="Elliott changed bug status from {initial} to {final}.".format(initial=original_state, final=new_state),
-                          private=True)
 
-    green_print("{} bugs successfullly modified".format(changed_bug_count))
+    green_print("{} bugs successfullly modified (or would have been)".format(changed_bug_count))
 
 
 #


### PR DESCRIPTION
Repair bugs has been updated to now include:

* Support for the `--use-default-advisory` option
* Clearer help text
* A `--noop` (`--dry-run`) mode
* Looking up bugs in parallel