### PR TITLE
[ART-2057] find-bugs sweep includes `ON_QA` bugs

### DIFF
--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -64,8 +64,7 @@ def get_flaw_bugs(trackers):
         # Tracker bugs can block more than one flaw bug, but must be more than 0
         if not t.blocks:
             # This should never happen, log a warning here if it does
-            util.yellow_print(
-                "Warning: found tracker bugs which doesn't block any other bugs")
+            logger.warning("Warning: found tracker bugs which doesn't block any other bugs")
         else:
             flaw_ids.extend(t.blocks)
     return flaw_ids
@@ -158,7 +157,7 @@ def get_flaw_aliases(flaws):
                 flaw_cve_map[flaw.id] = ""
     for key in flaw_cve_map.keys():
         if flaw_cve_map[key] == "":
-            logger.warning("Found flaw bug with no alias, this can happen is a flaw hasn't been assigned a CVE")
+            logger.warning("Found flaw bug with no alias, this can happen if a flaw hasn't been assigned to a CVE")
     return flaw_cve_map
 
 

--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -108,7 +108,7 @@ def get_bugs(bzapi, ids, raise_on_error=True):
     :return: A map of bug ids and bug objects
 
     :raises:
-        BugzillaFatorError: If bugs contains invalid bug ids, or if some other error occurs trying to
+        BugzillaFatalError: If bugs contains invalid bug ids, or if some other error occurs trying to
         use the Bugzilla XMLRPC api. Could be because you are not logged in to Bugzilla or the login
         session has expired.
     """
@@ -139,7 +139,7 @@ def get_flaw_aliases(flaws):
     :return: A map of flaw bug ids and associated CVE alisas.
 
     :raises:
-        BugzillaFatorError: If bugs contains invalid bug ids, or if some other error occurs trying to
+        BugzillaFatalError: If bugs contains invalid bug ids, or if some other error occurs trying to
         use the Bugzilla XMLRPC api. Could be because you are not logged in to Bugzilla or the login
         session has expired.
     """
@@ -160,6 +160,25 @@ def get_flaw_aliases(flaws):
         if flaw_cve_map[key] == "":
             logger.warning("Found flaw bug with no alias, this can happen is a flaw hasn't been assigned a CVE")
     return flaw_cve_map
+
+
+def set_state(bug, desired_state, noop=False):
+    """Change the state of a bug to desired_state
+
+    :param bug:
+    :param desired_state: Target state
+    :param noop: Do not do anything
+    """
+    current_state = bug.status
+    if noop:
+        logger.info(f"Would have changed BZ#{bug.bug_id} from {current_state} to {desired_state}")
+        return
+
+    logger.info(f"Changing BZ#{bug.bug_id} from {current_state} to {desired_state}")
+    comment = f'Elliott changed bug status from {current_state} to {desired_state}.'
+    bug.setstatus(status=desired_state,
+                  comment=comment,
+                  private=True)
 
 
 def create_placeholder(bz_data, kind, version):

--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -268,12 +268,13 @@ def search_for_security_bugs(bz_data, status=None, search_filter='security', cve
 def is_viable_bug(bug_obj):
     """ Check if a bug is viable to attach to an advisory.
 
-    A viable bug must be in one of MODIFIED and VERIFIED status.
+    A viable bug must be in one of MODIFIED and VERIFIED status. We accept ON_QA
+    bugs as viable as well, as they will be shortly moved to MODIFIED while attaching.
 
     :param bug_obj: bug object
     :returns: True if viable
     """
-    return bug_obj.status in ["MODIFIED", "VERIFIED"]
+    return bug_obj.status in ["MODIFIED", "ON_QA", "VERIFIED"]
 
 
 def is_cve_tracker(bug_obj):

--- a/elliottlib/cli/__main__.py
+++ b/elliottlib/cli/__main__.py
@@ -90,7 +90,7 @@ pass_runtime = click.make_pass_decorator(Runtime)
 @click.option("--status", 'status',
               multiple=True,
               required=False,
-              default=['MODIFIED', 'VERIFIED'],
+              default=['MODIFIED', 'VERIFIED', 'ON_QA'],
               type=click.Choice(elliottlib.constants.VALID_BUG_STATES),
               help="Status of the bugs")
 @click.option("--id", metavar='BUGID', default=None,
@@ -121,7 +121,7 @@ Use cases are described below:
 
 SWEEP: For this use-case the --group option MUST be provided. The
 --group automatically determines the correct target-releases to search
-for MODIFIED bugs in.
+for bugs claimed to be fixed, but not yet attached to advisories.
 
 LIST: The --group option is not required if you are specifying bugs
 manually. Provide one or more --id's for manual bug addition. In LIST

--- a/elliottlib/cli/__main__.py
+++ b/elliottlib/cli/__main__.py
@@ -547,19 +547,7 @@ providing an advisory with the -a/--advisory option.
     for bug in attached_bugs:
         if bug.status in original_state:
             changed_bug_count += 1
-            if noop:
-                click.echo("Would have changed BZ#{bug_id} from {initial} to {final}".format(
-                    bug_id=bug.bug_id,
-                    initial=bug.status,
-                    final=new_state))
-            else:
-                click.echo("Changing BZ#{bug_id} from {initial} to {final}".format(
-                    bug_id=bug.bug_id,
-                    initial=bug.status,
-                    final=new_state))
-                bug.setstatus(status=new_state,
-                              comment="Elliott changed bug status from {initial} to {final}.".format(initial=original_state, final=new_state),
-                              private=True)
+            elliottlib.bzutil.set_state(bug, new_state, noop=noop)
 
     green_print("{} bugs successfullly modified (or would have been)".format(changed_bug_count))
 

--- a/elliottlib/errata.py
+++ b/elliottlib/errata.py
@@ -15,7 +15,7 @@ import datetime
 import json
 import ssl
 import re
-from elliottlib import exceptions, constants, brew
+from elliottlib import exceptions, constants, brew, logutil, bzutil
 from elliottlib.util import green_prefix, exit_unauthenticated
 
 import requests
@@ -24,6 +24,8 @@ from kerberos import GSSError
 from errata_tool import Erratum, ErrataException, ErrataConnector
 
 import xmlrpc.client
+
+logger = logutil.getLogger(__name__)
 
 ErrataConnector._url = constants.errata_url
 errata_xmlrpc = xmlrpc.client.ServerProxy(constants.errata_xmlrpc_url)
@@ -409,6 +411,17 @@ def add_bugs_with_retry(advisory, bugs, retried=False):
         count=len(bugs),
         retry_times=1 if retried is False else 2
     ))
+
+    # Due to a limitation of Errata Tool, a bug cannot be attached to an advisory
+    # if it has state ON_QA. This might change, see https://projects.engineering.redhat.com/browse/CLOUDWF-3104
+    for bug in bugs:
+        if bug.status == 'ON_QA':
+            try:
+                bzutil.set_state(bug, 'MODIFIED')
+            except Exception as e:
+                # Accept exception, it will fail while adding the bugs, after which it will be retried
+                logger.warning(f'Could not change BZ {bug.id} to ON_QA: {e.message}, {e.args}')
+
     print(" {advs}".format(advs=advs))
     try:
         advs.addBugs([bug.id for bug in bugs])

--- a/tests/test_bzutil.py
+++ b/tests/test_bzutil.py
@@ -3,12 +3,19 @@ import unittest
 import mock
 import flexmock
 import bugzilla
+import logging
 from elliottlib import exceptions, constants, bzutil
 
 hostname = "bugzilla.redhat.com"
 
 
 class TestBZUtil(unittest.TestCase):
+    def setUp(self):
+        logging.disable(logging.CRITICAL)
+
+    def tearDown(self):
+        logging.disable(logging.NOTSET)
+
     def test_is_flaw_bug(self):
         bug = mock.MagicMock(product="Security Response", component="vulnerability")
         self.assertTrue(bzutil.is_flaw_bug(bug))
@@ -75,6 +82,11 @@ class TestSearchFilter(unittest.TestCase):
 
 
 class TestGetHigestImpact(unittest.TestCase):
+    def setUp(self):
+        logging.disable(logging.CRITICAL)
+
+    def tearDown(self):
+        logging.disable(logging.NOTSET)
 
     def test_lowest_to_highest_impact(self):
         trackers = [flexmock(id=index, severity=severity)
@@ -109,6 +121,12 @@ class TestGetHigestImpact(unittest.TestCase):
 
 
 class TestGetFlawBugs(unittest.TestCase):
+    def setUp(self):
+        logging.disable(logging.CRITICAL)
+
+    def tearDown(self):
+        logging.disable(logging.NOTSET)
+
     def test_get_flaw_bugs(self):
         t1 = flexmock(id='1', blocks=['b1', 'b2'])
         t2 = flexmock(id='2', blocks=['b3'])
@@ -119,6 +137,12 @@ class TestGetFlawBugs(unittest.TestCase):
 
 
 class TestGetFlawAliases(unittest.TestCase):
+    def setUp(self):
+        logging.disable(logging.CRITICAL)
+
+    def tearDown(self):
+        logging.disable(logging.NOTSET)
+
     def test_get_flaw_aliases(self):
         CVE01 = flexmock(
             id='1',


### PR DESCRIPTION
To enable a new workflow, `elliott` needs to be able to find `ON_QA` bugs which are not attached to advisories, and attach them. A limitation and/or configuration  of Errata Tool does not allow to attach an `ON_QA` bug. This PR sets the state of an eligible `ON_QA` bug to `MODIFIED` in order to attach it to an advisory.

**end-to-end verification**
`elliott repair-bugs` still works:

```
% bugzilla query --id 1850481
#1850481 CLOSED     - lmeyer@redhat.com - Placeholder bug for OCP 4.2.z metadata release

% elliott --group=openshift-4.2 repair-bugs --auto --use-default-advisory metadata --from CLOSED --to MODIFIED
2020-08-28 09:51:52,755 INFO Cloning config data from https://github.com/openshift/ocp-build-data.git
2020-08-28 09:51:54,328 INFO Using branch from group.yml: rhaos-4.2-rhel-7
Default advisory detected: 56352
Fetching Erratum(errata_id=56352)
Getting bugs for advisory
Fetching data for 1 bugs: Hold on a moment, we have to grab each one
[*]
[*]
Got bugs for advisory
2020-08-28 09:52:02,294 INFO Changing BZ#1850481 from CLOSED to MODIFIED
1 bugs successfullly modified (or would have been)

% bugzilla query --id 1850481
#1850481 MODIFIED   - lmeyer@redhat.com - Placeholder bug for OCP 4.2.z metadata release
```

`elliott find-bugs` has the new functionality:

```
% bugzilla query --id 1873405
#1873405 ON_QA      - lmeyer@redhat.com - Dummy bug to test advisory automation

% elliott --group=openshift-4.2 find-bugs --mode=list --id 1873405 --add 56350
2020-08-28 10:18:59,076 INFO Cloning config data from https://github.com/openshift/ocp-build-data.git
2020-08-28 10:19:01,281 INFO Using branch from group.yml: rhaos-4.2-rhel-7
Found 1 bugs: 1873405
Adding 1 bugs to advisory 1 times:2020-08-28 10:19:14,228 INFO Changing BZ#1873405 from ON_QA to MODIFIED
...

% bugzilla query --id 1873405 --full
#1873405 ON_QA      - lmeyer@redhat.com - Dummy bug to test advisory automation
...
* 20200828T08:19:16 - :
Elliott changed bug status from ON_QA to MODIFIED.

* 20200828T08:19:27 - :
This bug has been added to advisory RHBA-2020:56350 by Joep Delft (jdelft@redhat.com)

* 20200828T08:19:38 - :
Bug report changed to ON_QA status by Errata System.
A QE request has been submitted for advisory RHBA-2020:56350-02
https://errata.devel.redhat.com/advisory/56350
```

`elliott find-bugs --mode=sweep` finds and attaches `ON_QA` bugs:
```
% bugzilla query --id 1873405
#1873405 ON_QA      - lmeyer@redhat.com - Dummy bug to test advisory automation

% elliott --group=openshift-4.2 find-bugs --mode=sweep --use-default-advisory image
2020-08-28 10:46:35,520 INFO Cloning config data from https://github.com/openshift/ocp-build-data.git
2020-08-28 10:46:37,904 INFO Using branch from group.yml: rhaos-4.2-rhel-7
Default advisory detected: 56350
Searching for bugs with target release(s): 4.2.z
Found 1 bugs (0 ignored): 1873405
Adding 1 bugs to advisory 1 times:
2020-08-28 10:46:54,313 INFO Changing BZ#1873405 from ON_QA to MODIFIED
 RHBA-2020:56350-02: OpenShift Container Platform 4.2.37 bug fix update
  package owner: talessio@redhat.com  qe: openshift-qe-errata@redhat.com qe_group: OpenShift QE
  url:   https://errata.devel.redhat.com/advisory/56350
...

% bugzilla query --id 1873405 --full
...
* 20200828T08:46:56 - :
Elliott changed bug status from ON_QA to MODIFIED.

* 20200828T08:47:06 - :
This bug has been added to advisory RHBA-2020:56350 by Joep Delft (jdelft@redhat.com)

* 20200828T08:47:07 - :
Bug report changed to ON_QA status by Errata System.
A QE request has been submitted for advisory RHBA-2020:56350-02
https://errata.devel.redhat.com/advisory/56350
```