### PR TITLE
Dev container: Use Microsoft Python Language Server for autocomplete

### DIFF
--- a/.devcontainer/dev.Dockerfile
+++ b/.devcontainer/dev.Dockerfile
@@ -10,6 +10,8 @@ RUN dnf install -y \
     # development dependencies
     gcc krb5-devel libgit2-devel openssl-devel krb5-devel \
     python3-devel python3-pip \
+    # Microsoft Python Language Server requires .NET Core 2.1 or later
+    dotnet-runtime-3.1 \
     # other tools
     bash-completion vim tmux procps-ng psmisc wget curl net-tools iproute \
   # Red Hat IT Root CA

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,7 +27,9 @@
 		],
 		"python.testing.pytestEnabled": false,
 		"python.testing.nosetestsEnabled": false,
-		"python.testing.unittestEnabled": true
+		"python.testing.unittestEnabled": true,
+		"python.jediEnabled": false,  // false to use Microsoft Python Language Server. This requires .NET Core 2.1+
+		"python.languageServer": "Microsoft"
 	},
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
@@ -36,6 +38,7 @@
 	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"ms-python.python",
-		"eamodio.gitlens"
+		"eamodio.gitlens",
+		"visualstudioexptteam.vscodeintellicode"
 	]
 }


### PR DESCRIPTION
For VSCode users, this will dramatically improve the autocompete experience comparing with the default jedi language server.