### PR TITLE
Set correct permissions on rcm-guest for tarball sources

### DIFF
--- a/elliottlib/cli/tarball_sources_cli.py
+++ b/elliottlib/cli/tarball_sources_cli.py
@@ -136,7 +136,7 @@ Use --force to add new tarball sources to an existing directory.".format(os.path
 
                 LOGGER.debug("Copying {} to {}...".format(
                     temp_tarball_path, tarball_abspath))
-                shutil.copy2(temp_tarball_path, tarball_abspath)
+                shutil.copyfile(temp_tarball_path, tarball_abspath)  # `shutil.copyfile` uses default umask
                 tarball_sources_list.append(tarball_abspath)
                 util.green_print(
                     "Created tarball source {}.".format(tarball_abspath))
@@ -167,7 +167,7 @@ All tarball sources are successfully created.
 
 To send all tarball sources to rcm-guest, run:
 
-    rsync -avz {} ocp-build@rcm-guest.app.eng.bos.redhat.com:/mnt/rcm-guest/puddles/RHAOS/container-sources/
+    rsync -avz --chmod=go+rX {} ocp-build@rcm-guest.app.eng.bos.redhat.com:/mnt/rcm-guest/puddles/RHAOS/container-sources/
 
 Then notify RCM (https://projects.engineering.redhat.com/projects/RCM/issues) that the following tarball sources have been uploaded to rcm-guest:
 


### PR DESCRIPTION
Per https://projects.engineering.redhat.com/browse/RCM-68294,
it would be more convenient for RCM if the file permissions
of tarball sources include read for other (o+r).

This PR uses `shutils.copyfile` rather than `shutils.copy2` to honor the umask for creating local tarballs,
and changes the instructions of sending to rcm-guest to explicitly set `r` for files and `rx` for directories.