### PR TITLE
[ART-1342] speed up get_latest_build_info and solve the multi branch/tag mapping issue

### DIFF
--- a/elliottlib/brew.py
+++ b/elliottlib/brew.py
@@ -30,6 +30,16 @@ from requests_kerberos import HTTPKerberosAuth
 logger = logutil.getLogger(__name__)
 
 
+def get_latest_builds(tag, component_names, brew_session=koji.ClientSession(constants.BREW_HUB)):
+    latest_builds = {}
+    component_names = set(component_names)
+    builds = brew_session.getLatestBuilds(tag)
+    for b in builds:
+        if b['name'] in component_names:
+            latest_builds[b['name']] = b
+    return latest_builds
+
+
 def get_brew_build(nvr, product_version='', session=None):
     """5.2.2.1. GET /api/v1/build/{id_or_nvr}
 

--- a/elliottlib/imagecfg.py
+++ b/elliottlib/imagecfg.py
@@ -23,27 +23,3 @@ class ImageMetadata(Metadata):
         if present.
         """
         return self.config.base_only
-
-    def get_latest_build_info(self, product_version_dict, tag_set, latest_builds, brew_session):
-        """
-        Queries brew to determine the most recently built release of the component
-        associated with this image. This method does not rely on the "release"
-        label needing to be present in the Dockerfile.
-
-        :return: A tuple: (component name, version, release, product_version); e.g. ("registry-console-docker", "v3.6.173.0.75", "1", "OSE-4.1-RHEL-8")
-        """
-        component_name = self.get_component_name()
-        tag = "{}-candidate".format(self.branch())
-        if tag not in tag_set:
-            tags = brew_session.getLatestBuilds(tag)
-            for t in tags:
-                latest_builds[t['name']] = t['nvr']
-            tag_set.add(tag)
-
-        nvr = latest_builds.get(component_name, "")
-        if nvr != "":
-            name, version, release = nvr.rsplit("-", 2)
-            return name, version, release, product_version_dict[self.name]
-
-        # If no builds found
-        raise exceptions.BrewBuildException("No builds detected for %s using tag: %s" % (component_name, tag))


### PR DESCRIPTION
previously we list all the images using brew latest-build one by one, that’s about 130-150 command call which is not very efficient.
in this PR, we change brew latest-build tag componet_name into directly API call and avoid list every componet indivitually instead
we compare the list returned from API with image_meta