### PR TITLE
ART-1613: Fix `find-builds --between` claims `No builds needed to be …

### DIFF
--- a/elliottlib/cli/find_builds_cli.py
+++ b/elliottlib/cli/find_builds_cli.py
@@ -169,11 +169,8 @@ def _json_dump(as_json, unshipped_builds, kind, tag_pv_map):
 
 def _fetch_builds_from_diff(from_payload, to_payload, tag_pv_map):
     green_print('Fetching changed images between payloads...')
-    payload_tuple = []
-    for tag in tag_pv_map:
-        latest_builds = brew.get_latest_builds('nvr', tag, elliottlib.openshiftclient.get_build_list(from_payload, to_payload))
-        payload_tuple.extend(_gen_nvrp_tuples(latest_builds, tag_pv_map, tag))
-    return payload_tuple
+    nvrs = elliottlib.openshiftclient.get_build_list(from_payload, to_payload)
+    return _fetch_builds_by_nvr_or_id(nvrs, tag_pv_map)
 
 
 def _fetch_builds_by_kind_image(runtime, tag_pv_map):


### PR DESCRIPTION
…attached`

I had trouble with `elliott find-builds --kind image --between` using master elliott. It just says `No builds needed to be attached.` whatever input you give:

``` bash
$ elliott -g openshift-4.1 find-builds --kind image --between quay.io/openshift-release-dev/ocp-release:4.1.34-x86_64 registry.svc.ci.openshift.org/ocp/release:4.1.0-0.nightly-2020-03-02-184454 --use-default-advisory image
2020-03-03 02:52:58,172 INFO Data clone directory already exists, checking commit sha
2020-03-03 02:52:58,734 INFO https://github.com/openshift/ocp-build-data.git is already cloned and latest
2020-03-03 02:52:58,822 INFO Using branch from group.yml: rhaos-4.1-rhel-7
Default advisory detected: 51343
Fetching changed images between payloads...
[]
No builds needed to be attached.
```

I had to spend a lot of time on debugging this issue (because it needs to fetch images while the network between US and China is increditability slow), finding out it is caused by a similar issue as ART-1491 (https://github.com/openshift/elliott/pull/113): it mistakenly passing NVRs to brew.getLatestBuilds however that API only accepts component names but not NVRs!

The fix is simple, just pass the NVRs returned from `elliottlib.openshiftclient.get_build_list` to `_fetch_builds_by_nvr_or_id`.