### PR TITLE
Update find-bugs to generate a report

### DIFF
--- a/elliott
+++ b/elliott
@@ -437,8 +437,12 @@ def find_default_advisory(runtime, default_advisory_type, quiet=False):
 @click.option("--flag", metavar='FLAG',
               required=False, multiple=True,
               help="Optional flag to apply to found bugs [MULTIPLE]")
+@click.option("--report",
+              required=False,
+              is_flag=True,
+              help="Output a detailed report of the found bugs")
 @pass_runtime
-def find_bugs(runtime, advisory, default_advisory_type, mode, status, id, from_diff, flag):
+def find_bugs(runtime, advisory, default_advisory_type, mode, status, id, from_diff, flag, report):
     """Find Red Hat Bugzilla bugs or add them to ADVISORY. Bugs can be
 "swept" into the advisory either automatically (--mode sweep), or by
 manually specifying one or more bugs using --mode list and the --id option.
@@ -517,6 +521,18 @@ advisory with the --add option.
 
     green_prefix("Found {} bugs:".format(len(bug_ids)))
     click.echo(" {}".format(", ".join([str(b.bug_id) for b in bug_ids])))
+
+    if report:
+        green_print("{:<8s} {:<25s} {:<12s} {:<7s} {:<10s} {:60s}".format("ID", "COMPONENT", "STATUS", "SCORE", "AGE", "SUMMARY"))
+        for bug in bug_ids:
+            created_date = datetime.datetime.strptime(str(bug.creation_time), '%Y%m%dT%H:%M:%S')
+            days_ago = (datetime.datetime.today() - created_date).days
+            click.echo("{:<8d} {:<25s} {:<12s} {:<7s} {:<3d} days   {:60s} ".format(bug.id,
+                                                                                    bug.component,
+                                                                                    bug.status,
+                                                                                    bug.cf_pm_score,
+                                                                                    days_ago,
+                                                                                    bug.summary[:60].encode('ascii','replace')))
 
     if len(flag) > 0:
         for bug in bug_ids:

--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -88,7 +88,7 @@ def search_for_bugs(bz_data, status, search_filter='default', filter_out_securit
     if verbose:
         click.echo(query_url)
 
-    return _perform_query(bzapi, query_url)
+    return _perform_query(bzapi, query_url, include_fields=['id', 'status', 'summary', 'creation_time', 'cf_pm_score', 'component'])
 
 
 def search_for_security_bugs(bz_data, status=None, search_filter='security', cve=None, verbose=False):


### PR DESCRIPTION
**Note:** This PR is just rebased https://github.com/openshift/elliott/pull/33

find-bugs has value as it lets us define exactly which bugs will be
attached to an advisory based on declaritive filters. This update will
allow users to see more useful information about those bugs other than
just the IDs.

#### without `--report` flag:

```
$ elliott --group=openshift-4.1 find-bugs --id 1755350
2019-10-14 15:41:32,183 INFO Data clone directory already exists, checking commit sha
2019-10-14 15:41:36,647 INFO git@gitlab.cee.redhat.com:openshift-art/ocp-build-data.git is already cloned and latest
2019-10-14 15:41:36,747 INFO Using branch from group.yml: rhaos-4.1-rhel-7
Found 1 bugs: 1755350
```

#### with `--report` flag:
```
$ elliott --group=openshift-4.1 find-bugs --id 1755350 --report
2019-10-14 15:41:20,802 INFO Data clone directory already exists, checking commit sha
2019-10-14 15:41:24,593 INFO git@gitlab.cee.redhat.com:openshift-art/ocp-build-data.git is already cloned and latest
2019-10-14 15:41:24,688 INFO Using branch from group.yml: rhaos-4.1-rhel-7
Found 1 bugs: 1755350
ID       COMPONENT                 STATUS       SCORE   AGE        SUMMARY                                                     
1755350  Release                   VERIFIED     0       19  days   Placeholder bug for OCP 4.1.z rpm release                    
```