### PR TITLE
[ART-2287] Create advisory-drop command

### DIFF
--- a/elliottlib/cli/__main__.py
+++ b/elliottlib/cli/__main__.py
@@ -55,6 +55,7 @@ from elliottlib.cli.advisory_images_cli import advisory_images_cli
 from elliottlib.cli.advisory_impetus_cli import advisory_impetus_cli
 from elliottlib.cli.tag_builds_cli import tag_builds_cli
 from elliottlib.cli.verify_cvp_cli import verify_cvp_cli
+from elliottlib.cli.advisory_drop_cli import advisory_drop_cli
 
 # 3rd party
 import bugzilla
@@ -687,6 +688,7 @@ cli.add_command(rpmdiff_cli)
 cli.add_command(tag_builds_cli)
 cli.add_command(tarball_sources_cli)
 cli.add_command(verify_cvp_cli)
+cli.add_command(advisory_drop_cli)
 
 
 # -----------------------------------------------------------------------------

--- a/elliottlib/cli/advisory_drop_cli.py
+++ b/elliottlib/cli/advisory_drop_cli.py
@@ -1,0 +1,34 @@
+import click
+import requests
+from requests_kerberos import HTTPKerberosAuth
+import sys
+
+from elliottlib.constants import errata_drop_url
+from elliottlib.cli.common import cli
+
+
+@cli.command("advisory-drop", short_help="Drop advisory")
+@click.argument("advisory", nargs=1)
+def advisory_drop_cli(advisory):
+    """Drop advisory
+
+    Advisories can only be dropped by the creators, and program management.
+    This script can get run on buildvm with the credentials of the creator of
+    ART's advisories, so the bot account can drop them.
+    """
+
+    url = errata_drop_url.format(id=advisory)
+    data = 'utf8=%E2%9C%93&reason=Dropping+unused+advisory%21&commit=Dropping+unused+advisory'
+    headers = {"Content-Type": "text/plain"}
+
+    r = requests.post(url, auth=HTTPKerberosAuth(), data=data, headers=headers)
+    if r.status_code == 200:
+        click.echo(f'Succesfully dropped advisory {advisory}')
+        sys.exit(0)
+    elif "ERROR: Validation failed: Previous - Transition DROPPED_NO_SHIP =&gt; DROPPED_NO_SHIP is invalid" in r.text:
+        click.echo(f'Advisory {advisory} already seems dropped')
+        sys.exit(0)
+    else:
+        click.echo(f'Failed to drop advisory {advisory}. Got status code {r.status_code}')
+        click.echo(r.text)
+        sys.exit(1)

--- a/elliottlib/constants.py
+++ b/elliottlib/constants.py
@@ -23,6 +23,7 @@ SECURITY_IMPACT = ["Low", "Low", "Moderate", "Important", "Critical"]
 
 errata_xmlrpc_url = 'http://errata.engineering.redhat.com/errata/xmlrpc.cgi'
 errata_url = "https://errata.devel.redhat.com"
+# errata_url = "https://errata.stage.engineering.redhat.com"
 
 # 1965 => (RHBA; Active; Product: RHOSE; Devel Group: ENG OpenShift
 #          Enterprise; sorted by newest)
@@ -138,6 +139,7 @@ errata_add_builds_url = errata_url + "/api/v1/erratum/{id}/add_builds"
 errata_add_comment_url = errata_url + "/api/v1/erratum/{id}/add_comment"
 errata_bug_refresh_url = errata_url + "/api/v1/bug/refresh"
 errata_change_state_url = errata_url + "/api/v1/erratum/{id}/change_state"
+errata_drop_url = errata_url + "/errata/drop_errata/{id}"
 errata_filter_list_url = errata_url + "/filter/{id}.json"
 errata_get_build_url = errata_url + "/api/v1/build/{id}"
 errata_get_builds_url = errata_url + "/api/v1/erratum/{id}/builds"


### PR DESCRIPTION
Advisories can only be dropped by their creators, or by program
management. This change implements the advisory-drop command, which
allows a bot user that creates advisories, to also drop them.