### PR TITLE
[ART-745] Payload nonpayload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ cover
 
 # Ignore vscode backup files
 .vscode
+
+# Ignore ocp-build-data
+ocp-build-data/

--- a/elliottlib/imagecfg.py
+++ b/elliottlib/imagecfg.py
@@ -23,3 +23,7 @@ class ImageMetadata(Metadata):
         if present.
         """
         return self.config.base_only
+
+    @property
+    def is_payload(self):
+        return self.config.get('for_payload', False)


### PR DESCRIPTION
https://issues.redhat.com/browse/ART-745

1. extend property of ImageMetadata to support parse for_payload field in ocp-buil-data (currently only 4.5 merged)
2. add two flags (`--payload` `--non-payload`) to support attach only payload images or only non-payload images, if not specify attach all (backward compatibility)
3. test result file: https://gist.githubusercontent.com/shiywang/82af57eda3a6b7700df2a96f645e82f3/raw/27de59cbb514060521c356d56e516a9c000f5823/gistfile1.txt

```
[dev@33036d511566 elliott]$  elliott -g openshift-4.5 find-builds -k image --allow-attached --payload 
2020-07-27 10:54:44,615 INFO Data clone directory already exists, checking commit sha
2020-07-27 10:54:47,380 INFO https://github.com/openshift/ocp-build-data.git is already cloned and latest
2020-07-27 10:54:47,938 INFO Using branch from group.yml: rhaos-4.5-rhel-7
Generating list of images: Hold on a moment, fetching Brew builds for 160 components with tags rhaos-4.5-rhel-7-candidate, rhaos-4.5-rhel-8-candidate...
[************************************************************************************************************************************************************************************************************************]
...


[dev@33036d511566 elliott]$  elliott -g openshift-4.5 find-builds -k image --allow-attached --non-payload 
2020-07-27 10:57:19,617 INFO Data clone directory already exists, checking commit sha
2020-07-27 10:57:22,546 INFO https://github.com/openshift/ocp-build-data.git is already cloned and latest
2020-07-27 10:57:23,215 INFO Using branch from group.yml: rhaos-4.5-rhel-7
Generating list of images: Hold on a moment, fetching Brew builds for 160 components with tags rhaos-4.5-rhel-7-candidate
...
 sriov-network-device-plugin-container-v4.5.0-202007240519.p0
 sriov-network-operator-container-v4.5.0-202007240519.p0
 sriov-network-webhook-container-v4.5.0-202007240519.p0
```