### PR TITLE
ART-1055: tarball sources includes lookaside-cache sources from dist-git

### DIFF
--- a/elliottlib/constants.py
+++ b/elliottlib/constants.py
@@ -6,6 +6,16 @@ BREW_HUB = "https://brewhub.engineering.redhat.com/brewhub"
 BREW_IMAGE_HOST = "brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888"
 CGIT_URL = "http://pkgs.devel.redhat.com/cgit"
 
+DIST_GIT_CONFIG = {
+    "pkgs.devel.redhat.com": {
+        "lookaside_cache": {
+            "hash_type": "md5",
+            "download_url": "http://pkgs.devel.redhat.com/repo",
+            "upload_url": "http://pkgs.devel.redhat.com/lookaside/upload.cgi"
+        }
+    }
+}
+
 VALID_BUG_STATES = ['NEW', 'ASSIGNED', 'POST', 'MODIFIED', 'ON_QA', 'VERIFIED', 'RELEASE_PENDING', 'CLOSED']
 
 BUG_SEVERITY = ["low", "medium", "high", "urgent"]

--- a/elliottlib/distgit.py
+++ b/elliottlib/distgit.py
@@ -1,0 +1,75 @@
+from __future__ import division, unicode_literals
+import requests
+from elliottlib import constants
+from pyrpkg.lookaside import CGILookasideCache
+from pyrpkg.sources import SourcesFile
+from urlparse import urljoin, urlparse
+from elliottlib.logutil import getLogger
+
+LOGGER = getLogger()
+
+
+class DistGitRepo(object):
+    """ Represents a dist-git repository.
+    Currently only lookaside cache related methods are implemented.
+    """
+
+    def __init__(self, repo_url):
+        """ Initialize DistGitRepo with a repository URL
+        """
+        url = urlparse(repo_url)
+        self.url = url
+        self.scheme = url.scheme
+        self.host = url.netloc
+        self.component = url.path.strip("/")
+
+    def get_lookaside_cache(self):
+        """ Get the lookaside cache from configuration for this repository
+        :returns: None if not found.
+        """
+        config = constants.DIST_GIT_CONFIG.get(self.url.netloc)
+        if not config:  # This is not a dist-git repo
+            return None
+        cache_config = config.get("lookaside_cache")
+        if not cache_config:
+            return None
+        return CGILookasideCache(cache_config["hash_type"], cache_config["download_url"], cache_config["upload_url"])
+
+    def download_lookaside_source(self, filename, hash, fileobj, session=None):
+        """ Download source from lookaside cache
+        :param filename: filename of the source
+        :param hash: hexstring of source hash
+        :param fileobj: file object to save the downloaded source
+        :param session: optional requests.Session object
+        :returns: number of bytes written to fileobj
+        """
+        lookaside = self.get_lookaside_cache()
+        download_url = lookaside.get_download_url(self.component, filename, hash)
+        LOGGER.info("Downloading dist-git lookaside source {} from {}...".format(filename, download_url))
+        if not session:
+            session = requests.session()
+        response = session.get(download_url, stream=True)
+        response.raise_for_status()
+        content_length = int(response.headers.get("Content-length", "-1"))
+        downloaded = 0
+        for chunk in response.iter_content(chunk_size=1024 * 1024):
+            if chunk:  # filter out keep-alive new chunks
+                fileobj.write(chunk)
+                downloaded += len(chunk)
+                if content_length < 0:  # unknown content length
+                    LOGGER.debug("Downloading {}: {}".format(filename, downloaded))
+                else:
+                    LOGGER.debug("Downloading {} ({:.2%}): {}/{}".format(filename, downloaded / content_length, downloaded, content_length))
+        fileobj.flush()
+        return downloaded
+
+
+def parse_lookaside_sources(file_obj):
+    """ Parse dist-git `sources` file.
+    :file_obj: File object for the sources file.
+    """
+    sources = SourcesFile(None, "old", True)
+    for line in file_obj:
+        entry = sources.parse_line(line)
+        sources.entries.append(entry)
+    return sources

--- a/elliottlib/util.py
+++ b/elliottlib/util.py
@@ -3,6 +3,8 @@ import datetime
 from multiprocessing import cpu_count
 from multiprocessing.dummy import Pool as ThreadPool
 import re
+import os
+import errno
 
 from errata_tool import Erratum
 from kerberos import GSSError
@@ -247,3 +249,15 @@ def override_product_version(pv, branch):
             return 'OSE-{}-RHEL-{}'.format(rb[1], rb[3])
         return 'RHEL-{}-OSE-{}'.format(rb[3], rb[1])
     return pv
+
+
+def mkdirs(path):
+    """ Make sure a directory exists. Similar to shell command `mkdir -p`.
+
+    This function will not be necessary when fully migrated to Python 3.
+    """
+    try:
+        os.makedirs(path)
+    except OSError as e:
+        if e.errno != errno.EEXIST:  # ignore if dest_dir exists
+            raise

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,5 @@ python-bugzilla
 pyyaml
 requests
 requests_kerberos
+rpkg
 typing

--- a/tests/test_distgit.py
+++ b/tests/test_distgit.py
@@ -1,0 +1,37 @@
+import unittest
+import io
+from elliottlib import distgit
+import mock
+
+
+class TestDistGit(unittest.TestCase):
+    def parse_lookaside_sources(self):
+        sources_file = io.BytesIO(b"2ba370dd5e06259ec4fa3b22c50ad2f9  openshift-clients-git-1.c8c7aaa.tar.gz")
+        sources = distgit.parse_lookaside_sources(sources_file)
+        self.assertEqual(sources.entries[0].hash, "2ba370dd5e06259ec4fa3b22c50ad2f9")
+        self.assertEqual(sources.entries[0].file, "openshift-clients-git-1.c8c7aaa.tar.gz")
+
+
+class TestDistGitRepo(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def test_get_lookaside_cache(self):
+        lookaside = distgit.DistGitRepo("git://unknown.example.com/rpms/openshift-clients").get_lookaside_cache()
+        self.assertEqual(lookaside, None)
+        lookaside = distgit.DistGitRepo("git://pkgs.devel.redhat.com/rpms/openshift-clients").get_lookaside_cache()
+        self.assertNotEqual(lookaside, None)
+
+    def test_download_lookaside_source(self):
+        repo = distgit.DistGitRepo("git://pkgs.devel.redhat.com/rpms/openshift-clients")
+        source_hash = "2ba370dd5e06259ec4fa3b22c50ad2f9"
+        source_content = b"abcdefg"
+        mock_response = mock.MagicMock()
+        mock_response.iter_content.return_value = [source_content]
+        mock_session = mock.MagicMock()
+        mock_session.get.return_value = mock_response
+        downloaded_file = io.BytesIO()
+        downloaded_bytes = repo.download_lookaside_source("example.txt", source_hash, downloaded_file, session=mock_session)
+        downloaded_file.seek(0)
+        self.assertEqual(downloaded_file.read(), source_content)
+        self.assertEqual(downloaded_bytes, len(source_content))


### PR DESCRIPTION
When use `elliott tarball-sources create`, it also fetches lookaside-cache sources.

## For reviewers:

I used `eliott --debug tarball-sources create --component=openshift-clients --out-dir=out/ --force 43535` to create a source tarball for `openshift-clients` build that is attached to advisory `43535`.
By extracting the content of created tarball, you can see another tarball inside, which is the source stored in dist-git lookaside cache (defined in `sources` at dist-git repo root.)