### PR TITLE
make find-buidls has option `--remove` to remove builds from advisory

### DIFF
--- a/elliottlib/cli/find_builds_cli.py
+++ b/elliottlib/cli/find_builds_cli.py
@@ -292,4 +292,4 @@ def _update_to_advisory(builds, kind, advisory, remove):
     except GSSError:
         exit_unauthenticated()
     except elliottlib.exceptions.BrewBuildException as ex:
-        raise ElliottFatalError(f'Error attaching/remvoing builds: {str(ex)}')
+        raise ElliottFatalError(f'Error attaching/removing builds: {str(ex)}')


### PR DESCRIPTION
This PR introduced an option for find-builds just to remove those unsinged builds since new workflow change in z-stream release.

cc @sosiouxme @thiagoalessio @vfreex 


```
[dev@8850aaf9493f elliott]$ elliott --group openshift-4.3 find-builds -k image -b oauth-server-container-v4.3.22-202005212137 -a 55017 --remove
2020-05-22 11:17:09,669 INFO Data clone directory already exists, checking commit sha
2020-05-22 11:17:12,355 INFO https://github.com/openshift/ocp-build-data.git is already cloned and latest
2020-05-22 11:17:12,490 INFO Using branch from group.yml: rhaos-4.3-rhel-7
Fetching tags for builds...Fetching builds from Errata: Hold on a moment, fetching buildinfos from Errata Tool...
[*]
[*]
Remvoing from advisory 55017...
Removed build(s) successfully:
 oauth-server-container-v4.3.22-202005212137
```

to add it back, just rerun without `--remove`
```
[dev@8850aaf9493f elliott]$ elliott --group openshift-4.3 find-builds -k image -b oauth-server-container-v4.3.22-202005212137 -a 55017 
2020-05-22 11:21:51,385 INFO Data clone directory already exists, checking commit sha
2020-05-22 11:21:53,428 INFO https://github.com/openshift/ocp-build-data.git is already cloned and latest
2020-05-22 11:21:53,579 INFO Using branch from group.yml: rhaos-4.3-rhel-7
Fetching tags for builds...Fetching builds from Errata: Hold on a moment, fetching buildinfos from Errata Tool...
[*]
[*]
Attaching to advisory 55017...
Attached build(s) successfully:
 oauth-server-container-v4.3.22-202005212137
```

Results are reflecting in here:
https://errata.devel.redhat.com/advisory/55017
