### PR TITLE
Additional fixes for better Python 2/3 compatibility

### DIFF
--- a/elliottlib/brew.py
+++ b/elliottlib/brew.py
@@ -2,19 +2,16 @@
 Utility functions for general interactions with Brew and Builds
 """
 from __future__ import absolute_import, print_function, unicode_literals
-
+from future.utils import as_native_str
 # stdlib
-from builtins import str, object
 import ast
 import time
 import datetime
 import subprocess
 from multiprocessing.dummy import Pool as ThreadPool
 from multiprocessing import cpu_count
-from multiprocessing import Lock
 import shlex
 import ssl
-import koji
 
 # ours
 from . import constants
@@ -324,9 +321,11 @@ initialized Build object (provided the build exists).
         self.buildinfo = {}
         self.process()
 
+    @as_native_str()
     def __str__(self):
         return self.nvr
 
+    @as_native_str()
     def __repr__(self):
         return "Build({nvr})".format(nvr=self.nvr)
 

--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -3,11 +3,10 @@ Utility functions and object abstractions for general interactions
 with Red Hat Bugzilla
 """
 from __future__ import absolute_import, print_function, unicode_literals
-
+from future.utils import as_native_str
 # stdlib
 from future import standard_library
 standard_library.install_aliases()
-from builtins import str, object
 from time import sleep
 
 import urllib.parse
@@ -351,6 +350,7 @@ class SearchURL(object):
         self.keyword = ""
         self.keywords_type = ""
 
+    @as_native_str()
     def __str__(self):
         root_string = SearchURL.url_format.format(self.bz_host)
 

--- a/elliottlib/cli/__main__.py
+++ b/elliottlib/cli/__main__.py
@@ -11,7 +11,6 @@ web service.
 # Prepare for Python 3
 # stdlib
 from __future__ import absolute_import, print_function, unicode_literals
-from builtins import str
 from multiprocessing import cpu_count
 from multiprocessing.dummy import Pool as ThreadPool
 import datetime

--- a/elliottlib/cli/create_cli.py
+++ b/elliottlib/cli/create_cli.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import, print_function, unicode_literals
-from builtins import str, map
 import click
 import datetime
 from kerberos import GSSError

--- a/elliottlib/cli/puddle_advisories_cli.py
+++ b/elliottlib/cli/puddle_advisories_cli.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import, print_function, unicode_literals
-from builtins import str
 import click
 import sys
 import elliottlib

--- a/elliottlib/cli/rpmdiff_cli.py
+++ b/elliottlib/cli/rpmdiff_cli.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import, print_function, unicode_literals
-from builtins import str
 import click
 import re
 

--- a/elliottlib/dotconfig.py
+++ b/elliottlib/dotconfig.py
@@ -2,7 +2,7 @@
 # and released under LGPL v3 <https://www.gnu.org/licenses/lgpl-3.0.en.html>
 
 from __future__ import absolute_import, print_function, unicode_literals
-from builtins import object
+from future.utils import string_types
 import yaml
 import os
 import shutil
@@ -75,7 +75,7 @@ class Config(object):
                 else:
                     with open(self.full_path, 'w') as f:
                         if template:
-                            if isinstance(template, str):
+                            if isinstance(template, string_types):
                                 f.write(template)
                             elif isinstance(template, dict):
                                 yaml.dump(template, f, default_flow_style=False)

--- a/elliottlib/errata.py
+++ b/elliottlib/errata.py
@@ -10,7 +10,6 @@ Classes representing an ERRATUM (a single errata)
 from __future__ import absolute_import, print_function, unicode_literals
 from future import standard_library
 standard_library.install_aliases()
-from builtins import str
 from errata_tool import ErrataConnector
 import datetime
 import json

--- a/elliottlib/exectools.py
+++ b/elliottlib/exectools.py
@@ -117,5 +117,5 @@ def cmd_gather(cmd, text_mode=True):
         return rc, out_str, err_str
     else:
         logger.debug(
-            "Process {}: exited with: {}".format(rc))
+            "Process {}: exited with: {}".format(cmd_info, rc))
         return rc, out, err

--- a/elliottlib/gitdata.py
+++ b/elliottlib/gitdata.py
@@ -1,7 +1,7 @@
 # This file is part of gitdata project <https://github.com/adammhaile/gitdata>
 # and released under LGPL v3 <https://www.gnu.org/licenses/lgpl-3.0.en.html>
 from __future__ import absolute_import, print_function, unicode_literals
-from builtins import str, object
+from future.utils import as_native_str
 from future.standard_library import install_aliases
 install_aliases()
 from urllib.parse import urlparse
@@ -38,6 +38,7 @@ class DataObj(object):
         self.filename = self.path.replace(self.base_dir, '').strip('/')
         self.data = data
 
+    @as_native_str()
     def __repr__(self):
         result = {
             'key': self.key,

--- a/elliottlib/model.py
+++ b/elliottlib/model.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import, print_function, unicode_literals
-from builtins import str
+from future.utils import as_native_str
 
 
 class ModelException(Exception):
@@ -20,6 +20,7 @@ class ModelException(Exception):
             d["result"] = self.result
         return d
 
+    @as_native_str()
     def __str__(self):
         if self.result is None:
             return self.msg
@@ -50,9 +51,11 @@ class MissingModel(dict):
     def __delitem__(self, key):
         raise ModelException("Invalid attempt to delete key(%s) in missing branch of model" % key)
 
+    @as_native_str()
     def __str__(self):
         return "(MissingModel)"
 
+    @as_native_str()
     def __repr__(self):
         return "(MissingModel)"
 

--- a/elliottlib/runtime.py
+++ b/elliottlib/runtime.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, print_function, unicode_literals
 from future import standard_library
 standard_library.install_aliases()
-from builtins import str, object
 from multiprocessing import Lock
 from multiprocessing.dummy import Pool as ThreadPool
 import os

--- a/elliottlib/tarball_sources.py
+++ b/elliottlib/tarball_sources.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import, print_function, unicode_literals
-from future.builtins import str
 from . import logutil
 import os
 from io import BytesIO

--- a/functional_tests/test_find_bugs.py
+++ b/functional_tests/test_find_bugs.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 import unittest
 import subprocess
+import six
 from functional_tests import constants
 
 
@@ -12,4 +13,4 @@ class FindBugsTestCase(unittest.TestCase):
                 "--group=openshift-4.3", "find-bugs", "--mode=sweep",
             ]
         )
-        self.assertRegexpMatches(out.decode("utf-8"), "Found \\d+ bugs")
+        six.assertRegex(self, out.decode("utf-8"), "Found \\d+ bugs")

--- a/functional_tests/test_find_cve_trackers.py
+++ b/functional_tests/test_find_cve_trackers.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 import unittest
 import subprocess
+import six
 from functional_tests import constants
 
 
@@ -12,4 +13,4 @@ class FindCVETrackersTestCase(unittest.TestCase):
                 "--group=openshift-4.3", "find-cve-trackers",
             ]
         )
-        self.assertRegexpMatches(out.decode("utf-8"), "Found \\d+ bugs")
+        six.assertRegex(self, out.decode("utf-8"), "Found \\d+ bugs")

--- a/functional_tests/test_poll_signed.py
+++ b/functional_tests/test_poll_signed.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 import unittest
 import subprocess
+import six
 from functional_tests import constants
 
 
@@ -12,4 +13,4 @@ class PollSignedTestCase(unittest.TestCase):
                 "--group=openshift-3.10", "poll-signed", "--noop", "--use-default-advisory=rpm",
             ]
         )
-        self.assertRegexpMatches(out.decode("utf-8"), "All builds signed|Signing incomplete")
+        six.assertRegex(self, out.decode("utf-8"), "All builds signed|Signing incomplete")

--- a/functional_tests/test_rpmdiff.py
+++ b/functional_tests/test_rpmdiff.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 import unittest
 import subprocess
+import six
 from functional_tests import constants
 
 
@@ -12,7 +13,7 @@ class RPMDiffTestCase(unittest.TestCase):
                 "--group=openshift-4.2", "rpmdiff", "show",
             ]
         )
-        self.assertRegexpMatches(out.decode("utf-8"), "good: \\d+, bad: \\d+, incomplete: \\d+")
+        six.assertRegex(self, out.decode("utf-8"), "good: \\d+, bad: \\d+, incomplete: \\d+")
 
     def test_rpmdiff_show_with_specified_advisory(self):
         out = subprocess.check_output(
@@ -21,4 +22,4 @@ class RPMDiffTestCase(unittest.TestCase):
                 "rpmdiff", "show", "49981"
             ]
         )
-        self.assertRegexpMatches(out.decode("utf-8"), "good: \\d+, bad: \\d+, incomplete: \\d+")
+        six.assertRegex(self, out.decode("utf-8"), "good: \\d+, bad: \\d+, incomplete: \\d+")

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,11 @@ dockerfile-parse
 errata-tool >= 1.19
 future
 koji >= 1.18
-pygit2 == 0.28.2
+pygit2 ~= 0.28 ; python_version <= '3.4'
+pygit2 ; python_version >= '3.5'
 python-bugzilla
 pyyaml
 requests
 requests_kerberos
-typing
+six
+typing ; python_version <= '3.4'


### PR DESCRIPTION
1. Don't override builtin `str` for Python 2 with `builtins.str` because the later type is a wrapper class which could break yaml deserialization.
2. Always return `str` for `__str__` and `__repr__` methods rather than unicode for Python 2.
3. Fix non-textmode error message formatting for `exectools.cmd_gather`.
4. Use fine-grained `pygit2` version locking.
5. Eliminate `assertRegexpMatches` deprecation warnings on Python 3 by using the `six` wrapper.