### PR TITLE
[ART-670] Generate Image List for CCS (docs team)

### DIFF
--- a/elliottlib/cli/__main__.py
+++ b/elliottlib/cli/__main__.py
@@ -49,6 +49,7 @@ from elliottlib.cli.add_metadata_cli import add_metadata_cli
 from elliottlib.cli.create_placeholder_cli import create_placeholder_cli
 from elliottlib.cli.puddle_advisories_cli import puddle_advisories_cli
 from elliottlib.cli.rpmdiff_cli import rpmdiff_cli
+from elliottlib.cli.advisory_images_cli import advisory_images_cli
 
 
 # 3rd party
@@ -884,6 +885,7 @@ cli.add_command(create_cli)
 cli.add_command(list_cli)
 cli.add_command(puddle_advisories_cli)
 cli.add_command(rpmdiff_cli)
+cli.add_command(advisory_images_cli)
 
 # -----------------------------------------------------------------------------
 # CLI Entry point

--- a/elliottlib/cli/advisory_images_cli.py
+++ b/elliottlib/cli/advisory_images_cli.py
@@ -1,0 +1,32 @@
+from __future__ import unicode_literals, print_function, with_statement
+import click
+
+from elliottlib import Runtime
+from elliottlib.cli.common import cli, find_default_advisory
+from elliottlib import errata
+
+pass_runtime = click.make_pass_decorator(Runtime)
+
+
+@cli.command('advisory-images', short_help='List of images in a given advisory')
+@click.option(
+    '--advisory', '-a', 'advisory',
+    type=int, default=None, metavar='ADVISORY',
+    help='Explicitly define image advisory ID to be used instead of the default')
+@pass_runtime
+def advisory_images_cli(runtime, advisory):
+    """List images of a given advisory in the format we usually send to CCS (docs team)
+
+    $ elliott advisory-images --advisory 48465
+
+    If no `--advisory` is provided, elliott will use the default image advisory
+    of the given group.
+
+    $ elliott --group openshift-4.2 advisory-images
+    """
+    runtime.initialize(no_group=(advisory is not None))
+
+    if advisory is None:
+        advisory = find_default_advisory(runtime, 'image')
+
+    print(errata.get_advisory_images(advisory))

--- a/elliottlib/constants.py
+++ b/elliottlib/constants.py
@@ -19,6 +19,7 @@ BUG_SEVERITY_NUMBER_MAP = {
 # https://jira.coreos.com/browse/ART-1192
 SECURITY_IMPACT = ["Low", "Low", "Moderate", "Important", "Critical"]
 
+errata_xmlrpc_url = 'http://errata.engineering.redhat.com/errata/xmlrpc.cgi'
 errata_url = "https://errata.devel.redhat.com"
 
 # 1965 => (RHBA; Active; Product: RHOSE; Devel Group: ENG OpenShift

--- a/tests/test_errata.py
+++ b/tests/test_errata.py
@@ -103,6 +103,112 @@ class TestErrata(unittest.TestCase):
         self.assertEqual(len(list(actual)), 3)
 
 
+class TestAdvisoryImages(unittest.TestCase):
+    def test_get_advisory_images_ocp_4(self):
+        mocked_response = {
+            'kube-rbac-proxy-container-v3.11.154-1': {
+                'docker': {
+                    'target': {
+                        'repos': {
+                            'redhat-openshift3-ose-kube-rbac-proxy': {
+                                'tags': ['latest', 'v3.11', 'v3.11.154', 'v3.11.154-1']
+                            }
+                        }
+                    }
+                }
+            },
+            'jenkins-slave-base-rhel7-container-v3.11.154-1': {
+                'docker': {
+                    'target': {
+                        'repos': {
+                            'redhat-openshift3-jenkins-slave-base-rhel7': {
+                                'tags': ['v3.11', 'v3.11.154', 'v3.11.154-1']
+                            }
+                        }
+                    }
+                }
+            },
+            'openshift-enterprise-pod-container-v3.11.154-1': {
+                'docker': {
+                    'target': {
+                        'repos': {
+                            'redhat-openshift3-ose-pod': {
+                                'tags': ['latest', 'v3.11', 'v3.11.154', 'v3.11.154-1']
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        errata.errata_xmlrpc.get_advisory_cdn_docker_file_list = lambda *_: mocked_response
+
+        expected = """#########
+openshift3/jenkins-slave-base-rhel7:v3.11.154-1
+openshift3/ose-kube-rbac-proxy:v3.11.154-1
+openshift3/ose-pod:v3.11.154-1
+#########"""
+        actual = errata.get_advisory_images('_irrelevant_')
+        self.assertEqual(actual, expected)
+
+    def test_get_advisory_images_ocp_4(self):
+        mocked_response = {
+            'atomic-openshift-cluster-autoscaler-container-v4.2.5-201911121709': {
+                'docker': {
+                    'target': {
+                        'repos': {
+                            'redhat-openshift4-ose-cluster-autoscaler': {
+                                'tags': ['4.2', 'latest', 'v4.2.5', 'v4.2.5-201911121709']
+                            }
+                        }
+                    }
+                }
+            },
+            'cluster-monitoring-operator-container-v4.2.5-201911121709': {
+                'docker': {
+                    'target': {
+                        'repos': {
+                            'redhat-openshift4-ose-cluster-monitoring-operator': {
+                                'tags': ['4.2', 'latest', 'v4.2.5', 'v4.2.5-201911121709']
+                            }
+                        }
+                    }
+                }
+            },
+            'cluster-node-tuning-operator-container-v4.2.5-201911121709': {
+                'docker': {
+                    'target': {
+                        'repos': {
+                            'redhat-openshift4-ose-cluster-node-tuning-operator': {
+                                'tags': ['4.2', 'latest', 'v4.2.5', 'v4.2.5-201911121709']
+                            }
+                        }
+                    }
+                }
+            },
+            'golang-github-openshift-oauth-proxy-container-v4.2.5-201911121709': {
+                'docker': {
+                    'target': {
+                        'repos': {
+                            'redhat-openshift4-ose-oauth-proxy': {
+                                'tags': ['4.2', 'latest', 'v4.2.5', 'v4.2.5-201911121709']
+                            }
+                        }
+                    }
+                }
+            },
+        }
+        errata.errata_xmlrpc.get_advisory_cdn_docker_file_list = lambda *_: mocked_response
+
+        expected = """#########
+openshift4/ose-cluster-autoscaler:v4.2.5-201911121709
+openshift4/ose-cluster-monitoring-operator:v4.2.5-201911121709
+openshift4/ose-cluster-node-tuning-operator:v4.2.5-201911121709
+openshift4/ose-oauth-proxy:v4.2.5-201911121709
+#########"""
+        actual = errata.get_advisory_images('_irrelevant_')
+        self.assertEqual(actual, expected)
+
+
 class testErratum:
     def __init__(self, rt, ntt):
         self.retry_times = rt


### PR DESCRIPTION
[ART-670](https://jira.coreos.com/browse/ART-670): Generate Image List for CCS (docs team)

### New elliott command introduced:
```
$ elliott -g openshift-4.2 generate-ccs-image-list
2019-11-21 14:57:08,922 INFO Data clone directory already exists, checking commit sha
2019-11-21 14:57:09,496 INFO https://github.com/openshift/ocp-build-data.git is already cloned and latest
2019-11-21 14:57:09,598 INFO Using branch from group.yml: rhaos-4.2-rhel-7
Default advisory detected: 48465                                                               
#########                                                                                      
openshift4/ose-cluster-autoscaler:v4.2.8-201911190952       
openshift4/ose-baremetal-machine-controllers:v4.2.8-201911190952
openshift4/ose-cluster-monitoring-operator:v4.2.8-201911190952
openshift4/ose-cluster-network-operator:v4.2.8-201911190952
openshift4/ose-cluster-node-tuning-operator:v4.2.8-201911190952
openshift4/ose-cluster-version-operator:v4.2.8-201911190952
...............
```
or
```
$ elliott -g openshift-4.2 generate-ccs-image-list --advisory --advisory 48465
2019-11-21 14:57:56,182 INFO Data clone directory already exists, checking commit sha
2019-11-21 14:57:56,742 INFO https://github.com/openshift/ocp-build-data.git is already cloned and latest
2019-11-21 14:57:56,830 INFO Using branch from group.yml: rhaos-4.2-rhel-7
#########                                                                                      
openshift4/ose-cluster-autoscaler:v4.2.8-201911190952       
openshift4/ose-baremetal-machine-controllers:v4.2.8-201911190952
openshift4/ose-cluster-monitoring-operator:v4.2.8-201911190952
openshift4/ose-cluster-network-operator:v4.2.8-201911190952
openshift4/ose-cluster-node-tuning-operator:v4.2.8-201911190952
openshift4/ose-cluster-version-operator:v4.2.8-201911190952
...............
```