### PR TITLE
[ART-544] (part 4 of 4) Run `tox` on Travis

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -1,0 +1,8 @@
+FROM centos:7
+
+RUN yum install -y epel-release gcc krb5-devel python-devel
+RUN yum install -y python-pip
+RUN pip install tox
+
+ENV PYTHONDONTWRITEBYTECODE 1
+ENTRYPOINT ["tox"]

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: python
 python:
 - '2.7'
 install:
-- echo "Disabling requirements.txt install. Will not work on Travis."
+- docker build -f .ci/Dockerfile -t elliott-ci-env .
 script:
-- echo "We should run tests here"
+- docker run -it --rm -v $(pwd):/code -w /code elliott-ci-env
 deploy:
   provider: pypi
   skip_cleanup: true


### PR DESCRIPTION
On this PR I'm making Travis run `tox` inside a container, but during development
we have a choice of running either inside the container or directly on the host.

    $ podman build -f .ci/Dockerfile -t elliott-ci-env .
    $ podman run -it --rm -v $(pwd):/code -w /code elliott-ci-env

or simply:

    $ tox

Related ticket:
https://jira.coreos.com/browse/ART-547