### PR TITLE
List installation dependencies on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ software and bug fixes
 
 `pip install rh-elliott`
 
+## Dependencies
+
+* [krb5-devel](https://apps.fedoraproject.org/packages/krb5-devel)
+* [python2-devel](https://apps.fedoraproject.org/packages/python2-devel)
+* [python2-rpm](https://apps.fedoraproject.org/packages/python2-rpm)
+* [redhat-rpm-config](https://apps.fedoraproject.org/packages/redhat-rpm-config)
+
 ## Authenticating
 
 Ensure you have a valid kerberos ticket before proceeding. A valid


### PR DESCRIPTION
I attempted to install elliott (via `pip install rh-elliott`) in a fresh Fedora 29, and it didn't succeed until I had installed all the packages listed on this PR.
Just thought it might be useful to have such dependencies list on the README for future reference.

Worth to mention that those are only the dependencies I didn't have installed on my machine, but I noticed that the installation also relies on `gcc` (and probably relies on even more packages that were already present).