### PR TITLE
ART-2592 Attach RPM CVE tracker bugs to RPM advisory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,16 @@
-venv/bin/activate: requirements-dev.txt
+.PHONY: venv tox lint test
+
+venv:
 	python3 -m venv venv
 	./venv/bin/pip install -r requirements-dev.txt
+	# source venv/bin/activate
 
 lint:
 	flake8
 
-test:
+test: lint
 	py.test --verbose --color=yes tests/
 
+# run by CI
 tox:
 	tox --recreate

--- a/elliottlib/brew.py
+++ b/elliottlib/brew.py
@@ -197,15 +197,12 @@ def find_unshipped_build_candidates(base_tag, kind='rpm', brew_session=koji.Clie
     :return: A set of build strings where each build is only tagged as
     a -candidate build
     """
-    shipped_builds_set = set()
+    shipped_builds_set = {b['nvr'] for b in brew_session.listTagged(tag=base_tag, latest=True, type=kind)}
+    candidate_builds_set = {b['nvr'] for b in brew_session.listTagged(tag='{}-candidate'.format(base_tag), latest=True,
+                                                             type=kind)}
     diff_builds = {}
-    candidate_builds = brew_session.listTagged(tag='{}-candidate'.format(base_tag), latest=True, type=kind)
-    for b in brew_session.listTagged(tag=base_tag, latest=True, type=kind):
-        shipped_builds_set.add(b['nvr'])
-
-    for b in candidate_builds:
-        if b['nvr'] not in shipped_builds_set:
-            diff_builds[b['nvr']] = b
+    for b in candidate_builds_set - shipped_builds_set:
+        diff_builds[b['nvr']] = b
 
     return diff_builds
 

--- a/elliottlib/brew.py
+++ b/elliottlib/brew.py
@@ -30,7 +30,8 @@ from requests_kerberos import HTTPKerberosAuth
 logger = logutil.getLogger(__name__)
 
 
-def get_tagged_builds(tags: Iterable[str], build_type: Optional[str], event: Optional[int], session: koji.ClientSession) -> List[Optional[List[Dict]]]:
+def get_tagged_builds(tags: Iterable[str], build_type: Optional[str], event: Optional[int],
+                      session: koji.ClientSession) -> List[Optional[List[Dict]]]:
     """ Get tagged builds for multiple Brew tags
 
     :param tags: List of tag names
@@ -44,7 +45,8 @@ def get_tagged_builds(tags: Iterable[str], build_type: Optional[str], event: Opt
     return [build for task in tasks for build in task.result]
 
 
-def get_latest_builds(tag_component_tuples: List[Tuple[str, str]], session: koji.ClientSession) -> List[Optional[List[Dict]]]:
+def get_latest_builds(tag_component_tuples: List[Tuple[str, str]], session: koji.ClientSession) -> List[
+    Optional[List[Dict]]]:
     """ Get latest builds for multiple Brew components
 
     :param tag_component_tuples: List of (tag, component_name) tuples
@@ -89,7 +91,8 @@ def wait_tasks(task_ids: Iterable[int], session: koji.ClientSession, sleep_secon
                 waiting_tasks.discard(task_id)  # remove from the wait list
         if waiting_tasks:
             if logger:
-                logger.debug(f"There are still {len(waiting_tasks)} tagging task(s) running. Will recheck in {sleep_seconds} seconds.")
+                logger.debug(
+                    f"There are still {len(waiting_tasks)} tagging task(s) running. Will recheck in {sleep_seconds} seconds.")
             time.sleep(sleep_seconds)
 
 
@@ -198,11 +201,12 @@ def find_unshipped_build_candidates(base_tag, kind='rpm', brew_session=koji.Clie
     a -candidate build
     """
     shipped_builds_set = {b['nvr'] for b in brew_session.listTagged(tag=base_tag, latest=True, type=kind)}
-    candidate_builds_set = {b['nvr'] for b in brew_session.listTagged(tag='{}-candidate'.format(base_tag),
-                                                                      latest=True, type=kind)}
+    candidate_builds = {b['nvr']: b for b in brew_session.listTagged(tag='f{base_tag}-candidate',
+                                                                         latest=True, type=kind)}
+    candidate_builds_set = candidate_builds.keys()
     diff_builds = {}
-    for b in candidate_builds_set - shipped_builds_set:
-        diff_builds[b['nvr']] = b
+    for nvr in candidate_builds_set - shipped_builds_set:
+        diff_builds[nvr] = candidate_builds[nvr]
 
     return diff_builds
 

--- a/elliottlib/brew.py
+++ b/elliottlib/brew.py
@@ -201,7 +201,7 @@ def find_unshipped_build_candidates(base_tag, kind='rpm', brew_session=koji.Clie
     a -candidate build
     """
     shipped_builds_set = {b['nvr'] for b in brew_session.listTagged(tag=base_tag, latest=True, type=kind)}
-    candidate_builds = {b['nvr']: b for b in brew_session.listTagged(tag='f{base_tag}-candidate',
+    candidate_builds = {b['nvr']: b for b in brew_session.listTagged(tag=f'{base_tag}-candidate',
                                                                          latest=True, type=kind)}
     candidate_builds_set = candidate_builds.keys()
     diff_builds = {}

--- a/elliottlib/brew.py
+++ b/elliottlib/brew.py
@@ -45,8 +45,7 @@ def get_tagged_builds(tags: Iterable[str], build_type: Optional[str], event: Opt
     return [build for task in tasks for build in task.result]
 
 
-def get_latest_builds(tag_component_tuples: List[Tuple[str, str]], session: koji.ClientSession) -> List[
-    Optional[List[Dict]]]:
+def get_latest_builds(tag_component_tuples: List[Tuple[str, str]], session: koji.ClientSession) -> List[Optional[List[Dict]]]:
     """ Get latest builds for multiple Brew components
 
     :param tag_component_tuples: List of (tag, component_name) tuples

--- a/elliottlib/brew.py
+++ b/elliottlib/brew.py
@@ -198,8 +198,8 @@ def find_unshipped_build_candidates(base_tag, kind='rpm', brew_session=koji.Clie
     a -candidate build
     """
     shipped_builds_set = {b['nvr'] for b in brew_session.listTagged(tag=base_tag, latest=True, type=kind)}
-    candidate_builds_set = {b['nvr'] for b in brew_session.listTagged(tag='{}-candidate'.format(base_tag), latest=True,
-                                                             type=kind)}
+    candidate_builds_set = {b['nvr'] for b in brew_session.listTagged(tag='{}-candidate'.format(base_tag),
+                                                                      latest=True, type=kind)}
     diff_builds = {}
     for b in candidate_builds_set - shipped_builds_set:
         diff_builds[b['nvr']] = b

--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -11,6 +11,7 @@ from time import sleep
 
 import urllib.parse
 from elliottlib import logutil
+import re
 
 # ours
 from . import constants
@@ -298,10 +299,12 @@ def get_valid_rpm_cves(bugs):
     """ Get valid rpm cve trackers with their component names
 
     An OCP rpm cve tracker has a whiteboard value "component:<component_name>"
+    excluding suffixes (apb|container)
 
     :param bugs: list of bug objects
     :returns: A dict of bug object as key and component name as value
     """
+
     marker = 'component:'
     rpm_cves = {}
     for b in bugs:
@@ -309,7 +312,8 @@ def get_valid_rpm_cves(bugs):
             tmp = b.whiteboard.split(marker)
             if len(tmp) == 2:
                 component_name = tmp[1].strip()
-                rpm_cves[b] = component_name
+                if not re.search(r'-(apb|container)$', component_name):
+                    rpm_cves[b] = component_name
     return rpm_cves
 
 

--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -236,7 +236,8 @@ def search_for_bugs(bz_data, status, search_filter='default', filter_out_securit
     if verbose:
         click.echo(query_url)
 
-    return _perform_query(bzapi, query_url, include_fields=['id', 'status', 'summary', 'creation_time', 'cf_pm_score', 'component', 'external_bugs'])
+    return _perform_query(bzapi, query_url, include_fields=['id', 'status', 'summary', 'creation_time',
+                                                            'cf_pm_score', 'component', 'external_bugs', 'whiteboard'])
 
 
 def search_for_security_bugs(bz_data, status=None, search_filter='security', cve=None, verbose=False):
@@ -289,6 +290,15 @@ def is_cve_tracker(bug_obj):
     """
     return "SecurityTracking" in bug_obj.keywords and "Security" in bug_obj.keywords
 
+def is_rpm_bug(bug_obj):
+    """ Check if a bug is an rpm bug.
+
+    An OCP rpm bug has a whiteboard value starting with "component:<component_name>"
+
+    :param bug_obj: bug object
+    :returns: True if the bug is an rpm bug.
+    """
+    return 'component:' in bug_obj.whiteboard
 
 def get_bzapi(bz_data, interactive_login=False):
     bzapi = bugzilla.Bugzilla(bz_data['server'])

--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -305,13 +305,14 @@ def get_valid_rpm_cves(bugs):
     :returns: A dict of bug object as key and component name as value
     """
 
-    marker = 'component:'
+    marker = r'component:\s*([-\w]+)'
     rpm_cves = {}
     for b in bugs:
-        if is_cve_tracker(b) and marker in b.whiteboard:
-            tmp = b.whiteboard.split(marker)
-            if len(tmp) == 2:
-                component_name = tmp[1].strip()
+        if is_cve_tracker(b):
+            tmp = re.search(marker, b.whiteboard)
+            if tmp and len(tmp.groups()) == 1:
+                component_name = tmp.groups()[0]
+                # filter out non-rpm suffixes
                 if not re.search(r'-(apb|container)$', component_name):
                     rpm_cves[b] = component_name
     return rpm_cves

--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -312,6 +312,7 @@ def get_valid_rpm_cves(bugs):
                 rpm_cves[b] = component_name
     return rpm_cves
 
+
 def get_bzapi(bz_data, interactive_login=False):
     bzapi = bugzilla.Bugzilla(bz_data['server'])
     if not bzapi.logged_in:

--- a/elliottlib/cli/find_bugs_cli.py
+++ b/elliottlib/cli/find_bugs_cli.py
@@ -258,7 +258,7 @@ advisory with the --add option.
                     if package_name not in packages:
                         not_found.append((bug.id, package_name))
                     else:
-                        click.echo(f"Build found for #{bug.id}, #{package_name}")
+                        click.echo(f"Build found for #{bug.id}, {package_name}")
                         impetus_bugs["rpm"].add(bug)
 
                 if not_found:

--- a/elliottlib/cli/find_bugs_cli.py
+++ b/elliottlib/cli/find_bugs_cli.py
@@ -258,6 +258,7 @@ advisory with the --add option.
                     if package_name not in packages:
                         not_found.append((bug.id, package_name))
                     else:
+                        click.echo(f"Build found for #{bug.id}, #{package_name}")
                         impetus_bugs["rpm"].add(bug)
 
                 if not_found:

--- a/elliottlib/cli/find_bugs_cli.py
+++ b/elliottlib/cli/find_bugs_cli.py
@@ -72,7 +72,7 @@ Use cases are described below:
 SWEEP: For this use-case the --group option MUST be provided. The
 --group automatically determines the correct target-releases to search
 for bugs claimed to be fixed, but not yet attached to advisories.
---check-builds flag forces bug validation with attached builds to advisory.
+--check-builds flag forces bug validation with attached builds to rpm advisory.
 It assumes builds have been attached and only attaches bugs with matching builds.
 
 LIST: The --group option is not required if you are specifying bugs
@@ -268,6 +268,8 @@ advisory with the --add option.
                                "brew builds were found attached to the rpm advisory. First attach builds and then "
                                "rerun to attach the bugs")
                     click.echo(not_found)
+            else:
+                click.echo("Skipping attaching RPM CVEs. Use --check-builds flag to validate with builds.")
 
         # optional operators bugs should be swept to the "extras" advisory
         # a way to identify operator-related bugs is by its "Component" value.

--- a/elliottlib/cli/find_bugs_cli.py
+++ b/elliottlib/cli/find_bugs_cli.py
@@ -258,7 +258,6 @@ advisory with the --add option.
                            "the bugs")
                 click.echo(failed)
 
-
         # optional operators bugs should be swept to the "extras" advisory
         # a way to identify operator-related bugs is by its "Component" value.
         # temporarily hardcode here until we need to move it to ocp-build-data.

--- a/elliottlib/cli/find_bugs_cli.py
+++ b/elliottlib/cli/find_bugs_cli.py
@@ -152,7 +152,7 @@ advisory with the --add option.
         bug_id_strings = openshiftclient.get_bug_list(runtime.working_dir, from_diff[0], from_diff[1])
         bugs = [bzapi.getbug(i) for i in bug_id_strings]
 
-    # Some bugs should goes to CPaaS so we should ignore them
+    # Some bugs should go to CPaaS so we should ignore them
     m = re.match(r"rhaos-(\d+).(\d+)", runtime.branch)  # extract OpenShift version from the branch name. there should be a better way...
     if not m:
         raise ElliottFatalError(f"Unable to determine OpenShift version from branch name {runtime.branch}.")
@@ -225,6 +225,12 @@ advisory with the --add option.
     if major_version < 4:  # for 3.x, all bugs should go to the rpm advisory
         impetus_bugs["rpm"] = set(bugs)
     else:  # for 4.x
+        # TODO: this will affect all bugs, check if we need to filter for cve bugs only
+        impetus_bugs["rpm"] = {b for b in bugs if "component:" in b.whiteboard}
+        # TODO: use bzutil.is_rpm_bug()
+        # TODO: check for brew build
+        click.echo("rpm bugs found: {}".format(impetus_bugs["rpm"]))
+
         # optional operators bugs should be swept to the "extras" advisory, while other bugs should be swept to "image" advisory.
         # a way to identify operator-related bugs is by its "Component" value. temporarily hardcode here until we need to move it to ocp-build-data.
         extra_components = {"Logging", "Service Brokers", "Metering Operator", "Node Feature Discovery Operator"}  # we will probably find more

--- a/elliottlib/cli/find_bugs_cli.py
+++ b/elliottlib/cli/find_bugs_cli.py
@@ -242,6 +242,7 @@ advisory with the --add option.
         impetus_bugs["rpm"] = set(bugs)
     else:  # for 4.x
         # sweep rpm cve trackers into "rpm" advisory
+        rpm_bugs = dict()
         if mode == 'sweep' and cve_trackers:
             rpm_bugs = bzutil.get_valid_rpm_cves(bugs)
             green_prefix("RPM CVEs found: ")

--- a/elliottlib/errata.py
+++ b/elliottlib/errata.py
@@ -426,7 +426,7 @@ def add_bugs_with_retry(advisory, bugs, retried=False, noop=False):
     :return:
     """
     if noop:
-        print(f'Would have added the following bugs to advisory {advisory}: {[bug.id for bug in bugs]}')
+        print(f'Would have added the following bugs to advisory {advisory}: {sorted(bug.id for bug in bugs)}')
         return
 
     try:


### PR DESCRIPTION
**Summary**
- https://issues.redhat.com/browse/ART-2592
- This is a change to elliott find-bugs sweep functionality (see the full command below), to detect rpm cve tracker bugs and attach those to the rpm advisory
- The bugs are validated against brew builds attached to advisory. If builds are not found then bugs are not attached, so the ideal sweep workflow needed for this change would be sweep builds and then sweep bugs.

**Status**
- [X] Code changes
- ~~Some unit tests~~ - No unit tests exist for find bugs - would do a follow up story after current refactoring see https://github.com/openshift/elliott/pull/177
- [X] Prepare_release job changes if needed - https://github.com/openshift/aos-cd-jobs/pull/2531

**Testing:**
- `./elliott -g openshift-4.6 find-bugs --mode sweep --cve-trackers --into-default-advisories --check-builds --dry-run`
- `./elliott -g openshift-4.7 find-builds -k rpm` <- verify it runs after refactoring