### PR TITLE
[ART-818] New "get advisory impetus" CLI command

### DIFF
--- a/elliottlib/cli/__main__.py
+++ b/elliottlib/cli/__main__.py
@@ -51,6 +51,7 @@ from elliottlib.cli.create_placeholder_cli import create_placeholder_cli
 from elliottlib.cli.puddle_advisories_cli import puddle_advisories_cli
 from elliottlib.cli.rpmdiff_cli import rpmdiff_cli
 from elliottlib.cli.advisory_images_cli import advisory_images_cli
+from elliottlib.cli.advisory_impetus_cli import advisory_impetus_cli
 
 
 # 3rd party
@@ -888,6 +889,7 @@ cli.add_command(list_cli)
 cli.add_command(puddle_advisories_cli)
 cli.add_command(rpmdiff_cli)
 cli.add_command(advisory_images_cli)
+cli.add_command(advisory_impetus_cli)
 
 # -----------------------------------------------------------------------------
 # CLI Entry point

--- a/elliottlib/cli/advisory_impetus_cli.py
+++ b/elliottlib/cli/advisory_impetus_cli.py
@@ -1,0 +1,41 @@
+from __future__ import unicode_literals, print_function, with_statement
+import click
+import sys
+
+from elliottlib import Runtime
+from elliottlib.cli.common import cli, use_default_advisory_option, find_default_advisory
+from elliottlib import errata
+
+pass_runtime = click.make_pass_decorator(Runtime)
+
+
+@cli.command('advisory-impetus', short_help='Get advisory impetus')
+@click.option(
+    '--advisory', '-a', 'advisory', type=int, default=None, metavar='ADVISORY',
+    help='Explicitly define advisory ID to be used instead of the default')
+@use_default_advisory_option
+@pass_runtime
+def advisory_impetus_cli(runtime, advisory, default_advisory_type):
+    """Get advisory impetus.
+
+    $ elliott advisory-impetus --advisory 48465
+
+    or
+
+    $ elliott -g openshift-4.2 advisory-impetus --use-default-advisory extras
+    """
+    if advisory and default_advisory_type:
+        raise click.BadParameter('Use only one of --use-default-advisory or --advisory')
+
+    runtime.initialize(no_group=(advisory is not None))
+
+    if advisory is None:
+        advisory = find_default_advisory(runtime, default_advisory_type)
+
+    comments = errata.get_metadata_comments_json(advisory)
+    if not comments or 'impetus' not in comments[0]:
+        print('Error! impetus not found for advisory {}'.format(advisory), file=sys.stderr)
+        print(comments, file=sys.stderr)
+        exit(1)
+
+    print(comments[0]['impetus'])


### PR DESCRIPTION
Part of the logic required by [ART-818](https://issues.redhat.com/browse/ART-818) depends on knowing an advisory's *impetus*.

This PR introduces a new CLI option to easily fetch the impetus of a given advisory.

### Usage examples:

```
$ ./elliott advisory-impetus -a 48465
standard
```

```
$ ./elliott -g openshift-4.4 advisory-impetus --use-default-advisory image
2020-01-03 14:31:50,285 INFO Data clone directory already exists, checking commit sha
2020-01-03 14:31:50,303 INFO Cloning config data from https://github.com/openshift/ocp-build-data.git
2020-01-03 14:31:51,709 INFO Using branch from group.yml: rhaos-4.4-rhel-7
Default advisory detected: 47983
ga
```