### PR TITLE
ART-1466: Fix Elliott fails to attach RPMs are tagged to released tag…

### DIFF
--- a/elliottlib/brew.py
+++ b/elliottlib/brew.py
@@ -397,6 +397,11 @@ initialized Build object (provided the build exists).
         return [e for e in self.all_errata if e['status'] in constants.errata_active_advisory_labels]
 
     @property
+    def shipped_erratum(self):
+        """Any shipped live erratum this build is attached to"""
+        return [e for e in self.all_errata if e['status'] == constants.errata_shipped_advisory_label]
+
+    @property
     def open_errata_id(self):
         """Any open erratum this build is attached to"""
         return [e['id'] for e in self.all_errata if e['status'] in constants.errata_active_advisory_labels]
@@ -405,6 +410,11 @@ initialized Build object (provided the build exists).
     def attached_to_open_erratum(self):
         """Attached to any open erratum"""
         return len(self.open_erratum) > 0
+
+    @property
+    def attached_to_shipped_erratum(self):
+        """Attached to any shipped erratum"""
+        return len(self.shipped_erratum) > 0
 
     @property
     def closed_erratum(self):

--- a/elliottlib/cli/find_builds_cli.py
+++ b/elliottlib/cli/find_builds_cli.py
@@ -98,7 +98,7 @@ PRESENT advisory. Here are some examples:
     # get the builds we want to add
     unshipped_nvrps = []
     if builds:
-        green_prefix('Fetching Brew tags...')
+        green_prefix('Fetching tags for builds...')
         unshipped_nvrps = _fetch_builds_by_nvr_or_id(builds, tag_pv_map)
     elif from_diff:
         green_print('Fetching changed images between payloads...')
@@ -114,7 +114,7 @@ PRESENT advisory. Here are some examples:
         lambda nvrp: elliottlib.brew.get_brew_build('{}-{}-{}'.format(nvrp[0], nvrp[1], nvrp[2]), nvrp[3], session=requests.Session())
     )
 
-    unshipped_builds = _attached_to_open_erratum_with_correct_pv(kind, results, elliottlib.errata)
+    unshipped_builds = _filter_out_inviable_builds(kind, results, elliottlib.errata)
 
     _json_dump(as_json, unshipped_builds, kind, tag_pv_map)
 
@@ -214,16 +214,14 @@ def _fetch_builds_by_kind_rpm(tag_pv_map):
     return rpm_tuple
 
 
-def _attached_to_open_erratum_with_correct_pv(kind, results, errata):
-    if kind != "image":
-        return results
+def _filter_out_inviable_builds(kind, results, errata):
     unshipped_builds = []
     # will probably end up loading the same errata and
     # its comments many times, which is pretty slow
     # so we cached the result.
     errata_version_cache = {}
     for b in results:
-        same_version_exist = False
+        in_same_version = False
         # We only want builds not attached to an existing open advisory
         if b.attached_to_open_erratum:
             for e in b.open_errata_id:
@@ -238,9 +236,9 @@ def _attached_to_open_erratum_with_correct_pv(kind, results, errata):
                     # but not much point in doing it). just looking at the first one is fine.
                     errata_version_cache[e] = metadata_comments_json[0]['release']
                 if errata_version_cache[e] == get_release_version(b.product_version):
-                    same_version_exist = True
+                    in_same_version = True
                     break
-        if not same_version_exist or not b.attached_to_open_erratum:
+        if not (in_same_version and (b.attached_to_open_erratum or b.attached_to_shipped_erratum)):
             unshipped_builds.append(b)
     return unshipped_builds
 

--- a/elliottlib/cli/find_builds_cli.py
+++ b/elliottlib/cli/find_builds_cli.py
@@ -216,29 +216,26 @@ def _fetch_builds_by_kind_rpm(tag_pv_map):
 
 def _filter_out_inviable_builds(kind, results, errata):
     unshipped_builds = []
-    # will probably end up loading the same errata and
-    # its comments many times, which is pretty slow
-    # so we cached the result.
-    errata_version_cache = {}
+    errata_version_cache = {}  # avoid reloading the same errata for multiple builds
     for b in results:
+        # check if build is attached to any existing advisory for this version
         in_same_version = False
-        # We only want builds not attached to an existing open advisory
-        if b.attached_to_open_erratum:
-            for e in b.open_errata_id:
-                if not errata_version_cache.get(e):
-                    metadata_comments_json = errata.get_metadata_comments_json(e)
-                    if not metadata_comments_json:
-                        # Does not contain ART metadata, skip it
-                        red_print("Errata {} Does not contain ART metadata\n".format(e))
-                        continue
-                    # it's possible for an advisory to have multiple metadata comments,
-                    # though not very useful (there's a command for adding them,
-                    # but not much point in doing it). just looking at the first one is fine.
-                    errata_version_cache[e] = metadata_comments_json[0]['release']
-                if errata_version_cache[e] == get_release_version(b.product_version):
-                    in_same_version = True
-                    break
-        if not (in_same_version and (b.attached_to_open_erratum or b.attached_to_shipped_erratum)):
+        for eid in [e['id'] for e in b.all_errata]:
+            if eid not in errata_version_cache:
+                metadata_comments_json = errata.get_metadata_comments_json(eid)
+                if not metadata_comments_json:
+                    # Does not contain ART metadata; consider it unversioned
+                    red_print("Errata {} Does not contain ART metadata\n".format(eid))
+                    errata_version_cache[eid] = ''
+                    continue
+                # it's possible for an advisory to have multiple metadata comments,
+                # though not very useful (there's a command for adding them,
+                # but not much point in doing it). just looking at the first one is fine.
+                errata_version_cache[eid] = metadata_comments_json[0]['release']
+            if errata_version_cache[eid] == get_release_version(b.product_version):
+                in_same_version = True
+                break
+        if not in_same_version:
             unshipped_builds.append(b)
     return unshipped_builds
 

--- a/elliottlib/constants.py
+++ b/elliottlib/constants.py
@@ -52,6 +52,8 @@ errata_inactive_advisory_labels = [
     "DROPPED_NO_SHIP"
 ]
 
+errata_shipped_advisory_label = "SHIPPED_LIVE"
+
 errata_valid_impetus = [
     'standard',
     'cve',

--- a/tests/test_find_builds_cli.py
+++ b/tests/test_find_builds_cli.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 import unittest
-from elliottlib.cli.find_builds_cli import _attached_to_open_erratum_with_correct_pv
+from elliottlib.cli.find_builds_cli import _filter_out_inviable_builds
 from elliottlib.brew import Build
 import elliottlib
 import flexmock, json, mock
@@ -29,7 +29,7 @@ class TestFindBuildsCli(unittest.TestCase):
         builds.should_receive("open_errata_id").and_return([12345])
 
         # expect return empty list []
-        self.assertEqual([], _attached_to_open_erratum_with_correct_pv("image", [builds], fake_errata))
+        self.assertEqual([], _filter_out_inviable_builds("image", [builds], fake_errata))
 
     def test_attached_errata_succeed(self):
         """
@@ -49,7 +49,7 @@ class TestFindBuildsCli(unittest.TestCase):
         builds.should_receive("open_errata_id").and_return([12345])
 
         # expect return list with one build
-        self.assertEqual([Build("test-1.1.1")], _attached_to_open_erratum_with_correct_pv("image", [builds], fake_errata))
+        self.assertEqual([Build("test-1.1.1")], _filter_out_inviable_builds("image", [builds], fake_errata))
 
 
 if __name__ == "__main__":

--- a/tests/test_find_builds_cli.py
+++ b/tests/test_find_builds_cli.py
@@ -25,8 +25,7 @@ class TestFindBuildsCli(unittest.TestCase):
         fake_errata.should_receive("get_metadata_comments_json").and_return(metadata_json_list)
 
         builds = flexmock(Build(nvr="test-1.1.1", product_version="RHEL-7-OSE-4.1"))
-        builds.should_receive("attached_to_open_erratum").and_return(True)
-        builds.should_receive("open_errata_id").and_return([12345])
+        builds.should_receive("all_errata").and_return([{"id": 12345}])
 
         # expect return empty list []
         self.assertEqual([], _filter_out_inviable_builds("image", [builds], fake_errata))
@@ -45,8 +44,7 @@ class TestFindBuildsCli(unittest.TestCase):
         fake_errata.should_receive("get_metadata_comments_json").and_return(metadata_json_list)
 
         builds = flexmock(Build(nvr="test-1.1.1", product_version="RHEL-7-OSE-4.5"))
-        builds.should_receive("attached_to_open_erratum").and_return(True)
-        builds.should_receive("open_errata_id").and_return([12345])
+        builds.should_receive("all_errata").and_return([{"id": 12345}])
 
         # expect return list with one build
         self.assertEqual([Build("test-1.1.1")], _filter_out_inviable_builds("image", [builds], fake_errata))


### PR DESCRIPTION
… out of order

Currently Elliott find unshipped RPMs using the following approach:
1. Get a list A of latest RPMs with candidate tag from Brew.
2. Get a list B of latest RPMs with base tag from Brew.
3. Subtract B from A.

The problem is some RPMs that are latest with the candidate tag are not considered latest with the base tag.
In such case, Elliott attempts to attach shipped RPMs but fails with the following exception:

```
$ elliott --group openshift-3.11 find-builds -k rpm  --use-default-advisory rpm
2020-01-17 06:35:26,363 INFO Data clone directory already exists, checking commit sha
2020-01-17 06:35:26,843 INFO https://github.com/openshift/ocp-build-data.git is already cloned and latest
2020-01-17 06:35:26,906 INFO Using branch from group.yml: rhaos-3.11-rhel-7
Default advisory detected: 50532
Generating list of rpms: Hold on a moment, fetching Brew builds
Refreshing for tag: rhaos-3.11-rhel-7
Refreshing for tag: rhaos-3.11-rhel-7-candidate
Gathering additional information: Brew buildinfo is required to continue
[**********************]
Refreshing for tag: rhaos-3.11-rhel-8-candidate
Refreshing for tag: rhaos-3.11-rhel-8
Gathering additional information: Brew buildinfo is required to continue
[]
[**********************]

Traceback (most recent call last):
  File "/home/nay/yuxzhu/.local/bin/elliott", line 11, in <module>
    sys.exit(main())
  File "/home/nay/yuxzhu/.local/lib/python3.6/site-packages/elliottlib/cli/__main__.py", line 902, in main
    cli(obj={})
  File "/home/nay/yuxzhu/.local/lib/python3.6/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/nay/yuxzhu/.local/lib/python3.6/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/nay/yuxzhu/.local/lib/python3.6/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/nay/yuxzhu/.local/lib/python3.6/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/nay/yuxzhu/.local/lib/python3.6/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/nay/yuxzhu/.local/lib/python3.6/site-packages/click/decorators.py", line 64, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/home/nay/yuxzhu/.local/lib/python3.6/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/nay/yuxzhu/.local/lib/python3.6/site-packages/elliottlib/cli/find_builds_cli.py", line 127, in find_builds_cli
    _attach_to_advisory(unshipped_builds, kind, advisory)
  File "/home/nay/yuxzhu/.local/lib/python3.6/site-packages/elliottlib/cli/find_builds_cli.py", line 249, in _attach_to_advisory
    file_types={build.nvr: [file_type] for build in builds}
  File "/home/nay/yuxzhu/.local/lib/python3.6/site-packages/errata_tool/erratum.py", line 695, in addBuilds
    return self.addBuildsDirect(buildlist, release, **kwargs)
  File "/home/nay/yuxzhu/.local/lib/python3.6/site-packages/errata_tool/erratum.py", line 674, in addBuildsDirect
    self._processResponse(r)
  File "/home/nay/yuxzhu/.local/lib/python3.6/site-packages/errata_tool/connector.py", line 256, in _processResponse
    raise ErrataException(err_msg)
errata_tool.exception.ErrataException: Erratum 50532: Unable to add build 'openshift-monitor-project-lifecycle-3.11.51-2.git.59.7b59e29.el7' which has already been released.
```

This PR filters shipped builds out of the to-be-attached list.