### PR TITLE
ART-2445 Add find-bugs mode to check for blocker bugs

### DIFF
--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -223,7 +223,8 @@ def search_for_bugs(bz_data, status, search_filter='default', flag=None, filter_
     :param bz_data: The Bugzilla data dump we got from our bugzilla.yaml file
     :param status: The status(es) of bugs to search for
     :param search_filter: Which search filter from bz_data to use if multiple are specified
-    :param flag: A specific flag to filter out bugs
+    :param flag: The Bugzilla flag (string) of bugs to search for. Flags are similar to status but are categorically
+    different. https://bugzilla.readthedocs.io/en/latest/using/understanding.html#flags
     :param filter_out_security_bugs: Boolean on whether to filter out bugs tagged with the SecurityTracking keyword.
 
     :return: A list of Bug objects

--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -217,18 +217,19 @@ def create_placeholder(bz_data, kind):
     return newbug
 
 
-def search_for_bugs(bz_data, status, search_filter='default', filter_out_security_bugs=True, verbose=False):
+def search_for_bugs(bz_data, status, search_filter='default', flag=None, filter_out_security_bugs=True, verbose=False):
     """Search the provided target_release's for bugs in the specified states
 
     :param bz_data: The Bugzilla data dump we got from our bugzilla.yaml file
     :param status: The status(es) of bugs to search for
     :param search_filter: Which search filter from bz_data to use if multiple are specified
+    :param flag: A specific flag to filter out bugs
     :param filter_out_security_bugs: Boolean on whether to filter out bugs tagged with the SecurityTracking keyword.
 
     :return: A list of Bug objects
     """
     bzapi = get_bzapi(bz_data)
-    query_url = _construct_query_url(bz_data, status, search_filter)
+    query_url = _construct_query_url(bz_data, status, search_filter, flag=flag)
 
     fields = ['id', 'status', 'summary', 'creation_time', 'cf_pm_score', 'component', 'external_bugs']
 
@@ -327,7 +328,7 @@ def get_bzapi(bz_data, interactive_login=False):
     return bzapi
 
 
-def _construct_query_url(bz_data, status, search_filter='default'):
+def _construct_query_url(bz_data, status, search_filter='default', flag=None):
     query_url = SearchURL(bz_data)
 
     if bz_data.get('filter'):
@@ -343,6 +344,9 @@ def _construct_query_url(bz_data, status, search_filter='default'):
 
     for r in bz_data.get('target_release', []):
         query_url.addTargetRelease(r)
+
+    if flag:
+        query_url.addFlagFilter(flag, "substring")
 
     return query_url
 
@@ -429,6 +433,9 @@ class SearchURL(object):
 
     def addFilter(self, field, operator, value):
         self.filters.append(SearchFilter(field, operator, value))
+
+    def addFlagFilter(self, flag, operator):
+        self.filters.append(SearchFilter("flagtypes.name", operator, flag))
 
     def addTargetRelease(self, release_string):
         self.target_releases.append(release_string)


### PR DESCRIPTION
## Links
- https://issues.redhat.com/browse/ART-2445
- Previous PR https://github.com/openshift/aos-cd-jobs/pull/2519

## Summary:
This PR adds a new mode to find-bugs 'blocker', which looks up blocker bugs for a group. 
- By default cve trackers are included
- Also a new flag `--exclude-status` which lets you exclude bug status

## TODO:
- [X] The list of component filters in story is different from what we have in bugzilla.yml, ~~make sure that bugzilla.yml is updated with that~~ After discussion with @sosiouxme we agreed to use the "default" component filter list in bugzilla.yml without any modification, since that is what ART uses in other places. The list could be changed/modified in the future accordingly.
- [x] prepare-release and promote job PR https://github.com/openshift/aos-cd-jobs/pull/2534

## Test
- `./elliott -g openshift-4.7 find-bugs --mode blocker --report`
- `./elliott -g openshift-4.7 find-bugs --mode blocker --exclude-status ON_QA --report`