### PR TITLE
Fix bug sweep

### DIFF
--- a/elliottlib/errata.py
+++ b/elliottlib/errata.py
@@ -420,7 +420,7 @@ def add_bugs_with_retry(advisory, bugs, retried=False, noop=False):
         print("ErrataException Message: {}, retry it again".format(e))
         if retried is not True:
             block_list = parse_exception_error_message(e)
-            retry_list = [x for x in bugs if x not in block_list]
+            retry_list = [x for x in bugs if x.id not in block_list]
             if len(retry_list) > 0:
                 add_bugs_with_retry(advisory, retry_list, retried=True, noop=noop)
         else:


### PR DESCRIPTION
Fix errors like

```bash
Error sweeping bugs (will retry a few times):
hudson.AbortException: failed shell command: elliott --group=openshift-3.11 find-...mode sweep --into-default-advisories
with rc=1 and output:
[...see full archive #6...]
      python-requests-2.19.1-4.el7ost
ErrataException Message: Erratum 58675: idsfixed: Bug #1873466 The bug is filed already in RHBA-2020:3694.
, retry it again
ElliottFatalError("ErrataException('Erratum 58675: idsfixed: Bug #1873466 The bug is filed already in RHBA-2020:3694.\\n',)",)
```