### PR TITLE
Refactor unit test imports for Python 3 migration

### DIFF
--- a/tests/test_assertion.py
+++ b/tests/test_assertion.py
@@ -3,7 +3,7 @@ Test the task related functions for the OpenShift Image/RPM Build Tool
 """
 import unittest
 
-import assertion
+from elliottlib import assertion
 
 
 class TestAssert(unittest.TestCase):

--- a/tests/test_brew.py
+++ b/tests/test_brew.py
@@ -5,40 +5,14 @@ Test the brew related functions/classes
 """
 
 import flexmock
-
-import logging
-import StringIO
-
 import platform
-(major, minor, patch) = platform.python_version_tuple()
-if int(major) == 2 and int(minor) < 7:
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
-from elliottlib import exceptions
-import constants
-import brew
-import test_structures
+from elliottlib import exceptions, constants, brew
+from . import test_structures
 
 
 class TestBrew(unittest.TestCase):
-
-    def setUp(self):
-        """
-        Define and provide mock logging for test/response
-        """
-        self.stream = StringIO.StringIO()
-        logging.basicConfig(level=logging.DEBUG, stream=self.stream)
-        self.logger = logging.getLogger()
-
-    def tearDown(self):
-        """
-        Reset logging for each test.
-        """
-        logging.shutdown()
-        reload(logging)
-
     def test_build_attached_to_open_erratum(self):
         """We can tell if a build is attached to any open erratum"""
         # Create Erratum(), create Build() using dict with all_errata

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,7 @@ Test the cli options functions
 """
 import unittest
 
-import cli_opts
+from elliottlib import cli_opts
 
 
 class TestCLI(unittest.TestCase):

--- a/tests/test_errata.py
+++ b/tests/test_errata.py
@@ -1,7 +1,6 @@
 """
 Test errata models/controllers
 """
-
 import datetime
 import mock
 import json
@@ -11,7 +10,7 @@ from errata_tool import ErrataException
 import bugzilla
 
 import unittest
-import test_structures
+from . import test_structures
 from elliottlib import errata, constants, brew, exceptions
 
 

--- a/tests/test_exectools.py
+++ b/tests/test_exectools.py
@@ -7,7 +7,7 @@ import unittest
 
 import flexmock
 
-import exectools
+from elliottlib import exectools
 
 
 class RetryTestCase(unittest.TestCase):

--- a/tests/test_imagecfg.py
+++ b/tests/test_imagecfg.py
@@ -6,7 +6,7 @@ import unittest
 
 import flexmock
 
-import imagecfg
+from elliottlib import imagecfg
 
 
 class TestImageMetadata(unittest.TestCase):

--- a/tests/test_pushd.py
+++ b/tests/test_pushd.py
@@ -7,7 +7,7 @@ import unittest
 import os
 from multiprocessing.dummy import Pool
 
-import pushd
+from elliottlib import pushd
 
 
 class DirTestCase(unittest.TestCase):

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import unittest
-from runtime import Runtime
+from elliottlib.runtime import Runtime
 
 
 class RuntimeTestCase(unittest.TestCase):


### PR DESCRIPTION
1. Use absolute imports.
2. Removes logging hacks from `tests/test_brew.py` (Not sure what is does and it causes troubles with `pytest`).
3. Rename `test_image.py` to `test_imagecfg.py` to be consistent with #69.