### PR TITLE
Add `tag-builds` command to replace ocp-tag-signed-errata-builds.py

### DIFF
--- a/elliottlib/cli/__main__.py
+++ b/elliottlib/cli/__main__.py
@@ -52,7 +52,7 @@ from elliottlib.cli.puddle_advisories_cli import puddle_advisories_cli
 from elliottlib.cli.rpmdiff_cli import rpmdiff_cli
 from elliottlib.cli.advisory_images_cli import advisory_images_cli
 from elliottlib.cli.advisory_impetus_cli import advisory_impetus_cli
-
+from elliottlib.cli.tag_builds_cli import tag_builds_cli
 
 # 3rd party
 import bugzilla
@@ -809,6 +809,7 @@ cli.add_command(find_builds_cli)
 cli.add_command(list_cli)
 cli.add_command(puddle_advisories_cli)
 cli.add_command(rpmdiff_cli)
+cli.add_command(tag_builds_cli)
 cli.add_command(tarball_sources_cli)
 
 # -----------------------------------------------------------------------------

--- a/elliottlib/cli/change_state_cli.py
+++ b/elliottlib/cli/change_state_cli.py
@@ -12,6 +12,7 @@ LOGGER = logutil.getLogger(__name__)
 
 pass_runtime = click.make_pass_decorator(Runtime)
 
+
 #
 # Set advisory state
 # change-state

--- a/elliottlib/cli/tag_builds_cli.py
+++ b/elliottlib/cli/tag_builds_cli.py
@@ -1,0 +1,194 @@
+from typing import List, Tuple
+import click
+import requests
+import koji
+import time
+from elliottlib import Runtime
+from elliottlib import errata, brew, constants, exceptions
+from elliottlib.cli.common import cli, use_default_advisory_option, find_default_advisory
+from elliottlib.util import green_print, red_print, yellow_print
+
+pass_runtime = click.make_pass_decorator(Runtime)
+
+
+#
+# Tag Brew builds
+# tag-builds
+#
+@cli.command("tag-builds", short_help="Tag specified Brew builds into specified tag")
+@click.option(
+    '--advisory', '-a', 'advisories',
+    multiple=True, metavar='ADVISORY', type=int,
+    help='Add builds on ADVISORY to tag [MULTIPLE]')
+@use_default_advisory_option
+@click.option(
+    '--product-version', '--pv', 'product_version',
+    metavar='PRODUCT_VERSION', type=str,
+    help='Narrow builds with specified product version. e.g. RHEL-7-OSE-4.4, OSE-4.4-RHEL-8')
+@click.option(
+    '--build', '-b', 'builds',
+    multiple=True, metavar='NVR_OR_ID',
+    help='Add build NVR_OR_ID to tag [MULTIPLE]')
+@click.option(
+    '--tag', '-t',
+    metavar='TAG', required=True,
+    help='Tag name. e.g. rhaos-4.4-rhel-8-image-build')
+@click.option(
+    '--dont-untag', '-d', is_flag=True,
+    help="Don't untag unspecified Brew builds")
+@click.option(
+    '--dry-run', is_flag=True,
+    help="Don't really tag/untag any builds. Just print which builds should be tagged and untagged")
+@pass_runtime
+def tag_builds_cli(runtime: Runtime, advisories: Tuple[int], default_advisory_type: str, product_version: str,
+                   builds: Tuple[str], tag: str, dont_untag: bool, dry_run: bool):
+    """ Tag builds into Brew tag and optionally untag unspecified builds.
+
+    Example 1: Tag RHEL7 RPMs that on ocp-build-data recorded advisory into rhaos-4.3-rhel-7-image-build
+
+    $ elliott --group=openshift-4.3 tag-builds --use-default-advisory rpm --product-version RHEL-7-OSE-4.3 --tag rhaos-4.3-rhel-7-image-build
+
+    Example 2: Tag RHEL8 RPMs that are on advisory 55016 into rhaos-4.3-rhel-8-image-build
+
+    $ elliott --group=openshift-4.3 tag-builds --advisory 55016 --product-version OSE-4.4-RHEL-8 --tag rhaos-4.3-rhel-8-image-build
+
+    Example 3: Tag specified builds into rhaos-4.3-rhel-8-image-build
+
+    $ elliott --group=openshift-4.3 tag-builds --build buildah-1.11.6-6.rhaos4.3.el8 --build openshift-4.3.23-202005230952.git.1.b596217.el8 --tag rhaos-4.3-rhel-8-image-build
+    """
+    if advisories and builds:
+        raise click.BadParameter('Use only one of --build or --advisory/-a.')
+    if advisories and default_advisory_type:
+        raise click.BadParameter('Use only one of --use-default-advisory or --advisory/-a.')
+    if default_advisory_type and builds:
+        raise click.BadParameter('Use only one of --build or --use-default-advisory.')
+    if product_version and not advisories and not default_advisory_type:
+        raise click.BadParameter('--product-version should only be used with --use-default-advisory or --advisory/-a.')
+
+    runtime.initialize()
+    logger = runtime.logger
+    if default_advisory_type:
+        advisories = (find_default_advisory(runtime, default_advisory_type), )
+
+    all_builds = set()  # All Brew builds that should be in the tag
+
+    if advisories:
+        errata_session = requests.session()
+        for advisory in advisories:
+            logger.info(f"Fetching attached Brew builds from advisory {advisory}...")
+            errata_builds = errata.get_builds(advisory, errata_session)
+            product_versions = list(errata_builds.keys())
+            logger.debug(f"Advisory {advisory} has builds for {len(product_versions)} product versions: {product_versions}")
+            if product_version:  # Only this product version should be concerned
+                product_versions = [product_version]
+            for pv in product_versions:
+                logger.debug(f"Extract Errata builds for product version {pv}")
+                nvrs = _extract_nvrs_from_errata_build_list(errata_builds, pv)
+                logger.info(f"Found {len(nvrs)} builds from advisory {advisory} with product version {pv}")
+                logger.debug(f"The following builds are found for product version {pv}:\n\t{list(nvrs)}")
+                all_builds |= set(nvrs)
+
+    brew_session = koji.ClientSession(runtime.group_config.urls.brewhub or constants.BREW_HUB)
+    if builds:  # NVRs are directly specified with --build
+        build_objs = brew.get_build_objects(list(builds), brew_session)
+        all_builds = {build["nvr"] for build in build_objs}
+
+    click.echo(f"The following {len(all_builds)} build(s) should be in tag {tag}:")
+    for nvr in all_builds:
+        green_print(f"\t{nvr}")
+
+    # get NVRs that have been tagged
+    tagged_build_objs = brew_session.listTagged(tag, latest=False, inherit=False)
+    tagged_builds = {build["nvr"] for build in tagged_build_objs}
+
+    # get NVRs that should be tagged
+    missing_builds = all_builds - tagged_builds
+    click.echo(f"{len(missing_builds)} build(s) need to be tagged into {tag}:")
+    for nvr in missing_builds:
+        green_print(f"\t{nvr}")
+
+    # get NVRs that should be untagged
+    extra_builds = tagged_builds - all_builds
+    click.echo(f"{len(extra_builds)} build(s) need to be untagged from {tag}:")
+    for nvr in extra_builds:
+        green_print(f"\t{nvr}")
+
+    if dry_run:
+        yellow_print("Dry run: Do nothing.")
+        return
+
+    brew_session.gssapi_login()
+
+    if not dont_untag:
+        # untag extra builds
+        extra_builds = list(extra_builds)
+        logger.info(f"Untagging {len(extra_builds)} build(s) from {tag}...")
+        multicall_tasks = brew.untag_builds(tag, extra_builds, brew_session)
+        failed_to_untag = []
+        for index, task in enumerate(multicall_tasks):
+            try:
+                task.result
+                click.echo(f"{nvr} has been successfully untagged from {tag}")
+            except Exception as ex:
+                nvr = extra_builds[index]
+                failed_to_untag.append(nvr)
+                logger.error(f"Failed to untag {nvr}: {ex}")
+
+    # tag missing builds
+    missing_builds = list(missing_builds)
+    task_id_nvr_map = {}
+    logger.info(f"Tagging {len(missing_builds)} build(s) into {tag}...")
+    multicall_tasks = brew.tag_builds(tag, missing_builds, brew_session)
+    failed_to_tag = []
+    for index, task in enumerate(multicall_tasks):
+        nvr = missing_builds[index]
+        try:
+            task_id = task.result
+            task_id_nvr_map[task_id] = nvr
+        except Exception as ex:
+            failed_to_tag.append(nvr)
+            logger.error(f"Failed to tag {nvr}: {ex}")
+
+    if task_id_nvr_map:
+        # wait for tag task to finish
+        logger.info("Waiting for tag tasks to finish")
+        brew.wait_tasks(task_id_nvr_map.keys(), brew_session, logger=logger)
+        # get tagging results
+        stopped_tasks = list(task_id_nvr_map.keys())
+        with brew_session.multicall(strict=False) as m:
+            multicall_tasks = []
+            for task_id in stopped_tasks:
+                multicall_tasks.append(m.getTaskResult(task_id, raise_fault=False))
+        for index, t in enumerate(multicall_tasks):
+            task_id = stopped_tasks[index]
+            nvr = task_id_nvr_map[task_id]
+            tag_res = t.result
+            logger.debug(f"Tagging task {task_id} {nvr} returned result {tag_res}")
+            click.echo(f"{nvr} has been successfully tagged into {tag}")
+            if tag_res and 'faultCode' in tag_res:
+                if "already tagged" not in tag_res["faultString"]:
+                    failed_to_tag.append(nvr)
+                    logger.error(f'Failed to tag {nvr} into {tag}: {tag_res["faultString"]}')
+
+    if failed_to_untag:
+        red_print("The following builds were failed to untag:")
+        for nvr in failed_to_untag:
+            red_print(f"\t{nvr}")
+    elif not dont_untag:
+        green_print(f"All unspecified builds have been successfully untagged from {tag}.")
+
+    if failed_to_tag:
+        red_print("The following builds were failed to tag:")
+        for nvr in failed_to_tag:
+            red_print(f"\t{nvr}")
+    else:
+        green_print(f"All builds have been successfully tagged into {tag}.")
+
+    if failed_to_untag or failed_to_tag:
+        raise exceptions.ElliottFatalError("Not all builds were successfully tagged/untagged.")
+
+
+# Extract NVRs for specified product version from Errata returned build list.
+# This function is useful because Errata API returns attached builds in a very weird JSON format.
+def _extract_nvrs_from_errata_build_list(errata_builds, product_version):
+    return [key for build in errata_builds.get(product_version, {}).get("builds", {}) for key in build]

--- a/elliottlib/errata.py
+++ b/elliottlib/errata.py
@@ -258,7 +258,7 @@ def get_metadata_comments_json(advisory_id):
     return metadata_json_list
 
 
-def get_builds(advisory_id):
+def get_builds(advisory_id, session=None):
     """5.2.2.6. GET /api/v1/erratum/{id}/builds
      Fetch the Brew builds associated with an advisory.
      Returned builds are organized by product version, variant, arch
@@ -272,9 +272,11 @@ def get_builds(advisory_id):
     * variant_arch: the list of files grouped by variant and arch.
      https://errata.devel.redhat.com/developer-guide/api-http-api.html#api-get-apiv1erratumidbuilds
     """
-    res = requests.get(constants.errata_get_builds_url.format(id=advisory_id),
-                       verify=ssl.get_default_verify_paths().openssl_cafile,
-                       auth=HTTPKerberosAuth())
+    if not session:
+        session = requests.session()
+    res = session.get(constants.errata_get_builds_url.format(id=advisory_id),
+                      verify=ssl.get_default_verify_paths().openssl_cafile,
+                      auth=HTTPKerberosAuth())
     if res.status_code == 200:
         return res.json()
     else:


### PR DESCRIPTION
This PR reimplements [ocp-tag-signed-errata-builds.py](https://github.com/openshift/aos-cd-jobs/blob/6b4877d519f20cadad0f65b2f185cb7cf2b4edde/jobs/build/signed-compose/ocp-tag-signed-errata-builds.py),
which tags builds on advisories into a Brew tag for creating signed
compose.

Comparing with the original implementation, this PR has the following
advantages:

- Only tag RPMs that are on specified advisories rather than all open advisories. Advisory IDs can be given with `--advisory` or ocp-build-data. This is to avoid tagging unwanted builds like https://issues.redhat.com/browse/ART-1306.
- Don't tag images. It is not necessary.
- Leverage the Brew multicall API to improve the tagging performance.
- When waiting for the tagging tasks to finish, mimic the behavior of `brew tagBuild` command: Poll the task with `getTaskInfo` then call `getTaskResult`.

This new implementation is really fast: Tagging all builds for a release
usually takes less than 1 minute.

Example runs:

```bash
$ time python3 ./elliott --group=openshift-4.3 --debug tag-builds --use-default-advisory rpm --product-version RHEL-7-OSE-4.3 --tag rhaos-4.3-rhel-7-image-build                             
2020-05-26 06:18:49,096 INFO Cloning config data from https://github.com/openshift/ocp-build-data.git
2020-05-26 06:18:49,097 DEBUG Executing:cmd_gather [cwd=/mnt/nfs/home/jenkins/yuxzhu/elliott]: ["git", "clone", "-b", "openshift-4.3", "--depth", "1", "https://github.com/openshift/ocp-build-data.git", "/tmp/elliott-41_71ffx.tmp/ocp-build-data"]
2020-05-26 06:18:49,959 DEBUG Process [cwd=/mnt/nfs/home/jenkins/yuxzhu/elliott]: ["git", "clone", "-b", "openshift-4.3", "--depth", "1", "https://github.com/openshift/ocp-build-data.git", "/tmp/elliott-41_71ffx.tmp/ocp-build-data"]: exited with: 0
stdout>><<
stderr>>Cloning into '/tmp/elliott-41_71ffx.tmp/ocp-build-data'...
<<

2020-05-26 06:18:50,063 INFO Using branch from group.yml: rhaos-4.3-rhel-7
Default advisory detected: 55016
2020-05-26 06:18:50,064 INFO Fetching attached Brew builds from advisory 55016...
2020-05-26 06:18:50,603 DEBUG Advisory 55016 has builds for 2 product versions: ['OSE-4.3-RHEL-8', 'RHEL-7-OSE-4.3']
2020-05-26 06:18:50,603 DEBUG Extract Errata builds for product version RHEL-7-OSE-4.3
2020-05-26 06:18:50,603 INFO Found 5 builds from advisory 55016 with product version RHEL-7-OSE-4.3
2020-05-26 06:18:50,603 DEBUG The following builds are found for product version RHEL-7-OSE-4.3:
        ['openshift-4.3.23-202005230952.git.1.b596217.el7', 'openshift-clients-4.3.23-202005230952.git.1.63743cd.el7', 'openshift-ansible-4.3.23-202005230952.git.1.e0edc0f.el7', 'atomic-enterprise-service-catalog-4.3.23-202005250318.git.1.4c60be1.el7', 'atomic-openshift-service-idler-4.3.23-202005250318.git.1.61e064c.el7']
The following 5 build(s) should be in tag rhaos-4.3-rhel-7-image-build:
        atomic-openshift-service-idler-4.3.23-202005250318.git.1.61e064c.el7
        atomic-enterprise-service-catalog-4.3.23-202005250318.git.1.4c60be1.el7
        openshift-clients-4.3.23-202005230952.git.1.63743cd.el7
        openshift-ansible-4.3.23-202005230952.git.1.e0edc0f.el7
        openshift-4.3.23-202005230952.git.1.b596217.el7
5 build(s) need to be tagged into rhaos-4.3-rhel-7-image-build:
        atomic-openshift-service-idler-4.3.23-202005250318.git.1.61e064c.el7
        atomic-enterprise-service-catalog-4.3.23-202005250318.git.1.4c60be1.el7
        openshift-clients-4.3.23-202005230952.git.1.63743cd.el7
        openshift-ansible-4.3.23-202005230952.git.1.e0edc0f.el7
        openshift-4.3.23-202005230952.git.1.b596217.el7
0 build(s) need to be untagged from rhaos-4.3-rhel-7-image-build:
2020-05-26 06:18:50,849 INFO Untagging 0 build(s) from rhaos-4.3-rhel-7-image-build...
2020-05-26 06:18:50,850 INFO Tagging 5 build(s) into rhaos-4.3-rhel-7-image-build...
2020-05-26 06:18:53,590 INFO Waiting for tag tasks to finish
2020-05-26 06:18:53,609 DEBUG Task 28826092 state is FREE
2020-05-26 06:18:53,610 DEBUG Task 28826093 state is FREE
2020-05-26 06:18:53,610 DEBUG Task 28826094 state is FREE
2020-05-26 06:18:53,610 DEBUG Task 28826095 state is FREE
2020-05-26 06:18:53,610 DEBUG Task 28826096 state is FREE
2020-05-26 06:18:53,610 DEBUG There are still 5 tagging task(s) running. Will recheck in 10 seconds.
2020-05-26 06:19:03,694 DEBUG Task 28826092 state is CLOSED
2020-05-26 06:19:03,694 DEBUG Task 28826093 state is OPEN
2020-05-26 06:19:03,694 DEBUG Task 28826094 state is FREE
2020-05-26 06:19:03,694 DEBUG Task 28826095 state is FREE
2020-05-26 06:19:03,695 DEBUG Task 28826096 state is FREE
2020-05-26 06:19:03,695 DEBUG There are still 4 tagging task(s) running. Will recheck in 10 seconds.
2020-05-26 06:19:13,768 DEBUG Task 28826093 state is CLOSED
2020-05-26 06:19:13,768 DEBUG Task 28826094 state is OPEN
2020-05-26 06:19:13,768 DEBUG Task 28826095 state is FREE
2020-05-26 06:19:13,768 DEBUG Task 28826096 state is FREE
2020-05-26 06:19:13,768 DEBUG There are still 3 tagging task(s) running. Will recheck in 10 seconds.
2020-05-26 06:19:23,845 DEBUG Task 28826094 state is CLOSED
2020-05-26 06:19:23,846 DEBUG Task 28826095 state is FREE
2020-05-26 06:19:23,846 DEBUG Task 28826096 state is FREE
2020-05-26 06:19:23,846 DEBUG There are still 2 tagging task(s) running. Will recheck in 10 seconds.
2020-05-26 06:19:33,925 DEBUG Task 28826095 state is CLOSED
2020-05-26 06:19:33,925 DEBUG Task 28826096 state is OPEN
2020-05-26 06:19:33,925 DEBUG There are still 1 tagging task(s) running. Will recheck in 10 seconds.
2020-05-26 06:19:44,002 DEBUG Task 28826096 state is CLOSED
2020-05-26 06:19:44,015 DEBUG Tagging task 28826092 atomic-openshift-service-idler-4.3.23-202005250318.git.1.61e064c.el7 returned result None
atomic-openshift-service-idler-4.3.23-202005250318.git.1.61e064c.el7 has been successfully tagged into rhaos-4.3-rhel-7-image-build
2020-05-26 06:19:44,016 DEBUG Tagging task 28826093 atomic-enterprise-service-catalog-4.3.23-202005250318.git.1.4c60be1.el7 returned result None
atomic-enterprise-service-catalog-4.3.23-202005250318.git.1.4c60be1.el7 has been successfully tagged into rhaos-4.3-rhel-7-image-build
2020-05-26 06:19:44,016 DEBUG Tagging task 28826094 openshift-clients-4.3.23-202005230952.git.1.63743cd.el7 returned result None
openshift-clients-4.3.23-202005230952.git.1.63743cd.el7 has been successfully tagged into rhaos-4.3-rhel-7-image-build
2020-05-26 06:19:44,016 DEBUG Tagging task 28826095 openshift-ansible-4.3.23-202005230952.git.1.e0edc0f.el7 returned result None
openshift-ansible-4.3.23-202005230952.git.1.e0edc0f.el7 has been successfully tagged into rhaos-4.3-rhel-7-image-build
2020-05-26 06:19:44,016 DEBUG Tagging task 28826096 openshift-4.3.23-202005230952.git.1.b596217.el7 returned result None
openshift-4.3.23-202005230952.git.1.b596217.el7 has been successfully tagged into rhaos-4.3-rhel-7-image-build
All unspecified builds have been successfully untagged from rhaos-4.3-rhel-7-image-build.
All builds have been successfully tagged into rhaos-4.3-rhel-7-image-build.

real    0m55.455s
user    0m0.678s
sys     0m0.246s
```

``` bash
$ time python3 ./elliott  --group=openshift-4.3 --debug tag-builds --use-default-advisory rpm --product-version OSE-4.3-RHEL-8 --tag rhaos-4.3-rhel-8-image-build
$ time python3 ./elliott --group=openshift-4.3 --debug tag-builds --use-default-advisory rpm --product-version OSE-4.3-RHEL-8 --tag rhaos-4.3-rhel-8-image-build                             
2020-05-26 06:20:32,687 INFO Cloning config data from https://github.com/openshift/ocp-build-data.git
2020-05-26 06:20:32,688 DEBUG Executing:cmd_gather [cwd=/mnt/nfs/home/jenkins/yuxzhu/elliott]: ["git", "clone", "-b", "openshift-4.3", "--depth", "1", "https://github.com/openshift/ocp-build-data.git", "/tmp/elliot
t-n5kstg6m.tmp/ocp-build-data"]
2020-05-26 06:20:33,538 DEBUG Process [cwd=/mnt/nfs/home/jenkins/yuxzhu/elliott]: ["git", "clone", "-b", "openshift-4.3", "--depth", "1", "https://github.com/openshift/ocp-build-data.git", "/tmp/elliott-n5kstg6m.tm
p/ocp-build-data"]: exited with: 0
stdout>><<
stderr>>Cloning into '/tmp/elliott-n5kstg6m.tmp/ocp-build-data'...
stderr>>Cloning into '/tmp/elliott-n5kstg6m.tmp/ocp-build-data'...                                                                                                                                           [45/1888]
<<

2020-05-26 06:20:33,642 INFO Using branch from group.yml: rhaos-4.3-rhel-7
Default advisory detected: 55016
2020-05-26 06:20:33,643 INFO Fetching attached Brew builds from advisory 55016...
2020-05-26 06:20:34,141 DEBUG Advisory 55016 has builds for 2 product versions: ['OSE-4.3-RHEL-8', 'RHEL-7-OSE-4.3']
2020-05-26 06:20:34,141 DEBUG Extract Errata builds for product version OSE-4.3-RHEL-8
2020-05-26 06:20:34,141 INFO Found 5 builds from advisory 55016 with product version OSE-4.3-RHEL-8
2020-05-26 06:20:34,142 DEBUG The following builds are found for product version OSE-4.3-RHEL-8:
        ['buildah-1.11.6-6.rhaos4.3.el8', 'openshift-clients-4.3.23-202005230952.git.1.63743cd.el8', 'openshift-4.3.23-202005230952.git.1.b596217.el8', 'machine-config-daemon-4.3.23-202005250318.git.1.c3d0c8a.el8',
 'openshift-kuryr-4.3.23-202005250318.git.1.02fba3c.el8']
The following 5 build(s) should be in tag rhaos-4.3-rhel-8-image-build:
        openshift-4.3.23-202005230952.git.1.b596217.el8
        machine-config-daemon-4.3.23-202005250318.git.1.c3d0c8a.el8
        openshift-clients-4.3.23-202005230952.git.1.63743cd.el8
        buildah-1.11.6-6.rhaos4.3.el8
        openshift-kuryr-4.3.23-202005250318.git.1.02fba3c.el8
0 build(s) need to be tagged into rhaos-4.3-rhel-8-image-build:
21 build(s) need to be untagged from rhaos-4.3-rhel-8-image-build:
        ironic-ipa-downloader-container-v4.3.23-202005250318
        openshift-clients-4.3.22-202005180559.git.1.a478120.el8
        ironic-static-ip-manager-container-v4.3.0-202001211731.1580285192
        openshift-4.3.22-202005180559.git.1.95946a0.el8
        ironic-static-ip-manager-container-v4.3.22-202005201238
        ironic-rhcos-downloader-container-v4.3.22-202005201238
        kuryr-controller-container-v4.3.23-202005250318
        ironic-container-v4.3.22-202005201238
        ironic-inspector-container-v4.3.23-202005250318
        ironic-rhcos-downloader-container-v4.3.23-202005250318
        kuryr-controller-container-v4.3.22-202005201238
        ironic-inspector-container-v4.3.22-202005201238
        kuryr-cni-container-v4.3.23-202005250318
        machine-config-daemon-4.3.22-202005180559.git.1.867325c.el8
        ironic-hardware-inventory-recorder-image-container-v4.3.22-202005201238
        ironic-hardware-inventory-recorder-image-container-v4.3.23-202005250318
        kuryr-cni-container-v4.3.22-202005201238
        ironic-container-v4.3.23-202005250318
        openshift-kuryr-4.3.22-202005180559.git.1.67e396a.el8
        ironic-ipa-downloader-container-v4.3.22-202005201238
        ironic-static-ip-manager-container-v4.3.23-202005250318
2020-05-26 06:20:34,625 INFO Untagging 21 build(s) from rhaos-4.3-rhel-8-image-build...
{'methodName': 'untagBuild', 'params': ('rhaos-4.3-rhel-8-image-build', 'ironic-ipa-downloader-container-v4.3.23-202005250318')}
ironic-static-ip-manager-container-v4.3.23-202005250318 has been successfully untagged from rhaos-4.3-rhel-8-image-build
{'methodName': 'untagBuild', 'params': ('rhaos-4.3-rhel-8-image-build', 'openshift-clients-4.3.22-202005180559.git.1.a478120.el8')}
ironic-static-ip-manager-container-v4.3.23-202005250318 has been successfully untagged from rhaos-4.3-rhel-8-image-build
{'methodName': 'untagBuild', 'params': ('rhaos-4.3-rhel-8-image-build', 'ironic-static-ip-manager-container-v4.3.0-202001211731.1580285192')}
ironic-static-ip-manager-container-v4.3.23-202005250318 has been successfully untagged from rhaos-4.3-rhel-8-image-build                                                                                      [0/1888]
{'methodName': 'untagBuild', 'params': ('rhaos-4.3-rhel-8-image-build', 'ironic-static-ip-manager-container-v4.3.0-202001211731.1580285192')}
ironic-static-ip-manager-container-v4.3.23-202005250318 has been successfully untagged from rhaos-4.3-rhel-8-image-build
{'methodName': 'untagBuild', 'params': ('rhaos-4.3-rhel-8-image-build', 'openshift-4.3.22-202005180559.git.1.95946a0.el8')}
ironic-static-ip-manager-container-v4.3.23-202005250318 has been successfully untagged from rhaos-4.3-rhel-8-image-build
{'methodName': 'untagBuild', 'params': ('rhaos-4.3-rhel-8-image-build', 'ironic-static-ip-manager-container-v4.3.22-202005201238')}
ironic-static-ip-manager-container-v4.3.23-202005250318 has been successfully untagged from rhaos-4.3-rhel-8-image-build
{'methodName': 'untagBuild', 'params': ('rhaos-4.3-rhel-8-image-build', 'ironic-rhcos-downloader-container-v4.3.22-202005201238')}
ironic-static-ip-manager-container-v4.3.23-202005250318 has been successfully untagged from rhaos-4.3-rhel-8-image-build
{'methodName': 'untagBuild', 'params': ('rhaos-4.3-rhel-8-image-build', 'kuryr-controller-container-v4.3.23-202005250318')}
ironic-static-ip-manager-container-v4.3.23-202005250318 has been successfully untagged from rhaos-4.3-rhel-8-image-build
{'methodName': 'untagBuild', 'params': ('rhaos-4.3-rhel-8-image-build', 'ironic-container-v4.3.22-202005201238')}
ironic-static-ip-manager-container-v4.3.23-202005250318 has been successfully untagged from rhaos-4.3-rhel-8-image-build
{'methodName': 'untagBuild', 'params': ('rhaos-4.3-rhel-8-image-build', 'ironic-inspector-container-v4.3.23-202005250318')}
ironic-static-ip-manager-container-v4.3.23-202005250318 has been successfully untagged from rhaos-4.3-rhel-8-image-build
{'methodName': 'untagBuild', 'params': ('rhaos-4.3-rhel-8-image-build', 'ironic-rhcos-downloader-container-v4.3.23-202005250318')}
ironic-static-ip-manager-container-v4.3.23-202005250318 has been successfully untagged from rhaos-4.3-rhel-8-image-build
{'methodName': 'untagBuild', 'params': ('rhaos-4.3-rhel-8-image-build', 'kuryr-controller-container-v4.3.22-202005201238')}
ironic-static-ip-manager-container-v4.3.23-202005250318 has been successfully untagged from rhaos-4.3-rhel-8-image-build
{'methodName': 'untagBuild', 'params': ('rhaos-4.3-rhel-8-image-build', 'ironic-inspector-container-v4.3.22-202005201238')}
ironic-static-ip-manager-container-v4.3.23-202005250318 has been successfully untagged from rhaos-4.3-rhel-8-image-build
{'methodName': 'untagBuild', 'params': ('rhaos-4.3-rhel-8-image-build', 'kuryr-cni-container-v4.3.23-202005250318')}
ironic-static-ip-manager-container-v4.3.23-202005250318 has been successfully untagged from rhaos-4.3-rhel-8-image-build
{'methodName': 'untagBuild', 'params': ('rhaos-4.3-rhel-8-image-build', 'machine-config-daemon-4.3.22-202005180559.git.1.867325c.el8')}
ironic-static-ip-manager-container-v4.3.23-202005250318 has been successfully untagged from rhaos-4.3-rhel-8-image-build
{'methodName': 'untagBuild', 'params': ('rhaos-4.3-rhel-8-image-build', 'ironic-hardware-inventory-recorder-image-container-v4.3.22-202005201238')}
ironic-static-ip-manager-container-v4.3.23-202005250318 has been successfully untagged from rhaos-4.3-rhel-8-image-build
{'methodName': 'untagBuild', 'params': ('rhaos-4.3-rhel-8-image-build', 'ironic-hardware-inventory-recorder-image-container-v4.3.23-202005250318')}
ironic-static-ip-manager-container-v4.3.23-202005250318 has been successfully untagged from rhaos-4.3-rhel-8-image-build
{'methodName': 'untagBuild', 'params': ('rhaos-4.3-rhel-8-image-build', 'kuryr-cni-container-v4.3.22-202005201238')}
ironic-static-ip-manager-container-v4.3.23-202005250318 has been successfully untagged from rhaos-4.3-rhel-8-image-build
{'methodName': 'untagBuild', 'params': ('rhaos-4.3-rhel-8-image-build', 'ironic-container-v4.3.23-202005250318')}
ironic-static-ip-manager-container-v4.3.23-202005250318 has been successfully untagged from rhaos-4.3-rhel-8-image-build
{'methodName': 'untagBuild', 'params': ('rhaos-4.3-rhel-8-image-build', 'openshift-kuryr-4.3.22-202005180559.git.1.67e396a.el8')}
ironic-static-ip-manager-container-v4.3.23-202005250318 has been successfully untagged from rhaos-4.3-rhel-8-image-build
{'methodName': 'untagBuild', 'params': ('rhaos-4.3-rhel-8-image-build', 'ironic-ipa-downloader-container-v4.3.22-202005201238')}
ironic-static-ip-manager-container-v4.3.23-202005250318 has been successfully untagged from rhaos-4.3-rhel-8-image-build
{'methodName': 'untagBuild', 'params': ('rhaos-4.3-rhel-8-image-build', 'ironic-static-ip-manager-container-v4.3.23-202005250318')}
ironic-static-ip-manager-container-v4.3.23-202005250318 has been successfully untagged from rhaos-4.3-rhel-8-image-build
2020-05-26 06:20:37,520 INFO Tagging 0 build(s) into rhaos-4.3-rhel-8-image-build...
All unspecified builds have been successfully untagged from rhaos-4.3-rhel-8-image-build.
All builds have been successfully tagged into rhaos-4.3-rhel-8-image-build.

real    0m5.336s
user    0m0.600s
sys     0m0.214s
```