### PR TITLE
[ART-2297] placeholder version

### DIFF
--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -180,22 +180,24 @@ def set_state(bug, desired_state, noop=False):
                   private=True)
 
 
-def create_placeholder(bz_data, kind, version):
+def create_placeholder(bz_data, kind):
     """Create a placeholder bug
 
     :param bz_data: The Bugzilla data dump we got from our bugzilla.yaml file
     :param kind: The "kind" of placeholder to create. Generally 'rpm' or 'image'
-    :param version: The target version for the placeholder
 
     :return: Placeholder Bug object
     """
 
     bzapi = get_bzapi(bz_data)
-    boilerplate = "Placeholder bug for OCP {} {} release".format(version, kind)
+    version = bz_data['version'][0]
+    target_release = bz_data['target_release'][0]
+
+    boilerplate = "Placeholder bug for OCP {} {} release".format(target_release, kind)
 
     createinfo = bzapi.build_createbug(
         product=bz_data['product'],
-        version="unspecified",
+        version=version,
         component="Release",
         summary=boilerplate,
         description=boilerplate)
@@ -204,7 +206,7 @@ def create_placeholder(bz_data, kind, version):
 
     # change state to VERIFIED, set target release
     try:
-        update = bzapi.build_update(status="VERIFIED", target_release=version)
+        update = bzapi.build_update(status="VERIFIED", target_release=target_release)
         bzapi.update_bugs([newbug.id], update)
     except Exception as ex:  # figure out the actual bugzilla error. it only happens sometimes
         sleep(5)

--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -308,9 +308,6 @@ def _construct_query_url(bz_data, status, search_filter='default'):
     for f in filter_list:
         query_url.addFilter(f.get('field'), f.get('operator'), f.get('value'))
 
-    for v in bz_data.get('version', []):
-        query_url.addVersion(v)
-
     for s in status:
         query_url.addBugStatus(s)
 

--- a/elliottlib/cli/create_placeholder_cli.py
+++ b/elliottlib/cli/create_placeholder_cli.py
@@ -58,9 +58,8 @@ def create_placeholder_cli(runtime, kind, advisory, default_advisory_type):
             "--kind must be specified when not using --use-default-advisory")
 
     bz_data = runtime.gitdata.load_data(key='bugzilla').data
-    target_release = bz_data['target_release'][0]
-    newbug = elliottlib.bzutil.create_placeholder(
-        bz_data, kind, target_release)
+
+    newbug = elliottlib.bzutil.create_placeholder(bz_data, kind)
 
     click.echo("Created BZ: {} {}".format(newbug.id, newbug.weburl))
 


### PR DESCRIPTION
See [ART-2297](https://issues.redhat.com/browse/ART-2297)

This commit stops hardcoding the placeholder version to `unspecified`. This was suddenly not accepted anymore. Instead, it loads the `version` data from `bugzilla.yml` in `ocp-build-data`.

Warning, the `version` field gets recycled.
At the moment, for all the active release branches in ocp-build-data, only openshift-3.11 uses `version` in `bugzilla.yml` to narrow down the results of the appropriate bugs. The result set is not really narrow, as all active versions from that time were listed here. The real filtering of bugs happens when selecting on `target_release`.

The `openshift-4.Y` branches do not have `version` specified in `bugzilla.yml`. The first commit in this PR enables the recycling, as it stops using the `version` filter in queries.

Related commits:
3.11: openshift/ocp-build-data#682
4.2: openshift/ocp-build-data#681
4.3: openshift/ocp-build-data#680
4.4: openshift/ocp-build-data#677
4.5: openshift/ocp-build-data#678
4.6: openshift/ocp-build-data#679