### PR TITLE
correct misleading date format info

### DIFF
--- a/elliott
+++ b/elliott
@@ -156,7 +156,7 @@ Bugzilla Bugs.
 @click.option("--date", required=False,
               default=default_release_date.strftime(YMD),
               callback=validate_release_date,
-              help="Release date for the advisory. Optional. Format: YYYY-MM-DD. Defaults to 3 weeks after the release with the highest date for that series")
+              help="Release date for the advisory. Optional. Format: YYYY-Mon-DD. Defaults to 3 weeks after the release with the highest date for that series")
 @click.option('--assigned-to', metavar="EMAIL_ADDR", required=True,
               envvar="ELLIOTT_ASSIGNED_TO_EMAIL",
               callback=validate_email_address,
@@ -183,7 +183,7 @@ def create(ctx, runtime, errata_type, kind, impetus, date, assigned_to, manager,
 
 New advisories will be created with a Release Date set to 3 weeks (21
 days) from now. You may customize this (especially if that happens to
-fall on a weekend) by providing a YYYY-MM-DD formatted string to the
+fall on a weekend) by providing a YYYY-Mon-DD formatted string to the
 --date option.
 
 The default behavior for this command is to show what the generated
@@ -208,7 +208,7 @@ advisory.
     CREATE Image Advisory for the 3.5 series on the first Monday in March:
 
 \b
-    $ elliott --group openshift-3.5 create --yes -k image --date 2018-03-05
+    $ elliott --group openshift-3.5 create --yes -k image --date 2018-Mar-05
 """
     runtime.initialize()
 

--- a/elliottlib/errata.py
+++ b/elliottlib/errata.py
@@ -144,7 +144,7 @@ def new_erratum(et_data, errata_type=None, kind=None, release_date=None, create=
     :param et_data: The ET data dump we got from our erratatool.yaml file
     :param errata_type: The type of advisory to create (RHBA, RHSA, or RHEA)
     :param string kind: One of 'rpm' or 'image', effects boilerplate text
-    :param string release_date: A date in the form YYYY-MM-DD
+    :param string release_date: A date in the form YYYY-Mon-DD
     :param bool create: If true, create the erratum in the Errata
         tool, by default just the DATA we would have POSTed is
         returned

--- a/elliottlib/util.py
+++ b/elliottlib/util.py
@@ -77,7 +77,7 @@ def validate_release_date(ctx, param, value):
             click.echo("{} - Validated".format(release_date.strftime(YMD)))
         return value
     except ValueError:
-        raise click.BadParameter('Release date (--date) must be in YYYY-MM-DD format')
+        raise click.BadParameter('Release date (--date) must be in YYYY-Mon-DD format')
 
 
 def validate_email_address(ctx, param, value):


### PR DESCRIPTION
I might actually rather go in the direction of using the YYYY-MM-DD
format for the date, and simply reformat it when handing off to
errata-tool. But I could also see an argument that it's good for elliott
to use a consistent format as errata does.

Either way the help and errors should not give users the wrong format.