### PR TITLE
temp fix for pygit2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ dockerfile-parse
 errata-tool >= 1.19
 future
 koji >= 1.18
-pygit2
+pygit2 == 0.28.2
 pykwalify
 python-bugzilla
 pyyaml


### PR DESCRIPTION
So currenlty since pygit (https://pypi.org/project/pygit2/0.28.2/\#history) update on Dec 6,2019 with version 1.0.0 our pip install command will be failed see issue https://github.com/openshift/elliott/issues/100 for details error logs, tempeoray make pygit2 version sticked to older version

Fix https://github.com/openshift/elliott/issues/100