### PR TITLE
Add functional tests

### DIFF
--- a/elliottlib/cli/rpmdiff_cli.py
+++ b/elliottlib/cli/rpmdiff_cli.py
@@ -46,7 +46,7 @@ def show(ctx, advisory):
             incomplete_runs.append(rpmdiff_run)
     util.green_prefix("good: {}".format(len(good_runs)))
     click.echo(", ", nl=False)
-    util.red_prefix("bad:{}".format(len(bad_runs)))
+    util.red_prefix("bad: {}".format(len(bad_runs)))
     click.echo(", ", nl=False)
     util.yellow_print("incomplete: {}".format(len(incomplete_runs)))
 

--- a/functional_tests/README.md
+++ b/functional_tests/README.md
@@ -1,0 +1,35 @@
+# Functional Tests for Elliott
+
+This directory contains functional test suite for Elliott.
+The test suite works by invoking `elliott` as a subprocess then checking for
+the exit code and output.
+
+## Run Tests
+
+Currently the test suite doesn't mock any services, such as Errata Tool, Bugzilla, Brew, etc, but interacts with real production services. You have to obtain all required credentials before running the test suite:
+
+``` sh
+kinit $username
+bugzilla login
+# OCP pullspec in your $HOME/.docker/config.json
+```
+
+Then run the test suite using any tool that is compatible with Python unittest framework:
+
+``` sh
+# Go to project root directory
+
+# Run with Python 3
+python3 -m unittest discover -s functional_tests/
+# Run with Python 2
+python2 -m unittest discover -s functional_tests/
+# Use Pytest with Python 3
+python3 -m pytest functional_tests/
+# Use Pytest with Python 3
+ Python 2
+python2 -m pytest functional_tests/
+```
+
+## Known Issues
+1. Due to the nature of Errata Tool performance, it may take more than 10 minutes to finish all tests.
+2. Because the test interacts with real production services, the test may be flaky due to service outage, network issues, or production data changes.

--- a/functional_tests/constants.py
+++ b/functional_tests/constants.py
@@ -1,0 +1,6 @@
+from __future__ import absolute_import, print_function, unicode_literals
+import sys
+from elliottlib import constants as elliott_constants
+
+ELLIOTT_CMD = [sys.executable, "-m", "elliottlib.cli", "--quiet"]
+ERRATA_TOOL_URL = elliott_constants.errata_url

--- a/functional_tests/test_advisory_images.py
+++ b/functional_tests/test_advisory_images.py
@@ -1,0 +1,24 @@
+from __future__ import absolute_import, print_function, unicode_literals
+import unittest
+import subprocess
+from functional_tests import constants
+
+
+class AdvisoryImagesTestCase(unittest.TestCase):
+    def test_advisory_images_with_group(self):
+        out = subprocess.check_output(
+            constants.ELLIOTT_CMD
+            + [
+                "--group=openshift-4.2", "advisory-images"
+            ]
+        )
+        self.assertIn("\n#########\n", out.decode("utf-8"))
+
+    def test_advisory_images_with_given_advisory(self):
+        out = subprocess.check_output(
+            constants.ELLIOTT_CMD
+            + [
+                "advisory-images", "--advisory", "49645"
+            ]
+        )
+        self.assertIn("\n#########\n", out.decode("utf-8"))

--- a/functional_tests/test_change_state.py
+++ b/functional_tests/test_change_state.py
@@ -1,0 +1,17 @@
+from __future__ import absolute_import, print_function, unicode_literals
+import unittest
+import subprocess
+from functional_tests import constants
+
+
+class ChangeStateTestCase(unittest.TestCase):
+    def test_change_state(self):
+        p = subprocess.Popen(
+            constants.ELLIOTT_CMD
+            + [
+                "--group=openshift-3.9", "change-state", "--state=QE", "--advisory=47924",
+            ],
+            stdout=subprocess.PIPE
+        )
+        out, _ = p.communicate()
+        self.assertIn("Cannot change state from SHIPPED_LIVE to QE", out.decode("utf-8"))

--- a/functional_tests/test_create.py
+++ b/functional_tests/test_create.py
@@ -1,0 +1,16 @@
+from __future__ import absolute_import, print_function, unicode_literals
+import unittest
+import subprocess
+from functional_tests import constants
+
+
+class GreateTestCase(unittest.TestCase):
+    def test_create_rhba(self):
+        out = subprocess.check_output(
+            constants.ELLIOTT_CMD
+            + [
+                "--group=openshift-4.2", "create", "--type=RHBA", "--impetus=standard", "--kind=rpm",
+                "--date=2020-Jan-1", "--assigned-to=openshift-qe-errata@redhat.com", "--manager=vlaad@redhat.com", "--package-owner=lmeyer@redhat.com"
+            ]
+        )
+        self.assertIn("Would have created advisory:", out.decode("utf-8"))

--- a/functional_tests/test_find_bugs.py
+++ b/functional_tests/test_find_bugs.py
@@ -1,0 +1,15 @@
+from __future__ import absolute_import, print_function, unicode_literals
+import unittest
+import subprocess
+from functional_tests import constants
+
+
+class FindBugsTestCase(unittest.TestCase):
+    def test_sweep_bugs(self):
+        out = subprocess.check_output(
+            constants.ELLIOTT_CMD
+            + [
+                "--group=openshift-4.3", "find-bugs", "--mode=sweep",
+            ]
+        )
+        self.assertRegexpMatches(out.decode("utf-8"), "Found \\d+ bugs")

--- a/functional_tests/test_find_builds.py
+++ b/functional_tests/test_find_builds.py
@@ -1,0 +1,24 @@
+from __future__ import absolute_import, print_function, unicode_literals
+import unittest
+import subprocess
+from functional_tests import constants
+
+
+class FindBuildsTestCase(unittest.TestCase):
+    def test_find_rpms(self):
+        out = subprocess.check_output(
+            constants.ELLIOTT_CMD
+            + [
+                "--group=openshift-3.10", "find-builds", "--kind=rpm",
+            ]
+        )
+        self.assertIn("may be attached to an advisory", out.decode("utf-8"))
+
+    def test_find_images(self):
+        out = subprocess.check_output(
+            constants.ELLIOTT_CMD
+            + [
+                "--group=openshift-3.10", "find-builds", "--kind=image",
+            ]
+        )
+        self.assertIn("may be attached to an advisory", out.decode("utf-8"))

--- a/functional_tests/test_find_cve_trackers.py
+++ b/functional_tests/test_find_cve_trackers.py
@@ -1,0 +1,15 @@
+from __future__ import absolute_import, print_function, unicode_literals
+import unittest
+import subprocess
+from functional_tests import constants
+
+
+class FindCVETrackersTestCase(unittest.TestCase):
+    def test_find_cve_trackers(self):
+        out = subprocess.check_output(
+            constants.ELLIOTT_CMD
+            + [
+                "--group=openshift-4.3", "find-cve-trackers",
+            ]
+        )
+        self.assertRegexpMatches(out.decode("utf-8"), "Found \\d+ bugs")

--- a/functional_tests/test_get.py
+++ b/functional_tests/test_get.py
@@ -1,0 +1,14 @@
+from __future__ import absolute_import, print_function, unicode_literals
+import unittest
+import subprocess
+from functional_tests import constants
+
+
+class GetTestCase(unittest.TestCase):
+    def test_get_errutum(self):
+        out = subprocess.check_output(constants.ELLIOTT_CMD + ["get", "49982"])
+        self.assertIn("49982", out.decode("utf-8"))
+
+    def test_get_errutum_with_group(self):
+        out = subprocess.check_output(constants.ELLIOTT_CMD + ["--group=openshift-4.2", "get", "--use-default-advisory", "rpm"])
+        self.assertIn(constants.ERRATA_TOOL_URL, out.decode("utf-8"))

--- a/functional_tests/test_list.py
+++ b/functional_tests/test_list.py
@@ -1,0 +1,15 @@
+from __future__ import absolute_import, print_function, unicode_literals
+import unittest
+import subprocess
+from functional_tests import constants
+
+
+class ListTestCase(unittest.TestCase):
+    def test_sweep_bugs(self):
+        out = subprocess.check_output(
+            constants.ELLIOTT_CMD
+            + [
+                "list", "-n 1",
+            ]
+        )
+        self.assertIn(constants.ERRATA_TOOL_URL, out.decode("utf-8"))

--- a/functional_tests/test_poll_signed.py
+++ b/functional_tests/test_poll_signed.py
@@ -1,0 +1,15 @@
+from __future__ import absolute_import, print_function, unicode_literals
+import unittest
+import subprocess
+from functional_tests import constants
+
+
+class PollSignedTestCase(unittest.TestCase):
+    def test_poll_signed(self):
+        out = subprocess.check_output(
+            constants.ELLIOTT_CMD
+            + [
+                "--group=openshift-3.10", "poll-signed", "--noop", "--use-default-advisory=rpm",
+            ]
+        )
+        self.assertRegexpMatches(out.decode("utf-8"), "All builds signed|Signing incomplete")

--- a/functional_tests/test_rpmdiff.py
+++ b/functional_tests/test_rpmdiff.py
@@ -1,0 +1,24 @@
+from __future__ import absolute_import, print_function, unicode_literals
+import unittest
+import subprocess
+from functional_tests import constants
+
+
+class RPMDiffTestCase(unittest.TestCase):
+    def test_rpmdiff_show_with_group(self):
+        out = subprocess.check_output(
+            constants.ELLIOTT_CMD
+            + [
+                "--group=openshift-4.2", "rpmdiff", "show",
+            ]
+        )
+        self.assertRegexpMatches(out.decode("utf-8"), "good: \\d+, bad: \\d+, incomplete: \\d+")
+
+    def test_rpmdiff_show_with_specified_advisory(self):
+        out = subprocess.check_output(
+            constants.ELLIOTT_CMD
+            + [
+                "rpmdiff", "show", "49981"
+            ]
+        )
+        self.assertRegexpMatches(out.decode("utf-8"), "good: \\d+, bad: \\d+, incomplete: \\d+")

--- a/functional_tests/test_tarball_sources.py
+++ b/functional_tests/test_tarball_sources.py
@@ -1,0 +1,24 @@
+from __future__ import absolute_import, print_function, unicode_literals
+import unittest
+import subprocess
+import shutil
+import tempfile
+from functional_tests import constants
+
+
+class TarballSourcesTestCase(unittest.TestCase):
+    def setUp(self):
+        self.out_dir = tempfile.mkdtemp(prefix="tmp-elliott-functional-test-")
+
+    def tearDown(self):
+        shutil.rmtree(self.out_dir)
+
+    def test_tarball_sources_create(self):
+        out = subprocess.check_output(
+            constants.ELLIOTT_CMD
+            + [
+                "tarball-sources", "create", "--component=logging-fluentd-container",
+                "--out-dir", self.out_dir, "--force", "45606",
+            ]
+        )
+        self.assertIn("All tarball sources are successfully created.", out.decode("utf-8"))

--- a/functional_tests/test_verify_payload.py
+++ b/functional_tests/test_verify_payload.py
@@ -1,0 +1,17 @@
+from __future__ import absolute_import, print_function, unicode_literals
+import unittest
+import subprocess
+from functional_tests import constants
+
+
+class VerifyPayloadTestCase(unittest.TestCase):
+    def test_verify_payload(self):
+        out = subprocess.check_output(
+            constants.ELLIOTT_CMD
+            + [
+                "verify-payload",
+                "quay.io/openshift-release-dev/ocp-release:4.2.12",
+                "49645",
+            ]
+        )
+        self.assertIn("Summary results:", out.decode("utf-8"))

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/openshift/elliott",
     license="Apache License, Version 2.0",
-    packages=find_packages(exclude=["tests", "tests.*"]),
+    packages=find_packages(exclude=["tests", "tests.*", "functional_tests", "functional_tests.*"]),
     include_package_data=True,
     entry_points={
         'console_scripts': [

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ setenv =
     PYTHONDONTWRITEBYTECODE=1
 commands =
     flake8
-    coverage run --branch --source elliott,elliottlib -m unittest discover
+    coverage run --branch --source elliott,elliottlib -m unittest discover -t . -s tests/
     coverage report
 
 [flake8]
@@ -37,7 +37,9 @@ ignore =
     # lambda
     E731,
     # bare except
-    E722
+    E722,
+    # line break before binary operator
+    W503,
 
 exclude = build/*, *.ini, *.in, MANIFEST*, *.md, .eggs, .tox
 max-complexity = -1


### PR DESCRIPTION
Add functional test suite for Elliott. The test suite works by invoking `elliott` as a subprocess then checking for the exit code and output.

Currently the test suite doesn't mock any services, such as Errata Tool, Bugzilla, Brew, etc, but interacts with real production services. This is not perfect but can significantly help our Python 3 migration as a fuse.

See `functional_tests/README.md` for more information and known issues.