### PR TITLE
Fix bug in parsing Go version from root.logs

### DIFF
--- a/elliottlib/brew.py
+++ b/elliottlib/brew.py
@@ -224,7 +224,7 @@ def get_nvr_root_log(name, version, release, arch='x86_64'):
     res = requests.get(root_log_url, verify=ssl.get_default_verify_paths().openssl_cafile)
     if res.status_code != 200:
         raise exceptions.BrewBuildException("Could not get root.log for {}-{}-{}".format(name, version, release))
-    return str(res.content)
+    return res.text
 
 
 class Build(object):

--- a/elliottlib/cli/get_golang_versions.py
+++ b/elliottlib/cli/get_golang_versions.py
@@ -18,7 +18,11 @@ def get_rpm_golang_versions(advisory_id: str):
         except BrewBuildException as e:
             print(e)
             continue
-        golang_version = get_golang_version_from_root_log(root_log)
+        try:
+            golang_version = get_golang_version_from_root_log(root_log)
+        except AttributeError:
+            print('Could not find Go version in {}-{}-{} root.log'.format(*nvr))
+            continue
         print('{}-{}-{}:\t{}'.format(*nvr, golang_version))
 
 

--- a/elliottlib/util.py
+++ b/elliottlib/util.py
@@ -275,8 +275,9 @@ def minor_version_tuple(bz_target):
 
 
 def get_golang_version_from_root_log(root_log):
+    # TODO add a test for this
     # Based on below greps:
     # $ grep -m1 -o -E '(go-toolset-1[^ ]*|golang-(bin-|))[0-9]+.[0-9]+.[0-9]+[^ ]*' ./3.11/*.log | sed 's/:.*\([0-9]\+\.[0-9]\+\.[0-9]\+.*\)/: \1/'
     # $ grep -m1 -o -E '(go-toolset-1[^ ]*|golang.*module[^ ]*).*[0-9]+.[0-9]+.[0-9]+[^ ]*' ./4.5/*.log | sed 's/\:.*\([^a-z][0-9]\+\.[0-9]\+\.[0-9]\+[^ ]*\)/:\ \1/'
-    m = re.search(r'(go-toolset-1[^ ]*|golang-(bin-|))[0-9]+.[0-9]+.[0-9]+[^ \\]*', root_log)
+    m = re.search(r'(go-toolset-1[^\s]*|golang-bin).*[0-9]+.[0-9]+.[0-9]+[^\s]*', root_log)
     return m.group(0)


### PR DESCRIPTION
Previously was failing on some root.logs that installed Go from RHEL8 modules