### PR TITLE
Always pull latest CI image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,7 @@ pipeline {
     agent {
         docker {
             image "redhat/art-ci-toolkit:latest"
+            alwaysPull true
             args "--entrypoint=''"
         }
     }


### PR DESCRIPTION
Jenkins changed this behavior, just pulling the latest image if explicitly specified: https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/199