### PR TITLE
[ART-2196] introduce verify-attached-bugs

### DIFF
--- a/elliottlib/cli/__main__.py
+++ b/elliottlib/cli/__main__.py
@@ -57,6 +57,7 @@ from elliottlib.cli.tag_builds_cli import tag_builds_cli
 from elliottlib.cli.verify_cvp_cli import verify_cvp_cli
 from elliottlib.cli.advisory_drop_cli import advisory_drop_cli
 from elliottlib.cli.verify_attached_operators_cli import verify_attached_operators_cli
+from elliottlib.cli.verify_attached_bugs_cli import verify_attached_bugs_cli
 
 # 3rd party
 import bugzilla
@@ -691,6 +692,7 @@ cli.add_command(tarball_sources_cli)
 cli.add_command(verify_cvp_cli)
 cli.add_command(advisory_drop_cli)
 cli.add_command(verify_attached_operators_cli)
+cli.add_command(verify_attached_bugs_cli)
 
 
 # -----------------------------------------------------------------------------

--- a/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliottlib/cli/verify_attached_bugs_cli.py
@@ -1,0 +1,122 @@
+import click
+from kerberos import GSSError
+
+from errata_tool import Erratum
+
+from elliottlib import bzutil, errata
+from elliottlib.cli.common import cli, pass_runtime
+from elliottlib.exceptions import ElliottFatalError
+from elliottlib.util import (exit_unauthenticated, red_print, green_print, minor_version_tuple)
+
+
+@cli.command("verify-attached-bugs", short_help="Verify bugs in a release will not be regressed in the next version")
+@click.argument("advisories", nargs=-1, type=click.IntRange(1), required=False)
+@pass_runtime
+def verify_attached_bugs_cli(runtime, advisories):
+    """
+    Verify the bugs in the advisories (specified as arguments or in group.yml) for a release.
+    Requires a runtime to ensure that all bugs in the advisories match the runtime version.
+    Also ensures that bugs in the next release which block bugs in these advisories have
+    been verified, as those represent backports we do not want to regress in upgrades.
+
+    If any verification fails, a text explanation is given and the return code is 1.
+    Otherwise, prints the number of bugs in the advisories and exits with success.
+    """
+    runtime.initialize()
+    advisories = advisories or [a for a in runtime.group_config.get('advisories', {}).values()]
+    if not advisories:
+        red_print("No advisories specified on command line or in group.yml")
+        exit(1)
+    BugValidator(runtime).validate(advisories)
+
+
+class BugValidator:
+
+    def __init__(self, runtime):
+        self.runtime = runtime
+        self.bz_data = runtime.gitdata.load_data(key='bugzilla').data
+        self.target_releases = self.bz_data['target_release']
+        self.product = self.bz_data['product']
+        self.bzapi = bzutil.get_bzapi(self.bz_data)
+        self.problems = []
+
+    def validate(self, advisories):
+        bugs = self._get_attached_filtered_bugs(advisories)
+        blocking_bugs_for = self._get_blocking_bugs_for(bugs)
+        self._verify_blocking_bugs(blocking_bugs_for)
+        if self.problems:
+            red_print("Some bug problems were listed above. Please investigate.")
+            exit(1)
+        green_print("All bugs were verified.")
+
+    def _get_attached_bugs(self, advisories):
+        # get bugs attached to all advisories
+        bugs = []
+        try:
+            for advisory in advisories:
+                green_print(f"Retrieving bugs for advisory {advisory}")
+                bugs.extend(errata.get_bug_ids(advisory))
+        except GSSError:
+            exit_unauthenticated()
+        green_print(f"Found {len(bugs)} bugs")
+
+        return list(bzutil.get_bugs(self.bzapi, bugs).values())
+
+    def _get_attached_filtered_bugs(self, advisories):
+        # get bugs from advisories that are for the expected product and version
+        candidates = self._get_attached_bugs(advisories)
+
+        # filter out bugs for different product (presumably security flaw bugs)
+        candidates = [b for b in candidates if b.product == self.product]
+
+        # filter out bugs with an invalid target release (and complain)
+        filtered_bugs = []
+        for b in candidates:
+            # b.target release is a list of size 0 or 1
+            if any(target in self.target_releases for target in b.target_release):
+                filtered_bugs.append(b)
+            else:
+                self._complain(
+                    f"bug {b.id} target release {b.target_release} is not in "
+                    f"{self.target_releases}. Does it belong in this release?"
+                )
+
+        return filtered_bugs
+
+    def _get_blocking_bugs_for(self, bugs):
+        # get blocker bugs in the next version for all bugs we are examining
+        candidate_blockers = [b.depends_on for b in bugs if b.depends_on]
+        candidate_blockers = {b for deps in candidate_blockers for b in deps}
+
+        v = minor_version_tuple(self.target_releases[0])
+        next_version = (v[0], v[1] + 1)
+
+        # retrieve blockers and filter to those with correct product and target version
+        blocking_bugs = {
+            bug.id: bug
+            for bug in bzutil.get_bugs(self.bzapi, list(candidate_blockers)).values()
+            # b.target release is a list of size 0 or 1
+            if any(minor_version_tuple(target) == next_version for target in bug.target_release)
+            and bug.product == self.product
+        }
+
+        return {bug.id: [blocking_bugs[b] for b in bug.depends_on if b in blocking_bugs] for bug in bugs}
+
+    def _verify_blocking_bugs(self, blocking_bugs_for):
+        # complain about blocker bugs that aren't verified or shipped
+        for bug, blockers in blocking_bugs_for.items():
+            for blocker in blockers:
+                if blocker.status not in ['VERIFIED', 'RELEASE_PENDING', 'CLOSED']:
+                    self._complain(
+                        f"Regression possible: bug {bug} is a backport of bug "
+                        f"{blocker.id} which has status {blocker.status}"
+                    )
+                if blocker.status == 'CLOSED' and blocker.resolution not in ['CURRENTRELEASE', 'NEXTRELEASE', 'ERRATA']:
+                    self._complain(
+                        f"Regression possible: bug {bug} is a backport of bug "
+                        f"{blocker.id} which was CLOSED {blocker.resolution}"
+                    )
+
+    def _complain(self, problem):
+        red_print(problem)
+        self.problems.append(problem)

--- a/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliottlib/cli/verify_attached_bugs_cli.py
@@ -51,16 +51,16 @@ class BugValidator:
 
     def _get_attached_bugs(self, advisories):
         # get bugs attached to all advisories
-        bugs = []
+        bugs = set()
         try:
             for advisory in advisories:
                 green_print(f"Retrieving bugs for advisory {advisory}")
-                bugs.extend(errata.get_bug_ids(advisory))
+                bugs.update(errata.get_bug_ids(advisory))
         except GSSError:
             exit_unauthenticated()
         green_print(f"Found {len(bugs)} bugs")
 
-        return list(bzutil.get_bugs(self.bzapi, bugs).values())
+        return list(bzutil.get_bugs(self.bzapi, list(bugs)).values())
 
     def _get_attached_filtered_bugs(self, advisories):
         # get bugs from advisories that are for the expected product and version

--- a/elliottlib/errata.py
+++ b/elliottlib/errata.py
@@ -31,6 +31,21 @@ ErrataConnector._url = constants.errata_url
 errata_xmlrpc = xmlrpc.client.ServerProxy(constants.errata_xmlrpc_url)
 
 
+def get_raw_erratum(advisory_id):
+    """
+    Retrieve the raw dictionary object that we get for an erratum,
+    without wasting time processing it, loading builds, etc.
+    """
+    return ErrataConnector()._get(f"/api/v1/erratum/{advisory_id}")
+
+
+def get_bug_ids(advisory_id):
+    """
+    Retrieve just the bug IDs from an advisory without wasting time processing it, loading builds, etc.
+    """
+    return [bug['bug']['id'] for bug in get_raw_erratum(advisory_id)['bugs']['bugs']]
+
+
 def new_erratum(et_data, errata_type=None, boilerplate_name=None, kind=None, release_date=None, create=False,
                 assigned_to=None, manager=None, package_owner=None, impact=None, cves=None):
     """5.2.1.1. POST /api/v1/erratum

--- a/elliottlib/util.py
+++ b/elliottlib/util.py
@@ -268,5 +268,7 @@ def minor_version_tuple(bz_target):
     :param bz_target: A string like "4.5.0"
     :return: A tuple like (4, 5)
     """
+    if bz_target == '---':
+        return (0, 0)
     major, minor, _ = f"{bz_target}.z".split('.', 2)
     return (int(major), int(minor))

--- a/elliottlib/util.py
+++ b/elliottlib/util.py
@@ -258,3 +258,15 @@ def convert_remote_git_to_https(source):
         string=source.strip(),
     )
     return re.sub(string=url, pattern=r'\.git$', repl='').rstrip('/')
+
+
+def minor_version_tuple(bz_target):
+    """
+    Turns '4.5' or '4.5.z' into numeric (4, 5)
+    Assume the target version begins with numbers 'x.y' - explode otherwise
+
+    :param bz_target: A string like "4.5.0"
+    :return: A tuple like (4, 5)
+    """
+    major, minor, _ = f"{bz_target}.z".split('.', 2)
+    return (int(major), int(minor))

--- a/functional_tests/test_advisory_images.py
+++ b/functional_tests/test_advisory_images.py
@@ -3,13 +3,16 @@ import unittest
 import subprocess
 from functional_tests import constants
 
+# this test may break for EOL releases - apparently the CDN repos for
+# some images may become undefined after the fact.
+
 
 class AdvisoryImagesTestCase(unittest.TestCase):
     def test_advisory_images_with_group(self):
         out = subprocess.check_output(
             constants.ELLIOTT_CMD
             + [
-                "--group=openshift-4.2", "advisory-images"
+                "--group=openshift-4.6", "advisory-images"
             ]
         )
         self.assertIn("\n#########\n", out.decode("utf-8"))
@@ -18,7 +21,7 @@ class AdvisoryImagesTestCase(unittest.TestCase):
         out = subprocess.check_output(
             constants.ELLIOTT_CMD
             + [
-                "advisory-images", "--advisory", "49645"
+                "advisory-images", "--advisory", "65127"
             ]
         )
         self.assertIn("\n#########\n", out.decode("utf-8"))

--- a/functional_tests/test_change_state.py
+++ b/functional_tests/test_change_state.py
@@ -14,4 +14,4 @@ class ChangeStateTestCase(unittest.TestCase):
             stdout=subprocess.PIPE
         )
         out, _ = p.communicate()
-        self.assertIn("Cannot change state from SHIPPED_LIVE to QE", out.decode("utf-8"))
+        self.assertIn("current state is SHIPPED_LIVE", out.decode("utf-8"))

--- a/functional_tests/test_find_builds.py
+++ b/functional_tests/test_find_builds.py
@@ -3,13 +3,17 @@ import unittest
 import subprocess
 from functional_tests import constants
 
+# This test may start failing once this version is EOL and we either change the
+# ocp-build-data bugzilla schema or all of the non-shipped builds are garbage-collected.
+version = "4.3"
+
 
 class FindBuildsTestCase(unittest.TestCase):
     def test_find_rpms(self):
         out = subprocess.check_output(
             constants.ELLIOTT_CMD
             + [
-                "--group=openshift-3.10", "find-builds", "--kind=rpm",
+                f"--group=openshift-{version}", "find-builds", "--kind=rpm",
             ]
         )
         self.assertIn("may be attached to an advisory", out.decode("utf-8"))
@@ -18,7 +22,7 @@ class FindBuildsTestCase(unittest.TestCase):
         out = subprocess.check_output(
             constants.ELLIOTT_CMD
             + [
-                "--group=openshift-3.10", "find-builds", "--kind=image",
+                f"--group=openshift-{version}", "-i", "openshift-enterprise-cli", "find-builds", "--kind=image",
             ]
         )
         self.assertIn("may be attached to an advisory", out.decode("utf-8"))

--- a/functional_tests/test_verify_attached_bugs.py
+++ b/functional_tests/test_verify_attached_bugs.py
@@ -1,0 +1,106 @@
+from __future__ import absolute_import, print_function, unicode_literals
+from unittest import TestCase
+from mock import MagicMock, patch
+from functional_tests import constants
+import subprocess
+
+from elliottlib.cli.verify_attached_bugs_cli import BugValidator
+from elliottlib import bzutil
+
+
+class VerifyBugs(TestCase):
+
+    def setUp(self):
+        self.patchers = [
+            patch(f"elliottlib.cli.verify_attached_bugs_cli.{it}", lambda x: x)
+            for it in ["red_print", "green_print"]
+        ]
+        for p in self.patchers:
+            # disable the printed output during tests (remove this to debug...)
+            p.start()
+
+    def tearDown(self):
+        for p in self.patchers:
+            p.stop()
+
+    def runtime_fixture(self):
+        # fixture because it does have a real BZ server. everything else is dummy content to be overridden.
+        rt = MagicMock()
+        rt.gitdata.load_data().data = dict(
+            target_release=[],
+            product="dummy product",
+            server="bugzilla.redhat.com",
+        )
+        return rt
+
+    def _test_get_attached_bugs(self):
+        bugs = BugValidator(self.runtime_fixture())._get_attached_bugs([60085])
+        self.assertEqual(20, len(bugs))
+        self.assertIn(1812663, {bug.id for bug in bugs})
+        print(f"{list(bugs)[0].product}")
+
+    def test_get_attached_filtered_bugs(self):
+        bv = BugValidator(self.runtime_fixture())
+        bv.product = "OpenShift Container Platform"
+        bv.target_releases = ['4.5.0', '4.5.z']
+        bugs = {bug.id for bug in bv._get_attached_filtered_bugs([60089])}  # SHIPPED_LIVE RHSA
+        self.assertIn(1856529, bugs)  # security tracker
+        self.assertNotIn(1858981, bugs)  # flaw bug
+        self.assertFalse(bv.problems, "There should be no problems")
+
+    def test_get_attached_filtered_bugs_problems(self):
+        bv = BugValidator(self.runtime_fixture())
+        bv.product = "OpenShift Container Platform"
+        bv.target_releases = ['4.6.0', '4.6.z']
+        bv._get_attached_filtered_bugs([60089])  # SHIPPED_LIVE RHSA
+        self.assertTrue(bv.problems, "Should find version mismatch")
+        self.assertTrue(
+            any("1856529" in problem for problem in bv.problems),
+            "Should find version mismatch for 1856529"
+        )
+
+    def test_get_and_verify_blocking_bugs(self):
+        bv = BugValidator(self.runtime_fixture())
+        bv.product = "OpenShift Container Platform"
+        bv.target_releases = ['4.4.0', '4.4.z']
+        bugs = bzutil.get_bugs(bv.bzapi, [1875258, 1878798, 1881212, 1869790, 1840719])
+
+        bbf = bv._get_blocking_bugs_for(list(bugs.values()))
+        self.assertTrue(bbf[1875258], "CVE tracker with blocking bug")
+        self.assertTrue(any(bug.id == 1875259 for bug in bbf[1875258]), "1875259 blocks 1875258")
+        self.assertTrue(bbf[1878798], "regular bug with blocking bug")
+        self.assertTrue(any(bug.id == 1872337 for bug in bbf[1878798]), "1872337 blocks 1878798")
+        self.assertFalse(bbf[1881212], "placeholder bug w/o blocking")
+        self.assertTrue(bbf[1869790], "bug with several blocking bugs, one DUPLICATE")
+        self.assertTrue(any(bug.id == 1868735 for bug in bbf[1869790]), "DUPLICATE 1868735 blocks 1869790")
+        self.assertTrue(all(bug.id != 1868158 for bug in bbf[1869790]), "4.6 1868158 blocks 1869790")
+        self.assertFalse(bbf[1840719], "bug with 4.6 blocking bug")
+
+        # having acquired these bugs, might as well use them to test verification
+        bv._verify_blocking_bugs(bbf)
+        self.assertIn(
+            "Regression possible: bug 1869790 is a backport of bug 1868735 which was CLOSED DUPLICATE",
+            bv.problems
+        )
+        for bug in [1875258, 1878798, 1881212, 1840719]:
+            self.assertFalse(
+                any(str(bug) in problem for problem in bv.problems),
+                f"{bug} blocker status {bbf[bug]}"
+            )
+
+    def test_verify_attached_bugs_ok(self):
+        out = subprocess.check_output(
+            constants.ELLIOTT_CMD
+            + ["--group", "openshift-4.5", "verify-attached-bugs", "60085", "60089"]
+        )
+        self.assertIn("All bugs were verified", out.decode("utf-8"))
+
+    def test_verify_attached_bugs_wrong(self):
+        out = subprocess.run(
+            constants.ELLIOTT_CMD
+            + ["--group", "openshift-4.6", "verify-attached-bugs", "60089"],  # 4.5 RHSA
+            capture_output=True,
+            encoding='utf-8',
+        )
+        self.assertIn("bug 1856529 target release ['4.5.z'] is not in", out.stdout)
+        self.assertEqual(1, out.returncode)


### PR DESCRIPTION
validate that bugs in a release are also fixed in next minor version and that they target the right version in the first place.

also fixes up functional tests I found were broken. I implemented functional tests rather than unit tests as the main failure mode here is getting the API or API object attrs wrong.