### PR TITLE
python 3 - compatiblity fixes

### DIFF
--- a/elliottlib/cli/__main__.py
+++ b/elliottlib/cli/__main__.py
@@ -829,7 +829,7 @@ unsigned builds.
         all_signed = False
         # `errata_builds` is a dict with brew tags as keys, values are
         # lists of builds on the advisory with that tag
-        for k, v in e.errata_builds.iteritems():
+        for k, v in e.errata_builds.items():
             all_builds = all_builds.union(set(v))
         green_prefix("Fetching initial states: ")
         click.echo("{} builds to check".format(len(all_builds)))

--- a/elliottlib/cli_opts.py
+++ b/elliottlib/cli_opts.py
@@ -14,9 +14,9 @@ CLI_OPTS = {
     },
 }
 
-CLI_ENV_VARS = {k: v['env'] for (k, v) in CLI_OPTS.iteritems()}
+CLI_ENV_VARS = {k: v['env'] for (k, v) in CLI_OPTS.items()}
 
-CLI_CONFIG_TEMPLATE = '\n'.join(['#{}\n{}:\n'.format(v['help'], k) for (k, v) in CLI_OPTS.iteritems()])
+CLI_CONFIG_TEMPLATE = '\n'.join(['#{}\n{}:\n'.format(v['help'], k) for (k, v) in CLI_OPTS.items()])
 
 
 def id_convert(ids):

--- a/elliottlib/config.py
+++ b/elliottlib/config.py
@@ -20,7 +20,7 @@ VALID_UPDATES = {
 # in --help output
 def valid_updates():
     res = '\n\tKey\tValid Options\n\n'
-    for k, v in VALID_UPDATES.iteritems():
+    for k, v in VALID_UPDATES.items():
         opts = ""
         if v:
             v = [str(i) for i in v]

--- a/elliottlib/dotconfig.py
+++ b/elliottlib/dotconfig.py
@@ -83,12 +83,12 @@ class Config(object):
             data = yaml.full_load(f)
             self._data.update(data)
             # load envvars if given and override
-            for k, v in envvars.iteritems():
+            for k, v in envvars.items():
                 if v in os.environ:
                     self._data[k] = os.environ[v]
 
             # finally, override with given cli args
-            for k, v in cli_args.iteritems():
+            for k, v in cli_args.items():
                 if k not in self._data or v is not None:
                     self._data[k] = v
 
@@ -96,7 +96,7 @@ class Config(object):
         return self._data[item]
 
     def iteritems(self):
-        return self._data.iteritems()
+        return self._data.items()
 
     def to_dict(self):
         return dict(self._data)

--- a/elliottlib/errata.py
+++ b/elliottlib/errata.py
@@ -505,7 +505,7 @@ def get_advisory_images(image_advisory_id):
     pattern = re.compile(r'^redhat-openshift(\d)-')
 
     def _get_image_name(repo):
-        return pattern.sub(r'openshift\1/', repo['docker']['target']['repos'].keys()[0])
+        return pattern.sub(r'openshift\1/', list(repo['docker']['target']['repos'].keys())[0])
 
     def _get_nvr(component):
         parts = component.split('-')
@@ -513,7 +513,7 @@ def get_advisory_images(image_advisory_id):
 
     image_list = [
         '{}:{}'.format(_get_image_name(repo), _get_nvr(key))
-        for key, repo in sorted(cdn_docker_file_list.iteritems())
+        for key, repo in sorted(list(cdn_docker_file_list.items()))
     ]
 
     return '#########\n{}\n#########'.format('\n'.join(image_list))

--- a/elliottlib/gitdata.py
+++ b/elliottlib/gitdata.py
@@ -1,8 +1,11 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+from future.standard_library import install_aliases
+install_aliases()
+from urllib.parse import urlparse
+
 import yaml
 import logging
-import urlparse
 import os
 import shutil
 from . import exectools

--- a/elliottlib/model.py
+++ b/elliottlib/model.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 
+from builtins import str as text
+
 
 class ModelException(Exception):
 
@@ -109,12 +111,12 @@ class ListModel(list):
             return master is test
 
         if isinstance(master, str):
-            master = unicode(master)  # Turn str into unicode
+            master = text(master)  # Turn str into unicode
 
         if isinstance(test, str):
-            test = unicode(test)  # Turn str into unicode
+            test = text(test)  # Turn str into unicode
 
-        for prim in [bool, int, unicode, float]:
+        for prim in [bool, int, text, float]:
             if isinstance(master, prim):
                 return master == test or str(master) == str(test)
 

--- a/elliottlib/model.py
+++ b/elliottlib/model.py
@@ -198,7 +198,7 @@ class Model(dict):
     def primitive(self):
         """ Recursively turn Model into dicts. """
         d = {}
-        for k, v in self.iteritems():
+        for k, v in self.items():
             if isinstance(v, Model) or isinstance(v, ListModel):
                 v = v.primitive()
             d[k] = v

--- a/elliottlib/openshiftclient.py
+++ b/elliottlib/openshiftclient.py
@@ -94,7 +94,7 @@ def get_build_list(old, new):
     payload_json = json.loads(oc_output)
     changed_images = []
 
-    for k, v in payload_json["changedImages"].iteritems():
+    for k, v in payload_json["changedImages"].items():
         if k == "machine-os-content":
             continue  # no use in comparing this as it doesn't go in the advisory
         if v["to"]:

--- a/elliottlib/openshiftclient.py
+++ b/elliottlib/openshiftclient.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 # stdlib
+from __future__ import print_function
 from subprocess import call, check_output, CalledProcessError
 import json
 

--- a/elliottlib/runtime.py
+++ b/elliottlib/runtime.py
@@ -1,5 +1,9 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+from future.standard_library import install_aliases
+install_aliases()
+from urllib.parse import urlparse
+
 from multiprocessing import Lock
 from multiprocessing.dummy import Pool as ThreadPool
 from pykwalify.core import Core
@@ -16,7 +20,6 @@ import click
 import logging
 import functools
 import traceback
-import urlparse
 
 from elliottlib import gitdata
 from . import logutil

--- a/elliottlib/runtime.py
+++ b/elliottlib/runtime.py
@@ -433,7 +433,7 @@ class Runtime(object):
         # synchronize output to the file.
         with self.log_lock:
             record = "%s|" % record_type
-            for k, v in kwargs.iteritems():
+            for k, v in kwargs.items():
                 assert ("\n" not in str(k))
                 # Make sure the values have no linefeeds as this would interfere with simple parsing.
                 v = str(v).replace("\n", " ;;; ").replace("\r", "")

--- a/tests/test_assertion.py
+++ b/tests/test_assertion.py
@@ -1,8 +1,16 @@
 """
 Test the task related functions for the OpenShift Image/RPM Build Tool
 """
+from __future__ import absolute_import
 from __future__ import unicode_literals
+
 import unittest
+
+try:
+    from elliottlib.assertion import FileNotFoundError
+    from elliottlib.assertion import ChildProcessError
+except:
+    pass
 
 from elliottlib import assertion
 
@@ -23,15 +31,15 @@ class TestAssert(unittest.TestCase):
 
         try:
             assertion.isdir(dir_exists, "dir missing: {}".format(dir_exists))
-        except assertion.FileNotFoundError as fnf_error:
+        except FileNotFoundError as fnf_error:
             self.fail("asserted real directory does not exist: {}".
                       format(fnf_error))
 
-        with self.assertRaises(assertion.FileNotFoundError):
+        with self.assertRaises(FileNotFoundError):
             assertion.isdir(dir_missing, "dir missing: {}".format(dir_missing))
 
         # This should raise NotADirectory
-        with self.assertRaises(assertion.FileNotFoundError):
+        with self.assertRaises(FileNotFoundError):
             assertion.isdir(not_dir, "file, not dir: {}".format(not_dir))
 
     def test_isfile(self):
@@ -44,17 +52,17 @@ class TestAssert(unittest.TestCase):
 
         try:
             assertion.isfile(file_exists, "file missing: {}".format(file_exists))
-        except assertion.FileNotFoundError as fnf_error:
+        except FileNotFoundError as fnf_error:
             self.fail("asserted real file does not exist: {}".format(fnf_error))
 
-        with self.assertRaises(assertion.FileNotFoundError):
+        with self.assertRaises(FileNotFoundError):
             assertion.isfile(
                 file_missing,
                 "file missing: {}".format(file_missing)
             )
 
         # Should raise IsADirectory
-        with self.assertRaises(assertion.FileNotFoundError):
+        with self.assertRaises(FileNotFoundError):
             assertion.isfile(not_file, "dir, not file: {}".format(not_file))
 
     def test_success(self):
@@ -65,10 +73,10 @@ class TestAssert(unittest.TestCase):
         # When we move to Python 3 this will raise ChildProcessError directly
         try:
             assertion.success(0, "this should not fail")
-        except assertion.ChildProcessError as proc_fail:
+        except ChildProcessError as proc_fail:
             self.fail("success reported as fail: {}".format(proc_fail))
 
-        with self.assertRaises(assertion.ChildProcessError):
+        with self.assertRaises(ChildProcessError):
             assertion.success(1, "process failed")
 
 

--- a/tests/test_brew.py
+++ b/tests/test_brew.py
@@ -99,8 +99,8 @@ class TestBrew(unittest.TestCase):
         b2 = brew.Build(nvr='tuxracer-42')
 
         builds = set([])
-        builds.add(b1)
-        builds.add(b1)
+        builds.add(str(b1))
+        builds.add(str(b1))
 
         self.assertEqual(1, len(builds))
         self.assertTrue(b1 != b2)

--- a/tests/test_errata.py
+++ b/tests/test_errata.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 import datetime
 import mock
 import json
-from contextlib import nested
 import flexmock
 from errata_tool import ErrataException
 import bugzilla

--- a/tests/test_tarball_sources.py
+++ b/tests/test_tarball_sources.py
@@ -46,7 +46,7 @@ class TarballSourcesTestCase(unittest.TestCase):
         with mock.patch("koji.ClientSession", spec=True) as MockSession:
             session = MockSession()
             session.getBuild = mock.MagicMock(side_effect=fake_get_build)
-            expected = build_infos.values()
+            expected = list(build_infos.values())
             actual = tarball_sources.get_builds_from_brew(session, build_nvrs)
             self.assertListEqual(list(actual), expected)
 


### PR DESCRIPTION
split out a couple of other patches and have a long patch set of different python 2 vs 3 fixes/changes
tox -e py3 now works and passes locally

Most of these should be py2 backward compatible but some changes may impact runtime usage of the tool, more testing is required before anything can be said about whether it works or not.

Related: issue #84 