### PR TITLE
Fix rpmdiff list waivers API call

### DIFF
--- a/elliottlib/cli/rpmdiff_cli.py
+++ b/elliottlib/cli/rpmdiff_cli.py
@@ -85,7 +85,7 @@ def show(ctx, advisory):
             else:
                 util.red_print(result_msg)
             # get last waiver message
-            waivers = rpmdiff_client.get_waivers(package_name, test_id, limit=1)
+            waivers = rpmdiff_client.list_waivers(package_name, test_id, limit=1)
             if waivers:
                 util.green_print("    Last waiver: @" + waivers[0]["owner"]["username"] + ": " + waivers[0]["description"])
             else:

--- a/elliottlib/rpmdiff.py
+++ b/elliottlib/rpmdiff.py
@@ -31,11 +31,16 @@ class RPMDiffClient(object):
         resp.raise_for_status()
         return resp.json()["results"]
 
-    def get_waivers(self, package_name, test_id, offset=0, limit=10):
+    def list_waivers(self, package_name, test, offset=0, limit=10):
+        """ List waivers.
+
+        https://rpmdiff-hub.host.prod.eng.bos.redhat.com/api/v1/waivers/
+        """
         endpoint = self.hub_url + "/api/v1/waivers/"
         params = {
             "package": package_name,
-            "test_id": int(test_id),
+            "test": int(test),
+            "limit": int(limit),
         }
         resp = self.session.get(endpoint, params=params)
         resp.raise_for_status()

--- a/tests/test_rpmdiff.py
+++ b/tests/test_rpmdiff.py
@@ -44,7 +44,7 @@ class TestRPMDiffClient(unittest.TestCase):
         actual = self.client.get_test_results(12345)
         self.assertEqual(actual, response["results"])
 
-    def test_get_waivers(self):
+    def test_list_waivers(self):
         response = {
             "results": [
                 {"waiver_id": 1},
@@ -53,5 +53,5 @@ class TestRPMDiffClient(unittest.TestCase):
             ]
         }
         self.client.session.get.return_value.json.return_value = response
-        actual = self.client.get_waivers("foo", 123)
+        actual = self.client.list_waivers("foo", 123)
         self.assertEqual(actual, response["results"])


### PR DESCRIPTION
I mistakenly used incorrect parameter names and forgot to honor the `limit` parameter.
Also change the function name to `list_waivers`.