### PR TITLE
Show existing and new bugs when sweeping

### DIFF
--- a/elliottlib/cli/attach_cve_flaws_cli.py
+++ b/elliottlib/cli/attach_cve_flaws_cli.py
@@ -116,8 +116,15 @@ def attach_cve_flaws_cli(runtime, advisory_id, noop, default_advisory_type):
         advisory.update(security_impact=highest_impact)
 
     flaw_ids = [flaw_bug.id for flaw_bug in first_fix_flaw_bugs]
-    runtime.logger.info('Adding the following BZs to the advisory: {}'.format(flaw_ids))
-    advisory.addBugs(flaw_ids)
+    
+    runtime.logger.info(f'Request to attach {len(flaw_ids)} bugs to the advisory')
+    existing_bug_ids = advisory.errata_bugs
+    new_bugs = set(flaw_ids) - set(existing_bug_ids)
+    print(f'Bugs already attached: {len(existing_bug_ids)}')
+    print(f'New bugs ({len(new_bugs)}) : {sorted(new_bugs)}')
+    
+    if new_bugs:
+        advisory.addBugs(flaw_ids)
 
     if noop:
         print('DRY-RUN: The following changes would have been applied to the advisory:')

--- a/elliottlib/cli/attach_cve_flaws_cli.py
+++ b/elliottlib/cli/attach_cve_flaws_cli.py
@@ -116,13 +116,13 @@ def attach_cve_flaws_cli(runtime, advisory_id, noop, default_advisory_type):
         advisory.update(security_impact=highest_impact)
 
     flaw_ids = [flaw_bug.id for flaw_bug in first_fix_flaw_bugs]
-    
+
     runtime.logger.info(f'Request to attach {len(flaw_ids)} bugs to the advisory')
     existing_bug_ids = advisory.errata_bugs
     new_bugs = set(flaw_ids) - set(existing_bug_ids)
     print(f'Bugs already attached: {len(existing_bug_ids)}')
     print(f'New bugs ({len(new_bugs)}) : {sorted(new_bugs)}')
-    
+
     if new_bugs:
         advisory.addBugs(flaw_ids)
 


### PR DESCRIPTION
## Summary
This is a small modification for the attach bugs commands in elliott.
- `find-bugs --mode sweep`
- `attach-cve-flaws`

Now it shows exactly which bugs are new and not already attached to an advisory. It also happens in the --dry-run mode, so you can see what exactly will happen without actually running it.
 
There was no story for it, but I found this to be a feature I sorely needed to see what was actually changing in an advisory, when manually running those commands. This allows ARTists to run those commands with `--dry-run` and see what modification they would've made. Sometimes bugs are manually attached/dropped and reattaching old dropped bugs or new bugs unintentionally is problematic (more so in case of cve flaws in which case we have to get ProdSec to drop them).

Implementation-wise, I tried to find if there was a diff method in errata_tool (to show state changes before advisory.commit()) but couldn't find one. If you think that exists or know something otherwise, do leave feedback.

## Test
- `elliott -g openshift-4.6 find-bugs --mode sweep --cve-trackers --check-builds --into-default-advisories --dry-run`
- `elliott -g openshift-4.6 attach-cve-flaws --use-default-advisory image --dry-run`