### PR TITLE
ART-1011 improve rhsa creation

### DIFF
--- a/.devcontainer/settings.yaml
+++ b/.devcontainer/settings.yaml
@@ -2,7 +2,7 @@
 working_dir: /workspaces/elliott-working-dir
 
 #Git URL or File Path to build data
-data_path: https://gitlab.cee.redhat.com/openshift-art/ocp-build-data.git
+data_path: https://github.com/openshift/ocp-build-data.git
 
 #Sub-group directory or branch to pull build data
 # group:

--- a/elliottlib/constants.py
+++ b/elliottlib/constants.py
@@ -88,5 +88,6 @@ errata_get_comment_url = errata_url + "/api/v1/comments/{id}"
 errata_get_comments_url = errata_url + "/api/v1/comments"
 errata_get_erratum_url = errata_url + "/api/v1/erratum/{id}"
 errata_post_erratum_url = errata_url + "/api/v1/erratum"
+errata_get_advisories_for_bug_url = errata_url + "/bugs/{id}/advisories.json"
 
 DISTGIT_MAX_FILESIZE = 50000000

--- a/tests/test_bzutil.py
+++ b/tests/test_bzutil.py
@@ -44,6 +44,21 @@ class TestBZUtil(unittest.TestCase):
             actual = bzutil.get_tracker_flaws_map(None, trackers.values())
             self.assertEqual(expected, actual)
 
+    def test_is_viable_bug(self):
+        bug = mock.MagicMock()
+        bug.status = "MODIFIED"
+        self.assertTrue(bzutil.is_viable_bug(bug))
+        bug.status = "ASSIGNED"
+        self.assertFalse(bzutil.is_viable_bug(bug))
+
+    def test_is_cve_tracker(self):
+        bug = mock.MagicMock(keywords=[])
+        self.assertFalse(bzutil.is_cve_tracker(bug))
+        bug.keywords.append("Security")
+        self.assertFalse(bzutil.is_cve_tracker(bug))
+        bug.keywords.append("SecurityTracking")
+        self.assertTrue(bzutil.is_cve_tracker(bug))
+
 
 class TestSearchFilter(unittest.TestCase):
 


### PR DESCRIPTION
- Provide more correct boilerplate text for different kinds of advisories.
     See https://github.com/openshift/ocp-build-data/pull/183 for example.
- Raise an error if any bug is not viable:
  - For RHBA, assert bugs are in one of `MODIFIED`, `ON_QA`, or `VERIFIED` state and not attached to any other advisories.
  - For RHSA, perform the same checks as RHBA then validate they are tracker bugs.
- When running without `--yes` (preview mode), also print the full list of bugs that would be attached.
- CLI: Add help text and alias `--bug` for option `--bugs`

1. This PR doesn't prevent users from attaching a security bug to an RHBA/RHEA. Not sure if we should do that.
2. Boilerplate text updates:

  - 4.2 https://github.com/openshift/ocp-build-data/pull/183

  - 4.1 https://github.com/openshift/ocp-build-data/pull/184

  - 4.3 https://github.com/openshift/ocp-build-data/pull/185

  - 3.11 https://github.com/openshift/ocp-build-data/pull/186

3. It continues to use the existing boilerplate text as fallback so those ocp build data PRs are not blockers.

Test command:
`elliott --group=openshift-4.1 --debug create --type=RHSA --date=2019-Oct-12 --assigned-to=yuxzhu@redhat.com --manager=yuxzhu@redhat.com --package-owner=yuxzhu@redhat.com --kind=rpm --bugs=1757046`