### PR TITLE
ART-1192: Fix RHSA creation when no severity set on the tracking bug

### DIFF
--- a/elliottlib/cli/create_cli.py
+++ b/elliottlib/cli/create_cli.py
@@ -152,8 +152,18 @@ advisory.
     flaw_cve_map = {}
     impact = None
     unique_bugs = set(bugs)
-    if errata_type == 'RHSA':
-        flaw_cve_map, impact = elliottlib.bzutil.get_flaws(bz_data, unique_bugs)
+
+    if bugs:
+        bzapi = elliottlib.bzutil.get_bzapi(bz_data)
+        LOGGER.info("Fetching bugs {} from Bugzilla...".format(" ".join(map(str, bugs))))
+        bug_objects = bzapi.getbugs(bugs)
+        if errata_type == 'RHSA':
+            LOGGER.info("Fetching flaw bugs for trackers {}...".format(" ".join(map(str, bugs))))
+            tracker_flaws_map = elliottlib.bzutil.get_tracker_flaws_map(bzapi, bug_objects)
+            impact = elliottlib.bzutil.get_highest_impact(bug_objects, tracker_flaws_map)
+            flaw_bugs = [flaw for tracker, flaws in tracker_flaws_map.items() for flaw in flaws]
+            flaw_cve_map = elliottlib.bzutil.get_flaw_aliases(flaw_bugs)
+            unique_bugs |= set(flaw_cve_map.keys())
 
     ######################################################################
 

--- a/elliottlib/constants.py
+++ b/elliottlib/constants.py
@@ -8,8 +8,17 @@ CGIT_URL = "http://pkgs.devel.redhat.com/cgit"
 
 VALID_BUG_STATES = ['NEW', 'ASSIGNED', 'POST', 'MODIFIED', 'ON_QA', 'VERIFIED', 'RELEASE_PENDING', 'CLOSED']
 
-BUG_SEVERITY = ["low", "medium", "high", "urgent"]
-SECURITY_IMPACT = ["Low", "Moderate", "Important", "Critical"]
+BUG_SEVERITY_NUMBER_MAP = {
+    "unspecified": 0,
+    "low": 1,
+    "medium": 2,
+    "high": 3,
+    "urgent": 4,
+}
+
+# When severity isn't set on all tracking and flaw bugs, default to "Low"
+# https://jira.coreos.com/browse/ART-1192
+SECURITY_IMPACT = ["Low", "Low", "Moderate", "Important", "Critical"]
 
 errata_url = "https://errata.devel.redhat.com"
 

--- a/elliottlib/errata.py
+++ b/elliottlib/errata.py
@@ -12,16 +12,17 @@ import copy
 import datetime
 import json
 import ssl
-import constants
 import brew
 import re
-from elliottlib import exceptions
+from elliottlib import exceptions, constants
 from elliottlib.util import green_prefix, exit_unauthenticated
 
 import requests
 from requests_kerberos import HTTPKerberosAuth
-from errata_tool import Erratum, ErrataException
 from kerberos import GSSError
+from errata_tool import Erratum, ErrataException, ErrataConnector
+
+ErrataConnector._url = constants.errata_url
 
 
 def find_mutable_erratum(kind, minor, major=3):


### PR DESCRIPTION
According to ART-1192, if a tracking bug has `unspecified` severity,
we need to check the severity of the flaw bugs. If all flaw bugs have `unspecified` severity, we will default the impact to `Low` (ProdSec can correct it later).

Also makes the errata_tool lib honor the Errata Tool URL constant `elliottlib.constants.errata_url`.

## For reviewers

You can test this PR by creating an RHSA using a tracking bug with `unspecified` severity. For example, bug 1757044:

- Without this PR:

``` bash
$ elliott -g openshift-4.2 create -k image --impetus cve -t RHSA --date 2019-Nov-05 --assigned-to openshift-qe-errata@redhat.com --manager vlaad@redhat.com --package-owner lmeyer@redhat.com --bugs 1757044

$ elliott -g openshift-4.2 create -k image --impetus cve -t RHSA --date 2019-Nov-05 --assigned-to openshift-qe-errata@redhat.com --manager vlaad@redhat.com --package-owner lmeyer@redha
t.com --bugs 1757044
User provided release date: 2019-Nov-05 - Validated
2019-10-28 09:23:59,991 INFO Data clone directory already exists, checking commit sha
2019-10-28 09:24:00,008 INFO Cloning config data from https://gitlab.cee.redhat.com/openshift-art/ocp-build-data
2019-10-28 09:24:00,836 INFO Using branch from group.yml: rhaos-4.2-rhel-7
elliott requires cached login credentials for bugzilla.redhat.com
Traceback (most recent call last):
  File "/usr/bin/elliott", line 1275, in <module>
    main()
  File "/usr/bin/elliott", line 1265, in main
    cli(obj={})
  File "/usr/lib64/python2.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib64/python2.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/lib64/python2.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib64/python2.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib64/python2.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib64/python2.7/site-packages/click/decorators.py", line 64, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/usr/lib64/python2.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib64/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/bin/elliott", line 286, in create
    flaw_cve_map, impact = elliottlib.bzutil.get_flaws(bz_data, unique_bugs)
  File "/usr/lib/python2.7/site-packages/elliottlib/bzutil.py", line 42, in get_flaws
    trackers = get_tracker_bugs(bzapi, bugs)
  File "/usr/lib/python2.7/site-packages/elliottlib/bzutil.py", line 73, in get_tracker_bugs
    raise exceptions.BugzillaFatalError("Couldn't find bug with list of ids provided")
elliottlib.exceptions.BugzillaFatalError: Couldn't find bug with list of ids provided
```

- With this PR:

``` bash
elliott -g openshift-4.2 create -k image --impetus cve -t RHSA --date 2019-Nov-05 --assigned-to openshift-qe-errata@redhat.com --manager vlaad@redhat.com --package-owner lmeyer@redhat.com --bugs 1757044
User provided release date: 2019-Nov-05 - Validated
2019-10-28 13:24:11,176 INFO Data clone directory already exists, checking commit sha
2019-10-28 13:24:11,204 INFO Cloning config data from https://gitlab.cee.redhat.com/openshift-art/ocp-build-data.git
2019-10-28 13:24:14,023 INFO Using branch from group.yml: rhaos-4.2-rhel-7
2019-10-28 13:24:18,418 INFO Fetching bugs 1757044 from Bugzilla...
2019-10-28 13:24:20,268 INFO Fetching flaw bugs for trackers 1757044...
2019-10-28 13:24:22,231 WARNING Bug 1694935 is not a flaw bug.
Would have created advisory: 
(unassigned): OpenShift Container Platform 4.2 images update
  package owner: lmeyer@redhat.com  qe: openshift-qe-errata@redhat.com qe_group: OpenShift QE
  url:   https://errata.devel.redhat.com/advisory/0
  state: NEW_FILES
  created:     None
  ship target: 2019-Nov-05
  ship date:   None
  age:         0 days
  bugs:        []
  CVEs:        CVE-2019-3889
  builds: 
```

Note that `Impact` field doesn't show in the above preview output.
(Hint: You can test advisory creation with stage Errata by changing `elliottlib.constants.errata_url` to `errata.stage.engineering.redhat.com` then running with `--yes`).