### PR TITLE
Deprecate legacy CA

### DIFF
--- a/.devcontainer/brewkoji.conf
+++ b/.devcontainer/brewkoji.conf
@@ -10,4 +10,3 @@ weburl = https://brewweb.engineering.redhat.com/brew
 topurl = http://download.devel.redhat.com/brewroot
 use_fast_upload = yes
 anon_retry = yes
-serverca = /etc/pki/brew/legacy.crt


### PR DESCRIPTION
It is not used in latest brew and broken on new brew installation.