### PR TITLE
ART-2170: do not count shipped images as missing

### DIFF
--- a/elliottlib/cli/common.py
+++ b/elliottlib/cli/common.py
@@ -95,7 +95,7 @@ use_default_advisory_option = click.option(
 pass_runtime = click.make_pass_decorator(Runtime)
 
 
-def coro(f):
+def click_coroutine(f):
     """ A wrapper to allow to use asyncio with click.
     https://github.com/pallets/click/issues/85
     """

--- a/elliottlib/cli/verify_cvp_cli.py
+++ b/elliottlib/cli/verify_cvp_cli.py
@@ -14,7 +14,7 @@ from ruamel.yaml import YAML
 
 import elliottlib
 from elliottlib import Runtime, brew, constants
-from elliottlib.cli.common import (cli, coro, find_default_advisory,
+from elliottlib.cli.common import (cli, click_coroutine, find_default_advisory,
                                    pass_runtime, use_default_advisory_option)
 from elliottlib.imagecfg import ImageMetadata
 from elliottlib.resultsdb import ResultsDBAPI
@@ -46,7 +46,7 @@ yaml = YAML()
     '--message', '-m', 'message', metavar='COMMIT_MESSAGE',
     help='Commit message for ocp-build-data when using `--fix`. If not given, no changes will be committed.')
 @pass_runtime
-@coro
+@click_coroutine
 async def verify_cvp_cli(runtime: Runtime, all_images, nvrs, optional_checks, all_optional_checks, fix, message):
     """ Verify CVP test results
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ autopep8
 coverage
 flake8
 flexmock
-mock
+mock ~= 4.0.2
 pylint
 pytest
 tox


### PR DESCRIPTION
We no longer (necessarily) rebuild and ship all images each week, which means part of the payload may not be new and won't be present in the advisory we ship. In this situation elliott verify-payload should not count shipped images as missing.

This PR also show images already attached to advisories (useful when preparing a release but the previous release is on the fly) and introduces asyncio to boost the performance.

Test run:
```sh
$ elliott --group=openshift-4.4 verify-payload registry.svc.ci.openshift.org/ocp/release:4.4.0-0.nightly-2020-08-29-033321 58631

{
    "missing_in_advisory": {},
    "payload_advisory_mismatch": {},
    "in_other_adivosires": {
        "ose-aws-machine-controllers-container": "ose-aws-machine-controllers-container-v4.4.0-202008210157.p0",
        "ose-azure-machine-controllers-container": "ose-azure-machine-controllers-container-v4.4.0-202008210157.p0",
        "ose-baremetal-installer-container": "ose-baremetal-installer-container-v4.4.0-202008210157.p0",
        "baremetal-machine-controller-container": "baremetal-machine-controller-container-v4.4.0-202008210157.p0",
        "ose-baremetal-operator-container": "ose-baremetal-operator-container-v4.4.0-202008210157.p0",
        "ose-baremetal-runtimecfg-container": "ose-baremetal-runtimecfg-container-v4.4.0-202008210157.p0",
        "openshift-enterprise-cli-container": "openshift-enterprise-cli-container-v4.4.0-202008250111.p0",
        "ose-cli-artifacts-container": "ose-cli-artifacts-container-v4.4.0-202008250111.p0",
        "ose-cloud-credential-operator-container": "ose-cloud-credential-operator-container-v4.4.0-202008210157.p0",
        "ose-cluster-authentication-operator-container": "ose-cluster-authentication-operator-container-v4.4.0-202008210157.p0",
        "atomic-openshift-cluster-autoscaler-container": "atomic-openshift-cluster-autoscaler-container-v4.4.0-202008210157.p0",
        "ose-cluster-autoscaler-operator-container": "ose-cluster-autoscaler-operator-container-v4.4.0-202008210157.p0",
        "ose-cluster-bootstrap-container": "ose-cluster-bootstrap-container-v4.4.0-202008210157.p0",
        "ose-cluster-config-operator-container": "ose-cluster-config-operator-container-v4.4.0-202008210157.p0",
        "ose-cluster-csi-snapshot-controller-operator-container": "ose-cluster-csi-snapshot-controller-operator-container-v4.4.0-202008210157.p0",
        "ose-cluster-dns-operator-container": "ose-cluster-dns-operator-container-v4.4.0-202008210157.p0",
        "ose-cluster-image-registry-operator-container": "ose-cluster-image-registry-operator-container-v4.4.0-202008210157.p0",
        "ose-cluster-ingress-operator-container": "ose-cluster-ingress-operator-container-v4.4.0-202008210157.p0",
        "ose-cluster-kube-apiserver-operator-container": "ose-cluster-kube-apiserver-operator-container-v4.4.0-202008210157.p0",
        "ose-cluster-kube-controller-manager-operator-container": "ose-cluster-kube-controller-manager-operator-container-v4.4.0-202008210157.p0",
        "ose-cluster-kube-scheduler-operator-container": "ose-cluster-kube-scheduler-operator-container-v4.4.0-202008210157.p0",
        "ose-cluster-kube-storage-version-migrator-operator-container": "ose-cluster-kube-storage-version-migrator-operator-container-v4.4.0-202008210157.p0",
        "ose-cluster-machine-approver-container": "ose-cluster-machine-approver-container-v4.4.0-202008210157.p0",
        "cluster-monitoring-operator-container": "cluster-monitoring-operator-container-v4.4.0-202008210157.p0",
        "cluster-network-operator-container": "cluster-network-operator-container-v4.4.0-202008210157.p0",
        "tuned-container": "tuned-container-v4.4.0-202008210157.p0",
        "cluster-node-tuning-operator-container": "cluster-node-tuning-operator-container-v4.4.0-202008210157.p0",
        "ose-cluster-openshift-apiserver-operator-container": "ose-cluster-openshift-apiserver-operator-container-v4.4.0-202008210157.p0",
        "ose-cluster-openshift-controller-manager-operator-container": "ose-cluster-openshift-controller-manager-operator-container-v4.4.0-202008210157.p0",
        "ose-cluster-policy-controller-container": "ose-cluster-policy-controller-container-v4.4.0-202008210157.p0",
        "ose-cluster-samples-operator-container": "ose-cluster-samples-operator-container-v4.4.0-202008210157.p0",
        "ose-cluster-storage-operator-container": "ose-cluster-storage-operator-container-v4.4.0-202008210157.p0",
        "ose-cluster-svcat-apiserver-operator-container": "ose-cluster-svcat-apiserver-operator-container-v4.4.0-202008210157.p0",
        "ose-cluster-svcat-controller-manager-operator-container": "ose-cluster-svcat-controller-manager-operator-container-v4.4.0-202008210157.p0",
        "ose-cluster-update-keys-container": "ose-cluster-update-keys-container-v4.4.0-202008210157.p0",
        "cluster-version-operator-container": "cluster-version-operator-container-v4.4.0-202008210157.p0",
        "configmap-reload-container": "configmap-reload-container-v4.4.0-202008210157.p0",
        "openshift-enterprise-console-operator-container": "openshift-enterprise-console-operator-container-v4.4.0-202008210157.p0",
        "coredns-container": "coredns-container-v4.4.0-202008210157.p0",
        "ose-csi-snapshot-controller-container": "ose-csi-snapshot-controller-container-v4.4.0-202008210157.p0",
        "openshift-enterprise-deployer-container": "openshift-enterprise-deployer-container-v4.4.0-202008250111.p0",
        "openshift-enterprise-builder-container": "openshift-enterprise-builder-container-v4.4.0-202008210157.p0",
        "openshift-enterprise-registry-container": "openshift-enterprise-registry-container-v4.4.0-202008210157.p0",
        "ose-etcd-container": "ose-etcd-container-v4.4.0-202008210157.p0",
        "ose-gcp-machine-controllers-container": "ose-gcp-machine-controllers-container-v4.4.0-202008210157.p0",
        "grafana-container": "grafana-container-v4.4.0-202008210157.p0",
        "openshift-enterprise-haproxy-router-container": "openshift-enterprise-haproxy-router-container-v4.4.0-202008210157.p0",
        "openshift-enterprise-hyperkube-container": "openshift-enterprise-hyperkube-container-v4.4.0-202008250319.p0",
        "ose-insights-operator-container": "ose-insights-operator-container-v4.4.0-202008250837.p0",
        "ose-installer-container": "ose-installer-container-v4.4.0-202008210157.p0",
        "ose-installer-artifacts-container": "ose-installer-artifacts-container-v4.4.0-202008210157.p0",
        "ironic-static-ip-manager-container": "ironic-static-ip-manager-container-v4.4.0-202008210157.p0",
        "jenkins-agent-maven-35-rhel7-container": "jenkins-agent-maven-35-rhel7-container-v4.4.0-202008250111.p0",
        "ose-prometheus-adapter-container": "ose-prometheus-adapter-container-v4.4.0-202008210157.p0",
        "openshift-enterprise-keepalived-ipfailover-container": "openshift-enterprise-keepalived-ipfailover-container-v4.4.0-202008210157.p0",
        "ose-kube-client-agent-container": "ose-kube-client-agent-container-v4.4.0-202008210157.p0",
        "ose-kube-etcd-signer-server-container": "ose-kube-etcd-signer-server-container-v4.4.0-202008210157.p0",
        "kube-proxy-container": "kube-proxy-container-v4.4.0-202008210157.p0",
        "kube-rbac-proxy-container": "kube-rbac-proxy-container-v4.4.0-202008210157.p0",
        "kube-state-metrics-container": "kube-state-metrics-container-v4.4.0-202008210157.p0",
        "ose-kube-storage-version-migrator-container": "ose-kube-storage-version-migrator-container-v4.4.0-202008210157.p0",
        "ose-libvirt-machine-controllers-container": "ose-libvirt-machine-controllers-container-v4.4.0-202008210157.p0",
        "local-storage-static-provisioner-container": "local-storage-static-provisioner-container-v4.4.0-202008210157.p0",
        "ose-machine-api-operator-container": "ose-machine-api-operator-container-v4.4.0-202008210157.p0",
        "ose-machine-config-operator-container": "ose-machine-config-operator-container-v4.4.0-202008250111.p0",
        "ose-mdns-publisher-container": "ose-mdns-publisher-container-v4.4.0-202008210157.p0",
        "ose-multus-admission-controller-container": "ose-multus-admission-controller-container-v4.4.0-202008210157.p0",
        "ose-must-gather-container": "ose-must-gather-container-v4.4.0-202008250111.p0",
        "golang-github-openshift-oauth-proxy-container": "golang-github-openshift-oauth-proxy-container-v4.4.0-202008210157.p0",
        "oauth-server-container": "oauth-server-container-v4.4.0-202008210157.p0",
        "ose-openshift-apiserver-container": "ose-openshift-apiserver-container-v4.4.0-202008210157.p0",
        "ose-openshift-controller-manager-container": "ose-openshift-controller-manager-container-v4.4.0-202008210157.p0",
        "openshift-state-metrics-container": "openshift-state-metrics-container-v4.4.0-202008210157.p0",
        "ose-openstack-machine-controllers-container": "ose-openstack-machine-controllers-container-v4.4.0-202008210157.p0",
        "operator-lifecycle-manager-container": "operator-lifecycle-manager-container-v4.4.0-202008210157.p0",
        "marketplace-operator-container": "marketplace-operator-container-v4.4.0-202008210157.p0",
        "operator-registry-container": "operator-registry-container-v4.4.0-202008210157.p0",
        "ose-ovirt-machine-controllers-container": "ose-ovirt-machine-controllers-container-v4.4.0-202008210157.p0",
        "ose-ovn-kubernetes-container": "ose-ovn-kubernetes-container-v4.4.0-202008250111.p0",
        "openshift-enterprise-pod-container": "openshift-enterprise-pod-container-v4.4.0-202008210157.p0",
        "prom-label-proxy-container": "prom-label-proxy-container-v4.4.0-202008210157.p0",
        "golang-github-prometheus-prometheus-container": "golang-github-prometheus-prometheus-container-v4.4.0-202008210157.p0",
        "golang-github-prometheus-alertmanager-container": "golang-github-prometheus-alertmanager-container-v4.4.0-202008210157.p0",
        "prometheus-config-reloader-container": "prometheus-config-reloader-container-v4.4.0-202008210157.p0",
        "golang-github-prometheus-node_exporter-container": "golang-github-prometheus-node_exporter-container-v4.4.0-202008210157.p0",
        "prometheus-operator-container": "prometheus-operator-container-v4.4.0-202008210157.p0",
        "ose-node-container": "ose-node-container-v4.4.0-202008210157.p0",
        "ose-service-ca-operator-container": "ose-service-ca-operator-container-v4.4.0-202008210157.p0",
        "openshift-enterprise-service-catalog-container": "openshift-enterprise-service-catalog-container-v4.4.0-202008210157.p0",
        "telemeter-container": "telemeter-container-v4.4.0-202008210157.p0",
        "ose-thanos-container": "ose-thanos-container-v4.4.0-202008210157.p0"
    }
}
```