### PR TITLE
Fix bug in get-golang-versions which overlooked EL7/EL8 builds of the same package

### DIFF
--- a/elliottlib/cli/get_golang_versions.py
+++ b/elliottlib/cli/get_golang_versions.py
@@ -18,15 +18,14 @@ def get_golang_versions_cli(runtime, advisory):
 \b
     $ elliott --group openshift-3.7 get-golang-versions ID
 """
-    all_advisory_nvrs = errata.get_advisory_nvrs(advisory)
+    all_advisory_nvrs = errata.get_all_advisory_nvrs(advisory)
 
     click.echo("Found {} builds".format(len(all_advisory_nvrs)))
-    for component, value in all_advisory_nvrs.items():
-        version, release = value.rsplit('-', 1)
+    for nvr in all_advisory_nvrs:
         try:
-            root_log = brew.get_nvr_root_log(component, version, release)
+            root_log = brew.get_nvr_root_log(*nvr)
         except BrewBuildException as e:
             print(e)
             continue
         golang_version = get_golang_version_from_root_log(root_log)
-        print('{}-{}-{}: {}'.format(component, version, release, golang_version))
+        print('{}-{}-{}:\t{}'.format(*nvr, golang_version))


### PR DESCRIPTION
Before:
```
$ ./elliott get-golang-versions 66145
Fetching advisory builds: Advisory - 66145
Looping over tags: 2 tags to check
Looping over builds in tag: OSE-4.4-RHEL-8 with 3 builds
Looping over builds in tag: RHEL-7-OSE-4.4 with 6 builds
Found 7 builds
Could not get root.log for iptables-1.8.4-10.el8_2.4
openshift-4.4.0-202011130111.p0.git.0.4861dfa.el7: go-toolset-1.13.x86_64 0:1.13.15-1.el7
openshift-clients-4.4.0-202011122017.p0.git.3445.6937a03.el7: go-toolset-1.13.x86_64 0:1.13.15-1.el7
faq-0.0.6-5.el7: go-toolset-1.13.x86_64 0:1.13.15-1.el7
atomic-openshift-service-idler-4.4.0-202011122017.p0.git.15.d3ab88f.el7: go-toolset-1.13.x86_64 0:1.13.15-1.el7
atomic-enterprise-service-catalog-4.4.0-202011122017.p0.git.1806.53dc206.el7: go-toolset-1.13.x86_64 0:1.13.15-1.el7
Could not get root.log for openshift-ansible-4.4.0-202011122017.p0.git.0.2755c9b.el7
```

After:
```
$ ./elliott get-golang-versions 66145
Found 9 builds
Could not get root.log for iptables-1.8.4-10.el8_2.4
openshift-4.4.0-202011130111.p0.git.0.4861dfa.el8:	golang-1.13.15-1.module+el8.2.0+7662+fa98b974.x86_64
openshift-clients-4.4.0-202011122017.p0.git.3445.6937a03.el8:	golang-1.13.15-1.module+el8.2.0+7662+fa98b974.x86_64
faq-0.0.6-5.el7:	go-toolset-1.13.x86_64 0:1.13.15-1.el7
openshift-4.4.0-202011130111.p0.git.0.4861dfa.el7:	go-toolset-1.13.x86_64 0:1.13.15-1.el7
openshift-clients-4.4.0-202011122017.p0.git.3445.6937a03.el7:	go-toolset-1.13.x86_64 0:1.13.15-1.el7
atomic-openshift-service-idler-4.4.0-202011122017.p0.git.15.d3ab88f.el7:	go-toolset-1.13.x86_64 0:1.13.15-1.el7
atomic-enterprise-service-catalog-4.4.0-202011122017.p0.git.1806.53dc206.el7:	go-toolset-1.13.x86_64 0:1.13.15-1.el7
Could not get root.log for openshift-ansible-4.4.0-202011122017.p0.git.0.2755c9b.el7
```
