### PR TITLE
Update dev container configuration

### DIFF
--- a/.devcontainer/dev.Dockerfile
+++ b/.devcontainer/dev.Dockerfile
@@ -2,18 +2,18 @@ FROM fedora:30
 LABEL name="elliott-dev" \
   description="Elliott development container image" \
   maintainer="OpenShift Automated Release Tooling (ART) Team <aos-team-art@redhat.com>"
+
+ENV PYCURL_SSL_LIBRARY=openssl
+
 RUN dnf install -y \
     # runtime dependencies
-    krb5-workstation python-bugzilla-cli rsync docker \
-    python2 python2-certifi python2-click python2-dockerfile-parse python2-koji \
-    python2-pykwalify python2-pyyaml python2-bugzilla python2-requests \
-    python2-requests-kerberos python2-pygit2 python2-future \
-    python3-certifi python3-click python3-dockerfile-parse python3-koji \
-    python3-pykwalify python3-pyyaml python3-bugzilla python3-requests \
-    python3-requests-kerberos python3-pygit2 python3-future \
+    krb5-workstation python-bugzilla-cli git rsync docker \
+    python2 python2-certifi python2-rpm \
+    python3 python3-certifi python3-rpm \
     # development dependencies
-    gcc python2-devel python2-pip python2-typing pylint krb5-devel git \
-    python3-devel python3-autopep8 python3-typing-extensions \
+    gcc krb5-devel libgit2-devel openssl-devel krb5-devel \
+    python2-devel python2-pip \
+    python3-devel python3-pip \
     # other tools
     bash-completion vim tmux procps-ng psmisc wget curl net-tools iproute \
   # Red Hat IT Root CA
@@ -29,8 +29,8 @@ RUN wget -O /etc/yum.repos.d/rcm-tools-fedora.repo https://download.devel.redhat
   && dnf install -y rhpkg \
   && dnf clean all
 
-ARG OC_VERSION=4.2.4
-#include latest oc client
+ARG OC_VERSION=4.2.8
+# include oc client
 RUN wget -O /tmp/openshift-client-linux-"$OC_VERSION".tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/"$OC_VERSION"/openshift-client-linux-"$OC_VERSION".tar.gz \
   && tar -C /usr/local/bin -xzf  /tmp/openshift-client-linux-"$OC_VERSION".tar.gz oc kubectl \
   && rm /tmp/openshift-client-linux-"$OC_VERSION".tar.gz
@@ -49,11 +49,6 @@ RUN groupadd --gid "$USER_GID" "$USERNAME" \
     && chmod 0755 /home/"$USERNAME" \
     && echo "$USERNAME" ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/"$USERNAME" \
     && chmod 0440 /etc/sudoers.d/"$USERNAME"
-
-# Workaround for running `kinit` in an unprivileged container
-# by storing krb5 credential cache into a file rather than kernel keyring.
-# See https://blog.tomecek.net/post/kerberos-in-a-container/
-ENV KRB5CCNAME=FILE:/tmp/krb5cache
 
 USER "$USER_UID"
 WORKDIR /workspaces/elliott

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -51,6 +51,7 @@
 
 	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
-		"ms-python.python"
+		"ms-python.python",
+		"eamodio.gitlens"
 	]
 }

--- a/.devcontainer/krb5-redhat.conf
+++ b/.devcontainer/krb5-redhat.conf
@@ -7,5 +7,9 @@ REDHAT.COM = {
 .redhat.com = REDHAT.COM
 redhat.com = REDHAT.COM
 [libdefaults]
+# Workaround for running `kinit` in an unprivileged container
+# by storing krb5 credential cache into a file rather than kernel keyring.
+# See https://blog.tomecek.net/post/kerberos-in-a-container/
+default_ccache_name = FILE:/tmp/krb5cc_%{uid}
 rdns = false
 default_realm = REDHAT.COM

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,5 +3,8 @@ coverage
 flake8
 flexmock
 mock
+pylint
 pytest
 tox
+typing
+typing-extensions


### PR DESCRIPTION
1. Bump `oc` version to 4.2.8.
2. Remove most RPM based Python packages and use `pip` versions instead (to be consistent with How OpenShift ART team actually installs dependencies).
3. Move Kerberos ccache configuration from environment variable to configuration file, so that the configuration will not lost after switching user with `sudo`.
4. Install GitLens plugin for VSCode on dev container start.