### PR TITLE
Add get-golang-versions cli command

### DIFF
--- a/elliottlib/brew.py
+++ b/elliottlib/brew.py
@@ -210,6 +210,23 @@ def find_unshipped_build_candidates(base_tag, kind='rpm', brew_session=koji.Clie
     return diff_builds
 
 
+def get_nvr_root_log(name, version, release, arch='x86_64'):
+    root_log_url = '{host}/vol/rhel-{rhel_version}/packages/{name}/{version}/{release}/data/logs/{arch}/root.log'.format(
+        host=constants.BREW_DOWNLOAD_URL,
+        rhel_version=release[-1],
+        name=name,
+        version=version,
+        release=release,
+        arch=arch,
+    )
+
+    logger.debug(f"Trying {root_log_url}")
+    res = requests.get(root_log_url, verify=ssl.get_default_verify_paths().openssl_cafile)
+    if res.status_code != 200:
+        raise exceptions.BrewBuildException("Could not get root.log for {}-{}-{}".format(name, version, release))
+    return str(res.content)
+
+
 class Build(object):
     """An existing brew build
 

--- a/elliottlib/cli/__main__.py
+++ b/elliottlib/cli/__main__.py
@@ -59,6 +59,7 @@ from elliottlib.cli.advisory_drop_cli import advisory_drop_cli
 from elliottlib.cli.verify_attached_operators_cli import verify_attached_operators_cli
 from elliottlib.cli.verify_attached_bugs_cli import verify_attached_bugs_cli
 from elliottlib.cli.attach_cve_flaws_cli import attach_cve_flaws_cli
+from elliottlib.cli.get_golang_versions import get_golang_versions_cli
 
 # 3rd party
 import bugzilla
@@ -431,32 +432,7 @@ written out to summary_results.json.
     $ elliott verify-payload quay.io/openshift-release-dev/ocp-release:4.1.0-rc.6 41567
 
     """
-    try:
-        green_prefix("Fetching advisory builds: ")
-        click.echo("Advisory - {}".format(advisory))
-        builds = elliottlib.errata.get_builds(advisory)
-    except GSSError:
-        exit_unauthenticated()
-    except elliottlib.exceptions.ErrataToolError as ex:
-        raise ElliottFatalError(getattr(ex, 'message', repr(ex)))
-
-    all_advisory_nvrs = {}
-    # Results come back with top level keys which are brew tags
-    green_prefix("Looping over tags: ")
-    click.echo("{} tags to check".format(len(builds)))
-    for tag in builds.keys():
-        # Each top level has a key 'builds' which is a list of dicts
-        green_prefix("Looping over builds in tag: ")
-        click.echo("{} with {} builds".format(tag, len(builds[tag]['builds'])))
-        for build in builds[tag]['builds']:
-            # Each dict has a top level key which might be the actual
-            # 'nvr' but I don't have enough data to know for sure
-            # yet. Also I don't know when there might be more than one
-            # key in the build dict. We'll loop over it to be sure.
-            for name in build.keys():
-                n, v, r = name.rsplit('-', 2)
-                version_release = "{}-{}".format(v, r)
-                all_advisory_nvrs[n] = version_release
+    all_advisory_nvrs = elliottlib.errata.get_advisory_nvrs(advisory)
 
     click.echo("Found {} builds".format(len(all_advisory_nvrs)))
 

--- a/elliottlib/cli/get_golang_versions.py
+++ b/elliottlib/cli/get_golang_versions.py
@@ -1,0 +1,32 @@
+from elliottlib import brew, errata, Runtime
+from elliottlib.cli.common import cli
+from elliottlib.exceptions import BrewBuildException
+from elliottlib.util import get_golang_version_from_root_log
+
+import click
+pass_runtime = click.make_pass_decorator(Runtime)
+
+
+@cli.command("get-golang-versions", short_help="Get version of Go used for builds attached to an advisory")
+@click.argument('advisory', type=int)
+@pass_runtime
+def get_golang_versions_cli(runtime, advisory):
+    """
+    Only works for RPM builds.
+
+    Usage:
+\b
+    $ elliott --group openshift-3.7 get-golang-versions ID
+"""
+    all_advisory_nvrs = errata.get_advisory_nvrs(advisory)
+
+    click.echo("Found {} builds".format(len(all_advisory_nvrs)))
+    for component, value in all_advisory_nvrs.items():
+        version, release = value.rsplit('-', 1)
+        try:
+            root_log = brew.get_nvr_root_log(component, version, release)
+        except BrewBuildException as e:
+            print(e)
+            continue
+        golang_version = get_golang_version_from_root_log(root_log)
+        print('{}-{}-{}: {}'.format(component, version, release, golang_version))

--- a/elliottlib/constants.py
+++ b/elliottlib/constants.py
@@ -4,7 +4,8 @@ This file contains constants that are used to manage OCP Image and RPM builds
 from __future__ import absolute_import, print_function, unicode_literals
 
 BREW_HUB = "https://brewhub.engineering.redhat.com/brewhub"
-BREW_DOWNLOAD_TEMPLATE = "http://download.eng.bos.redhat.com/brewroot/packages/{name}/{version}/{release}/files/{file_path}"
+BREW_DOWNLOAD_URL = "http://download.eng.bos.redhat.com/brewroot"
+BREW_DOWNLOAD_TEMPLATE = BREW_DOWNLOAD_URL + "/packages/{name}/{version}/{release}/files/{file_path}"
 CGIT_URL = "http://pkgs.devel.redhat.com/cgit"
 RESULTSDB_API_URL = "https://resultsdb-api.engineering.redhat.com/api/v2.0"
 

--- a/elliottlib/util.py
+++ b/elliottlib/util.py
@@ -272,3 +272,11 @@ def minor_version_tuple(bz_target):
         return (0, 0)
     major, minor, _ = f"{bz_target}.z".split('.', 2)
     return (int(major), int(minor))
+
+
+def get_golang_version_from_root_log(root_log):
+    # Based on below greps:
+    # $ grep -m1 -o -E '(go-toolset-1[^ ]*|golang-(bin-|))[0-9]+.[0-9]+.[0-9]+[^ ]*' ./3.11/*.log | sed 's/:.*\([0-9]\+\.[0-9]\+\.[0-9]\+.*\)/: \1/'
+    # $ grep -m1 -o -E '(go-toolset-1[^ ]*|golang.*module[^ ]*).*[0-9]+.[0-9]+.[0-9]+[^ ]*' ./4.5/*.log | sed 's/\:.*\([^a-z][0-9]\+\.[0-9]\+\.[0-9]\+[^ ]*\)/:\ \1/'
+    m = re.search(r'(go-toolset-1[^ ]*|golang-(bin-|))[0-9]+.[0-9]+.[0-9]+[^ \\]*', root_log)
+    return m.group(0)


### PR DESCRIPTION
Adds a command that retrieves the root.log for brew builds and extracts the installed Go version. Potentially useful for tracing when the Go version has changed.

Example:

```
 $ ./elliott get-golang-versions 60147
Fetching advisory builds: Advisory - 60147
Looping over tags: 2 tags to check
Looping over builds in tag: OSE-4.6-RHEL-8 with 5 builds
Looping over builds in tag: RHEL-7-OSE-4.6 with 2 builds
Found 5 builds
podman-1.9.3-3.rhaos4.6.el8: golang-1.15.0-1.module+el8.4.0+7995+d3ff3d9b.x86_64
Could not get root.log for jenkins-2-plugins-4.6.1601368321-1.el8
skopeo-1.1.1-2.rhaos4.6.el8: golang-1.14.4-2.module+el8.3.0+7324+24e3ded4.x86_64
runc-1.0.0-81.rhaos4.6.git5b757d4.el7: go-toolset-1.13-1.13.4-3.el7.x86_64
openshift-clients-4.6.0-202010081244.p0.git.3794.4743d24.el7: go-toolset-1.15-golang.x86_64 0:1.15.0-2.el7.2
```