### PR TITLE
[ART-1176] Fix elliott find-builds --between does not partition by product version

### DIFF
--- a/elliottlib/cli/common.py
+++ b/elliottlib/cli/common.py
@@ -41,6 +41,10 @@ context_settings = dict(help_option_names=['-h', '--help'])
     default=None, metavar='BRANCH',
     help='Branch to override any default in group.yml.')
 @click.option(
+    '--product-id',
+    default=None, metavar='PRODUCT_ID',
+    help='Product ID to override any default in erratatool.yml.')
+@click.option(
     '--stage',
     default=False, is_flag=True,
     help='Force checkout stage branch for sources in group.yml.')

--- a/elliottlib/constants.py
+++ b/elliottlib/constants.py
@@ -142,5 +142,5 @@ errata_get_comments_url = errata_url + "/api/v1/comments"
 errata_get_erratum_url = errata_url + "/api/v1/erratum/{id}"
 errata_post_erratum_url = errata_url + "/api/v1/erratum"
 errata_get_advisories_for_bug_url = errata_url + "/bugs/{id}/advisories.json"
-
+errata_get_product_versions = errata_url + "/api/v1/products/{id}/product_versions"
 DISTGIT_MAX_FILESIZE = 50000000

--- a/elliottlib/errata.py
+++ b/elliottlib/errata.py
@@ -404,6 +404,26 @@ def get_advisories_for_bug(bug_id, session=None):
     return r.json()
 
 
+def get_product_version_from_tag(product_id, session=None):
+    """ Get the a product_version from a specific brew tag.
+
+    """
+    product_version_map = {}
+    if not session:
+        session = requests.session()
+
+    r = session.get(constants.errata_get_product_versions.format(id=int(product_id)),
+                    verify=ssl.get_default_verify_paths().openssl_cafile,
+                    auth=HTTPKerberosAuth())
+    r.raise_for_status()
+    data = r.json()
+    for l in data['data']:
+        if l['type'] == 'product_versions':
+            for tags in l['brew_tags']:
+                product_version_map[tags] = l['attributes']['name']
+    return product_version_map
+
+
 def parse_exception_error_message(e):
     """
     :param e: exception messages (format is like 'Bug #1685399 The bug is filed already in RHBA-2019:1589.

--- a/elliottlib/util.py
+++ b/elliottlib/util.py
@@ -237,16 +237,10 @@ def parallel_results_with_progress(inputs, func):
 
 
 def override_product_version(pv, branch):
-    """ Override product_version with given brew tags
-
-    :param pv: orignal product_version, will be override by branch is those two are not same,
-    if pv is empty, also will be overrided.
-
-    :param branch: if user specify -b branch will override product_version of erratatool.yml
-    """
+    """ if user specify -b branch will override product_version of erratatool.yml"""
     rp = pv.split("-")
     rb = branch.split("-")
-    if not pv or rp[1] != rb[3] or rp[3] != rb[1]:
+    if rp[1] != rb[3] or rp[3] != rb[1]:
         if rb[3] == '8':
             # hardcoded differently for RHEL8 since the product version name changed
             # TODO: it should look up the right product version that can accept content from the brew tag.
@@ -256,5 +250,6 @@ def override_product_version(pv, branch):
 
 
 def get_release_version(pv):
-    """ there are two kind of format of product_version: OSE-4.1-RHEL-8 RHEL-7-OSE-4.1 """
+    """ there are two kind of format of product_version: OSE-4.1-RHEL-8 RHEL-7-OSE-4.1 RHEL-7-OSE-4.1-FOR-POWER-LE """
+    print(pv)
     return re.search(r'OSE-(\d+\.\d+)', pv).groups()[0]

--- a/elliottlib/util.py
+++ b/elliottlib/util.py
@@ -237,10 +237,16 @@ def parallel_results_with_progress(inputs, func):
 
 
 def override_product_version(pv, branch):
-    """ if user specify -b branch will override product_version of erratatool.yml"""
+    """ Override product_version with given brew tags
+
+    :param pv: orignal product_version, will be override by branch is those two are not same,
+    if pv is empty, also will be overrided.
+
+    :param branch: if user specify -b branch will override product_version of erratatool.yml
+    """
     rp = pv.split("-")
     rb = branch.split("-")
-    if rp[1] != rb[3] or rp[3] != rb[1]:
+    if not pv or rp[1] != rb[3] or rp[3] != rb[1]:
         if rb[3] == '8':
             # hardcoded differently for RHEL8 since the product version name changed
             # TODO: it should look up the right product version that can accept content from the brew tag.

--- a/tests/test_errata.py
+++ b/tests/test_errata.py
@@ -72,6 +72,20 @@ class TestErrata(unittest.TestCase):
             actual = errata.get_advisories_for_bug(bug, session)
             self.assertEqual(actual, advisories)
 
+    def test_parse_proudct_version(self):
+        product_version_map = {}
+        product_version_json = """{
+            "data":[
+                {"id":964,"type":"product_versions","attributes":{"name":"OSE-4.1-RHEL-8","description":"Red Hat OpenShift Container Platform 4.1","default_brew_tag":"rhaos-4.1-rhel-8-candidate","allow_rhn_debuginfo":false,"is_oval_product":false,"is_rhel_addon":false,"is_server_only":true,"enabled":true},"brew_tags":["rhaos-4.1-rhel-8-candidate"],"relationships":{"rhel_release":{"id":87,"name":"RHEL-8"},"sig_key":{"id":8,"name":"redhatrelease2"}}}]
+        }"""
+        data = json.loads(product_version_json)
+        for l in data['data']:
+            if l['type'] == 'product_versions':
+                for tags in l['brew_tags']:
+                    product_version_map[tags] = l['attributes']['name']
+
+        self.assertEqual(product_version_map, {'rhaos-4.1-rhel-8-candidate': 'OSE-4.1-RHEL-8'})
+
     def test_get_rpmdiff_runs(self):
         advisory_id = 12345
         responses = [

--- a/tests/test_find_builds_cli.py
+++ b/tests/test_find_builds_cli.py
@@ -1,9 +1,8 @@
 import unittest
-from elliottlib.cli.find_builds_cli import _attached_to_open_erratum_with_correct_product_version
-from elliottlib.errata import get_metadata_comments_json
+from elliottlib.cli.find_builds_cli import _attached_to_open_erratum_with_correct_pv, _nvrs_to_builds, _get_product_version
 from elliottlib.brew import Build
 import elliottlib
-import flexmock, json
+import flexmock, json, mock
 
 
 class TestFindBuildsCli(unittest.TestCase):
@@ -24,12 +23,12 @@ class TestFindBuildsCli(unittest.TestCase):
         fake_errata = flexmock(model=elliottlib.errata, get_metadata_comments_json=lambda: 1234)
         fake_errata.should_receive("get_metadata_comments_json").and_return(metadata_json_list)
 
-        builds = flexmock(Build(nvr="test-1.1.1"))
+        builds = flexmock(Build(nvr="test-1.1.1", product_version="RHEL-7-OSE-4.1"))
         builds.should_receive("attached_to_open_erratum").and_return(True)
         builds.should_receive("open_errata_id").and_return([12345])
 
         # expect return empty list []
-        self.assertEqual([], _attached_to_open_erratum_with_correct_product_version([builds], "RHEL-7-OSE-4.1", fake_errata))
+        self.assertEqual([], _attached_to_open_erratum_with_correct_pv("image", [builds], fake_errata))
 
     def test_attached_errata_succeed(self):
         """
@@ -44,12 +43,45 @@ class TestFindBuildsCli(unittest.TestCase):
         fake_errata = flexmock(model=elliottlib.errata, get_metadata_comments_json=lambda: 1234)
         fake_errata.should_receive("get_metadata_comments_json").and_return(metadata_json_list)
 
-        builds = flexmock(Build(nvr="test-1.1.1"))
+        builds = flexmock(Build(nvr="test-1.1.1", product_version="RHEL-7-OSE-4.5"))
         builds.should_receive("attached_to_open_erratum").and_return(True)
         builds.should_receive("open_errata_id").and_return([12345])
 
         # expect return list with one build
-        self.assertEqual([Build("test-1.1.1")], _attached_to_open_erratum_with_correct_product_version([builds], "RHEL-7-OSE-4.5", fake_errata))
+        self.assertEqual([Build("test-1.1.1")], _attached_to_open_erratum_with_correct_pv("image", [builds], fake_errata))
+
+    def test_get_product_version(self):
+        """
+        Test get_product_version testing the product_version get from brew list tag and product_version map
+        """
+
+        nvr1 = "logging-fluentd-container-v4.1.14-201908291507"
+        nvr2 = "ironic-container-v4.2.7-201911150432"
+
+        product_version_map = {"rhaos-4.1-rhel-8-candidate": "OSE-4.1-RHEL-8",
+                               "rhaos-4.2-rhel-8-candidate": "OSE-4.2-RHEL-8",
+                               "rhaos-4.1-rhel-7-candidate": "RHEL-7-OSE-4.1",
+                               "rhaos-4.2-rhel-7-candidate": "RHEL-7-OSE-4.2",
+                               "rhaos-3.11-rhel-7-candidate": "RHEL-7-OSE-3.11"
+                               }
+
+        def fake_listTags(nvr):
+            if nvr == nvr1:
+                return [{'arches': None, 'id': 14991, 'locked': False, 'maven_include_all': False, 'maven_support': False,
+                         'name': 'rhaos-4.1-rhel-7-candidate', 'perm': None, 'perm_id': None}]
+            if nvr == nvr2:
+                return [{'arches': None, 'id': 14991, 'locked': False, 'maven_include_all': False, 'maven_support': False,
+                         'name': 'rhaos-4.2-rhel-8-candidate', 'perm': None, 'perm_id': None}]
+
+        with mock.patch("koji.ClientSession", spec=True) as MockSession:
+            session = MockSession()
+            session.listTags = mock.MagicMock(side_effect=fake_listTags)
+
+            pv = _get_product_version(nvr1, "RHEL-7-OSE-4.1", product_version_map, session)
+            self.assertEqual(pv, "RHEL-7-OSE-4.1")
+
+            pv = _get_product_version(nvr2, "RHEL-7-OSE-4.1", product_version_map, session)
+            self.assertEqual(pv, "OSE-4.2-RHEL-8")
 
 
 if __name__ == "__main__":

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -17,6 +17,12 @@ class UtilTestCase(unittest.TestCase):
         ret = util.override_product_version('RHEL-7-OSE-4.1', 'rhaos-4.1-rhel-7')
         self.assertEqual(ret, 'RHEL-7-OSE-4.1')
 
+        ret = util.override_product_version('', 'rhaos-4.1-rhel-7')
+        self.assertEqual(ret, 'RHEL-7-OSE-4.1')
+
+        ret = util.override_product_version('', 'rhaos-4.1-rhel-8-candidate')
+        self.assertEqual(ret, 'OSE-4.1-RHEL-8')
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -17,12 +17,6 @@ class UtilTestCase(unittest.TestCase):
         ret = util.override_product_version('RHEL-7-OSE-4.1', 'rhaos-4.1-rhel-7')
         self.assertEqual(ret, 'RHEL-7-OSE-4.1')
 
-        ret = util.override_product_version('', 'rhaos-4.1-rhel-7')
-        self.assertEqual(ret, 'RHEL-7-OSE-4.1')
-
-        ret = util.override_product_version('', 'rhaos-4.1-rhel-8-candidate')
-        self.assertEqual(ret, 'OSE-4.1-RHEL-8')
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
https://jira.coreos.com/browse/ART-1176

with test adv: https://errata.devel.redhat.com/advisory/47278
```
[root@dcea84a6f832 elliott]# elliott -g openshift-4.2 find-builds --between registry.svc.ci.openshift.org/ocp/release:4.2.0-0.nig
htly-2019-11-17-020725 registry.svc.ci.openshift.org/ocp/release:4.2.0-0.nightly-2019-11-15-223610 --kind image -a 47278 
2019-11-19 18:02:31,472 INFO Data clone directory already exists, checking commit sha
2019-11-19 18:02:33,177 INFO https://gitlab.cee.redhat.com/openshift-art/ocp-build-data.git is already cloned and latest
2019-11-19 18:02:33,280 INFO Using branch from group.yml: rhaos-4.2-rhel-7
Fetching changed images between payloads...
set(['OSE-4.2-RHEL-8', 'RHEL-7-OSE-4.2'])
Attached build(s) successfully:
 ironic-container-v4.2.7-201911150432
 ironic-inspector-container-v4.2.7-201911150432
 ironic-ipa-downloader-container-v4.2.7-201911150432
 ironic-rhcos-downloader-container-v4.2.7-201911150432
 ironic-static-ip-manager-container-v4.2.7-201911150432
 openshift-enterprise-hyperkube-container-v4.2.7-201911151631
 openshift-enterprise-tests-container-v4.2.7-201911151631
```


Also I did some refactoring of `find-builds` in the second commit, which I wrote a simple script to do regression test:
```
#!/usr/bin/env bash

set -euxo pipefail

# pip install -e /workspaces/elliott
OSE=( 3.11 4.1 4.2 4.3 )

diff_result_files() {
  local kind=$1
  for version in "${OSE[@]}"
  do
    diff /tmp/$kind-${version}-test /tmp/$kind-${version}-master
    if [[ $(echo $?) != 0 ]];
    then
      echo "e2e testing  /tmp/${kind}-${version}-test /tmp/${kind}-${version}-master failed..."
      exit 1
    fi
  done
}

elliott_find_builds_json_dumps () {
  local kind=$1
  local branch=$2
  for version in "${OSE[@]}"
  do
    elliott -g openshift-${version} --product-id 79 find-builds -k ${kind} --json /tmp/${kind}-${version}-$branch
  done
}

echo "start executing commands...."
elliott_find_builds_json_dumps "rpm" "test" 
elliott_find_builds_json_dumps "image" "test"
git checkout master
elliott_find_builds_json_dumps "rpm" "master" 
elliott_find_builds_json_dumps "image" "master"


echo "start comparing results...."
diff_result_files "rpm"
diff_result_files "image"
```