### PR TITLE
[ART-1176] Fix elliott find-builds --between does not partition by product version 

### DIFF
--- a/elliottlib/brew.py
+++ b/elliottlib/brew.py
@@ -30,6 +30,16 @@ from requests_kerberos import HTTPKerberosAuth
 logger = logutil.getLogger(__name__)
 
 
+def get_latest_builds(tag, component_names, brew_session=koji.ClientSession(constants.BREW_HUB)):
+    latest_builds = {}
+    component_names = set(component_names)
+    builds = brew_session.getLatestBuilds(tag)
+    for b in builds:
+        if b['name'] in component_names:
+            latest_builds[b['name']] = b
+    return latest_builds
+
+
 def get_brew_build(nvr, product_version='', session=None):
     """5.2.2.1. GET /api/v1/build/{id_or_nvr}
 

--- a/elliottlib/cli/find_builds_cli.py
+++ b/elliottlib/cli/find_builds_cli.py
@@ -6,14 +6,10 @@ from elliottlib import constants, logutil, Runtime, brew
 from elliottlib.cli.common import cli, use_default_advisory_option, find_default_advisory
 from elliottlib.exceptions import ElliottFatalError
 from elliottlib.util import exit_unauthenticated, override_product_version, ensure_erratatool_auth, get_release_version
-from elliottlib.util import green_prefix, green_print, parallel_results_with_progress, pbar_header, red_print
-
+from elliottlib.util import green_prefix, green_print, parallel_results_with_progress, pbar_header, red_print, progress_func
 from errata_tool import Erratum
 from kerberos import GSSError
-import requests
-import click
-import koji
-
+import requests, click, koji
 LOGGER = logutil.getLogger(__name__)
 
 pass_runtime = click.make_pass_decorator(Runtime)
@@ -99,17 +95,26 @@ PRESENT advisory. Here are some examples:
     ensure_erratatool_auth()  # before we waste time looking up builds we can't process
 
     # get the builds we want to add
-    unshipped_builds = []
-    session = requests.Session()
+    unshipped_nvrs = []
     if builds:
-        unshipped_builds = _fetch_builds_by_id(builds, product_version, session)
+        green_prefix('Build NVRs provided: ')
+        click.echo('Manually verifying the builds exist')
+        unshipped_nvrs = builds
     elif from_diff:
-        unshipped_builds = _fetch_builds_from_diff(from_diff[0], from_diff[1], product_version, session)
+        green_print('Fetching changed images between payloads...')
+        unshipped_nvrs = elliottlib.openshiftclient.get_build_list(from_diff[0], from_diff[1])
     else:
         if kind == 'image':
-            unshipped_builds = _fetch_builds_by_kind_image(runtime, tag_pv_map, session)
+            unshipped_builds = _fetch_builds_by_kind_image(runtime, tag_pv_map)
         elif kind == 'rpm':
-            unshipped_builds = _fetch_builds_by_kind_rpm(builds, base_tag, product_version, session)
+            unshipped_nvrs = _fetch_builds_by_kind_rpm(base_tag, product_version)
+
+    results = parallel_results_with_progress(
+        unshipped_nvrs,
+        lambda nvr: _nvrs_to_builds(nvr, product_version, tag_pv_map)
+    )
+
+    unshipped_builds = _attached_to_open_erratum_with_correct_pv(kind, results, elliottlib.errata)
 
     _json_dump(as_json, unshipped_builds, base_tag, kind)
 
@@ -117,7 +122,7 @@ PRESENT advisory. Here are some examples:
         green_print('No builds needed to be attached.')
         return
 
-    if advisory is not False:
+    if advisory:
         _attach_to_advisory(unshipped_builds, kind, advisory)
     else:
         click.echo('The following {n} builds '.format(n=len(unshipped_builds)), nl=False)
@@ -125,6 +130,21 @@ PRESENT advisory. Here are some examples:
         click.echo('to an advisory:')
         for b in sorted(unshipped_builds):
             click.echo(' ' + b.nvr)
+
+
+def _get_product_version(nvr, default_product_version, product_version_map, brew_session):
+    product_version = ""
+    for tag in brew_session.listTags(nvr):
+        tag_name = tag.get('name')
+        product_version = product_version_map.get(tag_name, "")
+        if product_version:
+            return product_version
+    return default_product_version
+
+
+def _nvrs_to_builds(nvr, default_product_version, product_version_map, errata_session=requests.Session(), brew_session=koji.ClientSession(constants.BREW_HUB)):
+    pv = _get_product_version(nvr, default_product_version, product_version_map, brew_session)
+    return elliottlib.brew.get_brew_build(nvr, pv, session=errata_session)
 
 
 def _json_dump(as_json, unshipped_builds, base_tag, kind):
@@ -142,30 +162,19 @@ def _determine_errata_info(runtime):
     if not runtime.branch:
         raise ElliottFatalError('Need to specify a branch either in group.yml or with --branch option')
     base_tag = runtime.branch
-
     et_data = runtime.gitdata.load_data(key='erratatool').data
     product_version = override_product_version(et_data.get('product_version'), base_tag)
     tag_pv_map = et_data.get('brew_tag_product_version_mapping')
     return base_tag, product_version, tag_pv_map
 
 
-def _fetch_builds_by_id(builds, product_version, session):
-    green_prefix('Build NVRs provided: ')
-    click.echo('Manually verifying the builds exist')
-    try:
-        return [elliottlib.brew.get_brew_build(b, product_version, session=session) for b in builds]
-    except elliottlib.exceptions.BrewBuildException as ex:
-        raise ElliottFatalError(getattr(ex, 'message', repr(ex)))
-
-
-def _fetch_builds_from_diff(from_payload, to_payload, product_version, session):
-    green_print('Fetching changed images between payloads...')
-    changed_builds = elliottlib.openshiftclient.get_build_list(from_payload, to_payload)
-    return [elliottlib.brew.get_brew_build(b, product_version, session=session) for b in changed_builds]
-
-
-def _fetch_builds_by_kind_image(runtime, tag_pv_map, session):
+def _fetch_builds_by_kind_image(runtime, tag_pv_map):
     image_metadata = runtime.image_metas()
+
+    pbar_header(
+        'Generating list of images: ',
+        'Hold on a moment, fetching Brew buildinfo',
+        image_metadata)
 
     # Returns a list of (n, v, r, pv) tuples of each build
     image_tuples = []
@@ -184,28 +193,13 @@ def _fetch_builds_by_kind_image(runtime, tag_pv_map, session):
         'Fetching data for {n} builds '.format(n=len(image_tuples)),
         image_tuples)
 
-    # By 'meta' I mean the lil bits of meta data given back from
-    # get_latest_build_info
-    #
-    # TODO: Update the ImageMetaData class to include the NVR as
-    # an object attribute.
-    results = parallel_results_with_progress(
-        image_tuples,
-        lambda meta: elliottlib.brew.get_brew_build(
-            '{}-{}-{}'.format(meta[0], meta[1], meta[2]),
-            product_version=meta[3],
-            session=session)
-    )
-
-    return [
-        b for b in results
-        if not b.attached_to_open_erratum
-        # filter out 'openshift-enterprise-base-container' since it's not needed in advisory
-        if 'openshift-enterprise-base-container' not in b.nvr
-    ]
+    nvrs = []
+    for meta in image_tuples:
+        nvrs.append('{}-{}-{}'.format(meta[0], meta[1], meta[2]))
+    return nvrs
 
 
-def _fetch_builds_by_kind_rpm(builds, base_tag, product_version, session):
+def _fetch_builds_by_kind_rpm(base_tag, product_version):
     green_prefix('Generating list of rpms: ')
     click.echo('Hold on a moment, fetching Brew builds')
     candidates = elliottlib.brew.find_unshipped_build_candidates(
@@ -214,22 +208,20 @@ def _fetch_builds_by_kind_rpm(builds, base_tag, product_version, session):
         kind='rpm')
 
     pbar_header('Gathering additional information: ', 'Brew buildinfo is required to continue', candidates)
-    # We could easily be making scores of requests, one for each build
-    # we need information about. May as well do it in parallel.
-    results = parallel_results_with_progress(
-        candidates,
-        lambda nvr: elliottlib.brew.get_brew_build(nvr, product_version, session=session)
-    )
-    return _attached_to_open_erratum_with_correct_product_version(results, product_version, elliottlib.errata)
+    return candidates
 
 
-def _attached_to_open_erratum_with_correct_product_version(results, product_version, errata):
+def _attached_to_open_erratum_with_correct_pv(kind, results, errata):
+    if kind != "image":
+        return results
     unshipped_builds = []
     # will probably end up loading the same errata and
     # its comments many times, which is pretty slow
     # so we cached the result.
     errata_version_cache = {}
     for b in results:
+        if b.nvr.startswith('openshift-enterprise-base-container'):
+            continue
         same_version_exist = False
         # We only want builds not attached to an existing open advisory
         if b.attached_to_open_erratum:
@@ -244,7 +236,7 @@ def _attached_to_open_erratum_with_correct_product_version(results, product_vers
                     # though not very useful (there's a command for adding them,
                     # but not much point in doing it). just looking at the first one is fine.
                     errata_version_cache[e] = metadata_comments_json[0]['release']
-                if errata_version_cache[e] == get_release_version(product_version):
+                if errata_version_cache[e] == get_release_version(b.product_version):
                     same_version_exist = True
                     break
         if not same_version_exist or not b.attached_to_open_erratum:

--- a/elliottlib/constants.py
+++ b/elliottlib/constants.py
@@ -143,3 +143,5 @@ errata_get_comments_url = errata_url + "/api/v1/comments"
 errata_get_erratum_url = errata_url + "/api/v1/erratum/{id}"
 errata_post_erratum_url = errata_url + "/api/v1/erratum"
 errata_get_advisories_for_bug_url = errata_url + "/bugs/{id}/advisories.json"
+errata_get_product_versions = errata_url + "/api/v1/products/{id}/product_versions"
+DISTGIT_MAX_FILESIZE = 50000000

--- a/elliottlib/imagecfg.py
+++ b/elliottlib/imagecfg.py
@@ -23,27 +23,3 @@ class ImageMetadata(Metadata):
         if present.
         """
         return self.config.base_only
-
-    def get_latest_build_info(self, product_version_dict, tag_set, latest_builds, brew_session):
-        """
-        Queries brew to determine the most recently built release of the component
-        associated with this image. This method does not rely on the "release"
-        label needing to be present in the Dockerfile.
-
-        :return: A tuple: (component name, version, release, product_version); e.g. ("registry-console-docker", "v3.6.173.0.75", "1", "OSE-4.1-RHEL-8")
-        """
-        component_name = self.get_component_name()
-        tag = "{}-candidate".format(self.branch())
-        if tag not in tag_set:
-            tags = brew_session.getLatestBuilds(tag)
-            for t in tags:
-                latest_builds[t['name']] = t['nvr']
-            tag_set.add(tag)
-
-        nvr = latest_builds.get(component_name, "")
-        if nvr != "":
-            name, version, release = nvr.rsplit("-", 2)
-            return name, version, release, product_version_dict[self.name]
-
-        # If no builds found
-        raise exceptions.BrewBuildException("No builds detected for %s using tag: %s" % (component_name, tag))

--- a/elliottlib/util.py
+++ b/elliottlib/util.py
@@ -251,5 +251,5 @@ def override_product_version(pv, branch):
 
 
 def get_release_version(pv):
-    """ there are two kind of format of product_version: OSE-4.1-RHEL-8 RHEL-7-OSE-4.1 """
+    """ there are two kind of format of product_version: OSE-4.1-RHEL-8 RHEL-7-OSE-4.1 RHEL-7-OSE-4.1-FOR-POWER-LE """
     return re.search(r'OSE-(\d+\.\d+)', pv).groups()[0]

--- a/tests/test_errata.py
+++ b/tests/test_errata.py
@@ -72,6 +72,20 @@ class TestErrata(unittest.TestCase):
             actual = errata.get_advisories_for_bug(bug, session)
             self.assertEqual(actual, advisories)
 
+    def test_parse_proudct_version(self):
+        product_version_map = {}
+        product_version_json = """{
+            "data":[
+                {"id":964,"type":"product_versions","attributes":{"name":"OSE-4.1-RHEL-8","description":"Red Hat OpenShift Container Platform 4.1","default_brew_tag":"rhaos-4.1-rhel-8-candidate","allow_rhn_debuginfo":false,"is_oval_product":false,"is_rhel_addon":false,"is_server_only":true,"enabled":true},"brew_tags":["rhaos-4.1-rhel-8-candidate"],"relationships":{"rhel_release":{"id":87,"name":"RHEL-8"},"sig_key":{"id":8,"name":"redhatrelease2"}}}]
+        }"""
+        data = json.loads(product_version_json)
+        for l in data['data']:
+            if l['type'] == 'product_versions':
+                for tags in l['brew_tags']:
+                    product_version_map[tags] = l['attributes']['name']
+
+        self.assertEqual(product_version_map, {'rhaos-4.1-rhel-8-candidate': 'OSE-4.1-RHEL-8'})
+
     def test_get_rpmdiff_runs(self):
         advisory_id = 12345
         responses = [

--- a/tests/test_find_builds_cli.py
+++ b/tests/test_find_builds_cli.py
@@ -1,10 +1,9 @@
 from __future__ import unicode_literals
 import unittest
-from elliottlib.cli.find_builds_cli import _attached_to_open_erratum_with_correct_product_version
-from elliottlib.errata import get_metadata_comments_json
+from elliottlib.cli.find_builds_cli import _attached_to_open_erratum_with_correct_pv, _nvrs_to_builds, _get_product_version
 from elliottlib.brew import Build
 import elliottlib
-import flexmock, json
+import flexmock, json, mock
 
 
 class TestFindBuildsCli(unittest.TestCase):
@@ -25,12 +24,12 @@ class TestFindBuildsCli(unittest.TestCase):
         fake_errata = flexmock(model=elliottlib.errata, get_metadata_comments_json=lambda: 1234)
         fake_errata.should_receive("get_metadata_comments_json").and_return(metadata_json_list)
 
-        builds = flexmock(Build(nvr="test-1.1.1"))
+        builds = flexmock(Build(nvr="test-1.1.1", product_version="RHEL-7-OSE-4.1"))
         builds.should_receive("attached_to_open_erratum").and_return(True)
         builds.should_receive("open_errata_id").and_return([12345])
 
         # expect return empty list []
-        self.assertEqual([], _attached_to_open_erratum_with_correct_product_version([builds], "RHEL-7-OSE-4.1", fake_errata))
+        self.assertEqual([], _attached_to_open_erratum_with_correct_pv("image", [builds], fake_errata))
 
     def test_attached_errata_succeed(self):
         """
@@ -45,12 +44,45 @@ class TestFindBuildsCli(unittest.TestCase):
         fake_errata = flexmock(model=elliottlib.errata, get_metadata_comments_json=lambda: 1234)
         fake_errata.should_receive("get_metadata_comments_json").and_return(metadata_json_list)
 
-        builds = flexmock(Build(nvr="test-1.1.1"))
+        builds = flexmock(Build(nvr="test-1.1.1", product_version="RHEL-7-OSE-4.5"))
         builds.should_receive("attached_to_open_erratum").and_return(True)
         builds.should_receive("open_errata_id").and_return([12345])
 
         # expect return list with one build
-        self.assertEqual([Build("test-1.1.1")], _attached_to_open_erratum_with_correct_product_version([builds], "RHEL-7-OSE-4.5", fake_errata))
+        self.assertEqual([Build("test-1.1.1")], _attached_to_open_erratum_with_correct_pv("image", [builds], fake_errata))
+
+    def test_get_product_version(self):
+        """
+        Test get_product_version testing the product_version get from brew list tag and product_version map
+        """
+
+        nvr1 = "logging-fluentd-container-v4.1.14-201908291507"
+        nvr2 = "ironic-container-v4.2.7-201911150432"
+
+        product_version_map = {"rhaos-4.1-rhel-8-candidate": "OSE-4.1-RHEL-8",
+                               "rhaos-4.2-rhel-8-candidate": "OSE-4.2-RHEL-8",
+                               "rhaos-4.1-rhel-7-candidate": "RHEL-7-OSE-4.1",
+                               "rhaos-4.2-rhel-7-candidate": "RHEL-7-OSE-4.2",
+                               "rhaos-3.11-rhel-7-candidate": "RHEL-7-OSE-3.11"
+                               }
+
+        def fake_listTags(nvr):
+            if nvr == nvr1:
+                return [{'arches': None, 'id': 14991, 'locked': False, 'maven_include_all': False, 'maven_support': False,
+                         'name': 'rhaos-4.1-rhel-7-candidate', 'perm': None, 'perm_id': None}]
+            if nvr == nvr2:
+                return [{'arches': None, 'id': 14991, 'locked': False, 'maven_include_all': False, 'maven_support': False,
+                         'name': 'rhaos-4.2-rhel-8-candidate', 'perm': None, 'perm_id': None}]
+
+        with mock.patch("koji.ClientSession", spec=True) as MockSession:
+            session = MockSession()
+            session.listTags = mock.MagicMock(side_effect=fake_listTags)
+
+            pv = _get_product_version(nvr1, "RHEL-7-OSE-4.1", product_version_map, session)
+            self.assertEqual(pv, "RHEL-7-OSE-4.1")
+
+            pv = _get_product_version(nvr2, "RHEL-7-OSE-4.1", product_version_map, session)
+            self.assertEqual(pv, "OSE-4.2-RHEL-8")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Since https://github.com/openshift/elliott/pull/88  is blocked by https://errata.devel.redhat.com/api/v1/products/79/product_versions, this is an alterntive way to solve it by adding brew_tag_product_version_mapping into ocp-build-data here: https://github.com/shiywang/ocp-build-data/blob/openshift-4.2/erratatool.yml#L13-L17
```
[dev@b72add542050 elliott]$ ./elliott --data-path /workspaces/ocp-build-data/  -g openshift-4.2 --product-id 79 find-builds -k image
2019-12-19 06:23:26,039 INFO Using product_id from command line: 79
2019-12-19 06:23:26,039 INFO Using branch from group.yml: rhaos-4.2-rhel-7
Generating list of images: Hold on a moment, fetching Brew buildinfo
[******************************************************************************************************************************************
*************]
[******************************************************************************************************************************************
*************]
Generating build metadata: Fetching data for 151 builds 
[******************************************************************************************************************************************
*************]
[******************************************************************************************************************************************
*************]
ose-cluster-kube-scheduler-operator-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-cloud-credential-operator-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-cluster-authentication-operator-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-node-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
openshift-enterprise-template-service-broker-operator-container-v4.2.11-201912171538 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
prometheus-config-reloader-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
cluster-nfd-operator-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
openshift-enterprise-cluster-capacity-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-machine-config-operator-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
baremetal-machine-controller-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ironic-static-ip-manager-container-v4.2.11-201912181719 OSE-4.2-RHEL-8
OSE-4.2-RHEL-8
ose-cluster-autoscaler-operator-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
sriov-dp-admission-controller-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
jenkins-agent-maven-35-rhel7-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
atomic-openshift-descheduler-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
cluster-network-operator-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-cli-artifacts-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-mdns-publisher-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
logging-kibana5-container-v4.2.11-201912100122 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
openshift-enterprise-service-catalog-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
openshift-enterprise-service-idler-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-cluster-update-keys-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-cluster-kube-controller-manager-operator-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
openshift-enterprise-haproxy-router-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
snapshot-controller-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-cluster-svcat-apiserver-operator-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
csi-livenessprobe-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-cluster-bootstrap-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
tuned-container-v4.2.11-201912100122 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-cluster-samples-operator-container-v4.2.11-201912100122 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
openshift-enterprise-builder-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
openshift-enterprise-deployer-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
elasticsearch-operator-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-containernetworking-plugins-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
atomic-openshift-cluster-autoscaler-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
jenkins-agent-nodejs-8-rhel7-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-cluster-svcat-controller-manager-operator-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
template-service-broker-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
prometheus-operator-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
openshift-enterprise-mariadb-apb-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-metering-helm-container-v4.2.11-201912100122 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
openshift-enterprise-mediawiki-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ironic-ipa-downloader-container-v4.2.11-201912181719 OSE-4.2-RHEL-8
OSE-4.2-RHEL-8
openshift-enterprise-postgresql-apb-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
kube-proxy-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-machine-api-operator-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
golang-github-prometheus-alertmanager-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
grafana-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-egress-http-proxy-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-openstack-machine-controllers-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-metering-reporting-operator-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-kube-etcd-signer-server-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
cluster-version-operator-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ironic-inspector-container-v4.2.11-201912181719 OSE-4.2-RHEL-8
OSE-4.2-RHEL-8
ose-cluster-dns-operator-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-libvirt-machine-controllers-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-multus-admission-controller-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
openshift-enterprise-apb-base-container-v4.2.11-201912171538 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
prom-label-proxy-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-baremetal-operator-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
csi-provisioner-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
kuryr-controller-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-cluster-openshift-controller-manager-operator-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-azure-machine-controllers-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
openshift-state-metrics-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
sriov-network-device-plugin-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-openshift-apiserver-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-cluster-config-operator-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
cluster-logging-operator-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
kube-state-metrics-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
openshift-enterprise-mediawiki-apb-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
csi-attacher-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
coredns-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
cluster-node-tuning-operator-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
openshift-enterprise-pod-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
openshift-enterprise-keepalived-ipfailover-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-installer-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
openshift-jenkins-2-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
telemeter-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
openshift-enterprise-console-operator-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
openshift-enterprise-ansible-operator-container-v4.2.11-201912171538 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-cluster-machine-approver-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-prometheus-adapter-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-cluster-ingress-operator-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
golang-github-openshift-oauth-proxy-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-aws-machine-controllers-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
descheduler-operator-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
openshift-enterprise-tests-container-v4.2.11-201912182101 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
openshift-enterprise-egress-router-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
operator-registry-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
golang-github-prometheus-node_exporter-container-v4.2.11-201912100122 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-gcp-machine-controllers-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
efs-provisioner-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
multus-cni-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-service-ca-operator-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
node-feature-discovery-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
oauth-server-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
jenkins-slave-base-rhel7-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
cluster-monitoring-operator-container-v4.2.11-201912162119 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ghostunnel-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
local-storage-diskmaker-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
hive-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
openshift-enterprise-hyperkube-container-v4.2.11-201912182101 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-must-gather-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
openshift-enterprise-mysql-apb-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
sriov-network-operator-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
logging-fluentd-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
logging-elasticsearch5-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-insights-operator-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
local-storage-static-provisioner-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-cluster-openshift-apiserver-operator-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
openshift-enterprise-console-container-v4.2.11-201912171719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-baremetal-installer-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-installer-artifacts-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
openshift-enterprise-cli-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
marketplace-operator-container-v4.2.11-201912161719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-kube-client-agent-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ironic-container-v4.2.11-201912181719 OSE-4.2-RHEL-8
OSE-4.2-RHEL-8
sriov-cni-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
local-storage-operator-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
logging-curator5-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
kube-rbac-proxy-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-baremetal-runtimecfg-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
kuryr-cni-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
logging-eventrouter-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
openshift-enterprise-apb-tools-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
hadoop-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-network-controller-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-cluster-storage-operator-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ironic-rhcos-downloader-container-v4.2.11-201912181719 OSE-4.2-RHEL-8
OSE-4.2-RHEL-8
ose-cluster-image-registry-operator-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
golang-github-prometheus-prometheus-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
openshift-enterprise-egress-dns-proxy-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
csi-node-driver-registrar-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-etcd-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
operator-lifecycle-manager-container-v4.2.11-201912171719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-openshift-controller-manager-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
openshift-enterprise-asb-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-cluster-kube-apiserver-operator-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
sriov-network-config-daemon-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-ovn-kubernetes-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
openshift-enterprise-recycler-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-leader-elector-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
configmap-reload-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
snapshot-provisioner-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
presto-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-metering-ansible-operator-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
openshift-enterprise-registry-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
ose-haproxy-router-base-container-v4.2.11-201912131719 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
openshift-enterprise-ansible-service-broker-operator-container-v4.2.11-201912171538 RHEL-7-OSE-4.2
RHEL-7-OSE-4.2
No builds needed to be attached.
```