### PR TITLE
Rebuild tox environment after change requirements

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,10 @@ pipeline {
             steps {
                 script {
                     catchError(stageResult: 'FAILURE') {
-                        sh "tox > results.txt 2>&1"
+                        sh """
+                            tox_args="\$(git diff --name-only HEAD~5 | grep -Fxq -e requirements.txt -e requirements-dev.txt -e MANIFEST.in -e setup.py && echo '--recreate')"
+                            tox \$tox_args > results.txt 2>&1
+                        """
                     }
                     results = readFile("results.txt").trim()
                     echo results


### PR DESCRIPTION
Tox does not detect changes in requirements, and will fail with missing
imports.
[example](https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/art-tools/job/elliott/job/master/6/console)
[tox bug](https://github.com/tox-dev/tox/issues/149)

This PR looks at the files that have changed in the last 5 commits, and
if one of the files that might contain requirements have changed, will
add the argument `--recreate` to the `tox` invocation.

The magical number 5 was chosen, as it is conceivable that there are
multiple commits locally which contain the change, and the change in
dependencies is not detected.

Alternative approaches are:
- install a tox plugin
- always recreate in Jenkins