### PR TITLE
Add container support to get-golang-versions

### DIFF
--- a/elliottlib/cli/get_golang_versions.py
+++ b/elliottlib/cli/get_golang_versions.py
@@ -1,24 +1,15 @@
-from elliottlib import brew, errata, Runtime
+from elliottlib import brew, constants, errata, Runtime
 from elliottlib.cli.common import cli
 from elliottlib.exceptions import BrewBuildException
 from elliottlib.util import get_golang_version_from_root_log
 
 import click
+import koji
 pass_runtime = click.make_pass_decorator(Runtime)
 
 
-@cli.command("get-golang-versions", short_help="Get version of Go used for builds attached to an advisory")
-@click.argument('advisory', type=int)
-@pass_runtime
-def get_golang_versions_cli(runtime, advisory):
-    """
-    Only works for RPM builds.
-
-    Usage:
-\b
-    $ elliott --group openshift-3.7 get-golang-versions ID
-"""
-    all_advisory_nvrs = errata.get_all_advisory_nvrs(advisory)
+def get_rpm_golang_versions(advisory_id: str):
+    all_advisory_nvrs = errata.get_all_advisory_nvrs(advisory_id)
 
     click.echo("Found {} builds".format(len(all_advisory_nvrs)))
     for nvr in all_advisory_nvrs:
@@ -29,3 +20,42 @@ def get_golang_versions_cli(runtime, advisory):
             continue
         golang_version = get_golang_version_from_root_log(root_log)
         print('{}-{}-{}:\t{}'.format(*nvr, golang_version))
+
+
+def get_container_golang_versions(advisory_id: str):
+    all_builds = errata.get_brew_builds(advisory_id)
+
+    all_build_objs = brew.get_build_objects([b.nvr for b in all_builds])
+    for build in all_build_objs:
+        golang_version = None
+        name = build.get('name')
+        try:
+            parents = build['extra']['image']['parent_image_builds']
+        except KeyError:
+            print('Could not get parent image info for {}'.format(name))
+            continue
+
+        for p, pinfo in parents.items():
+            if 'builder' in p:
+                golang_version = pinfo.get('nvr')
+
+        if golang_version is not None:
+            print('{}:\t{}'.format(name, golang_version))
+
+
+@cli.command("get-golang-versions", short_help="Get version of Go used for builds attached to an advisory")
+@click.argument('advisory', type=int)
+@pass_runtime
+def get_golang_versions_cli(runtime, advisory):
+    """
+    Prints the Go version used to build a component to stdout.
+
+    Usage:
+\b
+    $ elliott --group openshift-3.7 get-golang-versions ID
+"""
+    content_type = errata.get_erratum_content_type(advisory)
+    if content_type == 'docker':
+        get_container_golang_versions(advisory)
+    else:
+        get_rpm_golang_versions(advisory)

--- a/elliottlib/constants.py
+++ b/elliottlib/constants.py
@@ -129,6 +129,8 @@ RPMDIFF_SCORE_NAMES = {
 RPMDIFF_WEB_URL = "https://rpmdiff.engineering.redhat.com"
 RPMDIFF_HUB_URL = "https://rpmdiff-hub.host.prod.eng.bos.redhat.com"
 
+ADVISORY_TYPES = ('rhba', 'rhea', 'rhsa')
+
 ######################################################################
 # API endpoints with string formatting placeholders as
 # necessary. Index of all available endpoints is available in the

--- a/elliottlib/errata.py
+++ b/elliottlib/errata.py
@@ -47,6 +47,16 @@ def get_bug_ids(advisory_id):
     return [bug['bug']['id'] for bug in get_raw_erratum(advisory_id)['bugs']['bugs']]
 
 
+def get_erratum_content_type(advisory_id: str):
+    raw_erratum = get_raw_erratum(advisory_id)
+    erratum = raw_erratum.get('errata')
+    for t in constants.ADVISORY_TYPES:
+        data = erratum.get(t)
+        if data is not None:
+            return data.get('content_types')[0]
+    return None
+
+
 def new_erratum(et_data, errata_type=None, boilerplate_name=None, kind=None, release_date=None, create=False,
                 assigned_to=None, manager=None, package_owner=None, impact=None, cves=None):
     """5.2.1.1. POST /api/v1/erratum


### PR DESCRIPTION
Currently `get-golang-versions` command only works for RPMs. This PR adds support for container builds.

Example
```
$ ./elliott get-golang-versions 66146
atomic-openshift-descheduler-container:	openshift-golang-builder-container-v1.13.0-202011132013.el7
cluster-logging-operator-container:	openshift-golang-builder-container-v1.13.0-202011132013.el7
cluster-nfd-operator-container:	openshift-golang-builder-container-v1.13.0-202011132013.el7
ose-clusterresourceoverride-operator-container:	openshift-golang-builder-container-v1.13.0-202011132013.el7
ose-clusterresourceoverride-container:	openshift-golang-builder-container-v1.13.0-202011132013.el7
...
```