### PR TITLE
Sweep builds by brew event

### DIFF
--- a/elliottlib/brew.py
+++ b/elliottlib/brew.py
@@ -183,7 +183,7 @@ def get_brew_build(nvr, product_version='', session=None):
             msg=res.text))
 
 
-def find_unshipped_build_candidates(base_tag, kind='rpm', brew_session=koji.ClientSession(constants.BREW_HUB)):
+def find_unshipped_build_candidates(base_tag, event: Optional[int], kind='rpm', brew_session=koji.ClientSession(constants.BREW_HUB)):
     """Find builds for a product and return a list of the builds only
     labeled with the -candidate tag that aren't attached to any open
     advisory.
@@ -204,8 +204,8 @@ def find_unshipped_build_candidates(base_tag, kind='rpm', brew_session=koji.Clie
     :return: A set of build strings where each build is only tagged as
     a -candidate build
     """
-    shipped_builds_set = {b['nvr'] for b in brew_session.listTagged(tag=base_tag, latest=True, type=kind)}
-    candidate_builds = {b['nvr']: b for b in brew_session.listTagged(tag=f'{base_tag}-candidate',
+    shipped_builds_set = {b['nvr'] for b in brew_session.listTagged(tag=base_tag, event=event, latest=True, type=kind)}
+    candidate_builds = {b['nvr']: b for b in brew_session.listTagged(tag=f'{base_tag}-candidate', event=event,
                                                                          latest=True, type=kind)}
     candidate_builds_set = candidate_builds.keys()
     diff_builds = {}

--- a/elliottlib/brew.py
+++ b/elliottlib/brew.py
@@ -45,7 +45,7 @@ def get_tagged_builds(tags: Iterable[str], build_type: Optional[str], event: Opt
     return [build for task in tasks for build in task.result]
 
 
-def get_latest_builds(tag_component_tuples: List[Tuple[str, str]], event: Optional[int], session: koji.ClientSession) \
+def get_latest_builds(tag_component_tuples: List[Tuple[str, str]], session: koji.ClientSession, event: Optional[int] = None) \
         -> List[Optional[List[Dict]]]:
     """ Get latest builds for multiple Brew components
 
@@ -183,7 +183,7 @@ def get_brew_build(nvr, product_version='', session=None):
             msg=res.text))
 
 
-def find_unshipped_build_candidates(base_tag, event, kind='rpm', brew_session=koji.ClientSession(constants.BREW_HUB)):
+def find_unshipped_build_candidates(base_tag, kind='rpm', session=koji.ClientSession(constants.BREW_HUB), event: Optional[int] = None):
     """Find builds for a product and return a list of the builds only
     labeled with the -candidate tag that aren't attached to any open
     advisory.
@@ -192,10 +192,10 @@ def find_unshipped_build_candidates(base_tag, event, kind='rpm', brew_session=ko
     builds. This is combined with '-candidate' to return the build
     difference.
 
-    :param int event: The brew event by which to limit builds by
-
     :param str kind: Search for RPM builds by default. 'image' is also
     acceptable (In elliott we only use this function for rpm)
+
+    :param int event: The brew event by which to limit builds by
 
     For example, if `base_tag` is 'rhaos-3.7-rhel7' then this will
     look for two sets of tagged builds:
@@ -209,8 +209,8 @@ def find_unshipped_build_candidates(base_tag, event, kind='rpm', brew_session=ko
     if event:
         event = int(event)
 
-    shipped_builds_set = {b['nvr'] for b in brew_session.listTagged(tag=base_tag, event=event, latest=True, type=kind)}
-    candidate_builds = {b['nvr']: b for b in brew_session.listTagged(tag=f'{base_tag}-candidate', event=event, latest=True, type=kind)}
+    shipped_builds_set = {b['nvr'] for b in session.listTagged(tag=base_tag, event=event, latest=True, type=kind)}
+    candidate_builds = {b['nvr']: b for b in session.listTagged(tag=f'{base_tag}-candidate', event=event, latest=True, type=kind)}
     candidate_builds_set = candidate_builds.keys()
     diff_builds = {}
     for nvr in candidate_builds_set - shipped_builds_set:

--- a/elliottlib/brew.py
+++ b/elliottlib/brew.py
@@ -46,7 +46,7 @@ def get_tagged_builds(tags: Iterable[str], build_type: Optional[str], event: Opt
 
 
 def get_latest_builds(tag_component_tuples: List[Tuple[str, str]], event: Optional[int], session: koji.ClientSession) \
-    -> List[Optional[List[Dict]]]:
+        -> List[Optional[List[Dict]]]:
     """ Get latest builds for multiple Brew components
 
     :param tag_component_tuples: List of (tag, component_name) tuples

--- a/elliottlib/brew.py
+++ b/elliottlib/brew.py
@@ -45,20 +45,25 @@ def get_tagged_builds(tags: Iterable[str], build_type: Optional[str], event: Opt
     return [build for task in tasks for build in task.result]
 
 
-def get_latest_builds(tag_component_tuples: List[Tuple[str, str]], session: koji.ClientSession) -> List[Optional[List[Dict]]]:
+def get_latest_builds(tag_component_tuples: List[Tuple[str, str]], event: Optional[int], session: koji.ClientSession) \
+    -> List[Optional[List[Dict]]]:
     """ Get latest builds for multiple Brew components
 
     :param tag_component_tuples: List of (tag, component_name) tuples
+    :param event: Brew event ID, or None for now.
     :param session: instance of Brew session
     :return: a list Koji/Brew build objects
     """
+    if event:
+        event = int(event)
+
     tasks = []
     with session.multicall(strict=True) as m:
         for tag, component_name in tag_component_tuples:
             if not (tag and component_name):
                 tasks.append(None)
                 continue
-            tasks.append(m.getLatestBuilds(tag, package=component_name))
+            tasks.append(m.getLatestBuilds(tag, event=event, package=component_name))
     return [task.result if task else None for task in tasks]
 
 

--- a/elliottlib/brew.py
+++ b/elliottlib/brew.py
@@ -192,6 +192,8 @@ def find_unshipped_build_candidates(base_tag, event: Optional[int], kind='rpm', 
     builds. This is combined with '-candidate' to return the build
     difference.
 
+    :param int event: The brew event by which to limit builds by
+
     :param str kind: Search for RPM builds by default. 'image' is also
     acceptable (In elliott we only use this function for rpm)
 
@@ -204,6 +206,9 @@ def find_unshipped_build_candidates(base_tag, event: Optional[int], kind='rpm', 
     :return: A set of build strings where each build is only tagged as
     a -candidate build
     """
+    if event:
+        event = int(event)
+
     shipped_builds_set = {b['nvr'] for b in brew_session.listTagged(tag=base_tag, event=event, latest=True, type=kind)}
     candidate_builds = {b['nvr']: b for b in brew_session.listTagged(tag=f'{base_tag}-candidate', event=event,
                                                                          latest=True, type=kind)}

--- a/elliottlib/brew.py
+++ b/elliottlib/brew.py
@@ -183,7 +183,7 @@ def get_brew_build(nvr, product_version='', session=None):
             msg=res.text))
 
 
-def find_unshipped_build_candidates(base_tag, event: Optional[int], kind='rpm', brew_session=koji.ClientSession(constants.BREW_HUB)):
+def find_unshipped_build_candidates(base_tag, event, kind='rpm', brew_session=koji.ClientSession(constants.BREW_HUB)):
     """Find builds for a product and return a list of the builds only
     labeled with the -candidate tag that aren't attached to any open
     advisory.
@@ -210,8 +210,7 @@ def find_unshipped_build_candidates(base_tag, event: Optional[int], kind='rpm', 
         event = int(event)
 
     shipped_builds_set = {b['nvr'] for b in brew_session.listTagged(tag=base_tag, event=event, latest=True, type=kind)}
-    candidate_builds = {b['nvr']: b for b in brew_session.listTagged(tag=f'{base_tag}-candidate', event=event,
-                                                                         latest=True, type=kind)}
+    candidate_builds = {b['nvr']: b for b in brew_session.listTagged(tag=f'{base_tag}-candidate', event=event, latest=True, type=kind)}
     candidate_builds_set = candidate_builds.keys()
     diff_builds = {}
     for nvr in candidate_builds_set - shipped_builds_set:

--- a/elliottlib/cli/find_builds_cli.py
+++ b/elliottlib/cli/find_builds_cli.py
@@ -305,7 +305,7 @@ def _fetch_builds_by_kind_rpm(tag_pv_map, brew_event, brew_session):
         else:
             red_print("key of brew_tag_product_version_mapping in erratatool.yml must be candidate\n")
             continue
-        candidates = elliottlib.brew.find_unshipped_build_candidates(base_tag, brew_event, brew_session)
+        candidates = elliottlib.brew.find_unshipped_build_candidates(base_tag, brew_event, kind='rpm', brew_session=brew_session)
         rpm_tuple.extend(_gen_nvrp_tuples(candidates, tag_pv_map, tag))
     return rpm_tuple
 

--- a/elliottlib/cli/find_builds_cli.py
+++ b/elliottlib/cli/find_builds_cli.py
@@ -70,7 +70,7 @@ pass_runtime = click.make_pass_decorator(Runtime)
     help='Only attach non-payload images')
 @click.option(
     '--brew-event', required=False,
-    help='Lock koji clients from runtime to this brew event')
+    help='Query brew at this time in the past, defined by the eventID')
 @pass_runtime
 def find_builds_cli(runtime, advisory, default_advisory_type, builds, kind, from_diff, as_json, allow_attached,
                     remove, clean, no_cdn_repos, payload, non_payload, brew_event):

--- a/elliottlib/cli/find_builds_cli.py
+++ b/elliottlib/cli/find_builds_cli.py
@@ -68,8 +68,12 @@ pass_runtime = click.make_pass_decorator(Runtime)
 @click.option(
     '--non-payload', required=False, is_flag=True,
     help='Only attach non-payload images')
+@click.option(
+    '--brew-event', required=False,
+    help='Lock koji clients from runtime to this brew event')
 @pass_runtime
-def find_builds_cli(runtime, advisory, default_advisory_type, builds, kind, from_diff, as_json, allow_attached, remove, clean, no_cdn_repos, payload, non_payload):
+def find_builds_cli(runtime, advisory, default_advisory_type, builds, kind, from_diff, as_json, allow_attached,
+                    remove, clean, no_cdn_repos, payload, non_payload, brew_event):
     '''Automatically or manually find or attach/remove viable rpm or image builds
 to ADVISORY. Default behavior searches Brew for viable builds in the
 given group. Provide builds manually by giving one or more --build
@@ -149,7 +153,8 @@ PRESENT advisory. Here are some examples:
         unshipped_nvrps = _fetch_builds_from_diff(from_diff[0], from_diff[1], tag_pv_map)
     else:
         if kind == 'image':
-            unshipped_nvrps = _fetch_builds_by_kind_image(runtime, tag_pv_map, brew_session, payload, non_payload)
+            unshipped_nvrps = _fetch_builds_by_kind_image(runtime, tag_pv_map, brew_event, brew_session, payload,
+                                                          non_payload)
         elif kind == 'rpm':
             unshipped_nvrps = _fetch_builds_by_kind_rpm(tag_pv_map, brew_session)
 
@@ -255,7 +260,7 @@ def _fetch_builds_from_diff(from_payload, to_payload, tag_pv_map):
     return _fetch_nvrps_by_nvr_or_id(nvrs, tag_pv_map)
 
 
-def _fetch_builds_by_kind_image(runtime, tag_pv_map, brew_session, p, np):
+def _fetch_builds_by_kind_image(runtime, tag_pv_map, brew_event, brew_session, p, np):
     # filter out image like 'openshift-enterprise-base'
     image_metas = [i for i in runtime.image_metas() if not i.base_only]
     # Returns a list of (name, version, release, product_version) tuples of each build
@@ -279,7 +284,7 @@ def _fetch_builds_by_kind_image(runtime, tag_pv_map, brew_session, p, np):
         'Generating list of images: ',
         f'Hold on a moment, fetching Brew builds for {len(image_metas)} components with tags {", ".join(tag_pv_map.keys())}...',
         tag_component_tuples)
-    latest_builds = brew.get_latest_builds(tag_component_tuples, brew_session)
+    latest_builds = brew.get_latest_builds(tag_component_tuples, brew_event, brew_session)
 
     for i, build in enumerate(latest_builds):
         if not build:

--- a/elliottlib/cli/find_builds_cli.py
+++ b/elliottlib/cli/find_builds_cli.py
@@ -156,7 +156,7 @@ PRESENT advisory. Here are some examples:
             unshipped_nvrps = _fetch_builds_by_kind_image(runtime, tag_pv_map, brew_event, brew_session, payload,
                                                           non_payload)
         elif kind == 'rpm':
-            unshipped_nvrps = _fetch_builds_by_kind_rpm(tag_pv_map, brew_session)
+            unshipped_nvrps = _fetch_builds_by_kind_rpm(tag_pv_map, brew_event, brew_session)
 
     pbar_header(
         'Fetching builds from Errata: ',

--- a/elliottlib/cli/find_builds_cli.py
+++ b/elliottlib/cli/find_builds_cli.py
@@ -295,7 +295,7 @@ def _fetch_builds_by_kind_image(runtime, tag_pv_map, brew_event, brew_session, p
     return nvrps
 
 
-def _fetch_builds_by_kind_rpm(tag_pv_map, brew_session):
+def _fetch_builds_by_kind_rpm(tag_pv_map, brew_event, brew_session):
     green_prefix('Generating list of rpms: ')
     click.echo('Hold on a moment, fetching Brew builds')
     rpm_tuple = []
@@ -305,7 +305,7 @@ def _fetch_builds_by_kind_rpm(tag_pv_map, brew_session):
         else:
             red_print("key of brew_tag_product_version_mapping in erratatool.yml must be candidate\n")
             continue
-        candidates = elliottlib.brew.find_unshipped_build_candidates(base_tag, brew_session=brew_session)
+        candidates = elliottlib.brew.find_unshipped_build_candidates(base_tag, brew_event, brew_session)
         rpm_tuple.extend(_gen_nvrp_tuples(candidates, tag_pv_map, tag))
     return rpm_tuple
 

--- a/elliottlib/cli/find_builds_cli.py
+++ b/elliottlib/cli/find_builds_cli.py
@@ -284,7 +284,7 @@ def _fetch_builds_by_kind_image(runtime, tag_pv_map, brew_event, brew_session, p
         'Generating list of images: ',
         f'Hold on a moment, fetching Brew builds for {len(image_metas)} components with tags {", ".join(tag_pv_map.keys())}...',
         tag_component_tuples)
-    latest_builds = brew.get_latest_builds(tag_component_tuples, brew_event, brew_session)
+    latest_builds = brew.get_latest_builds(tag_component_tuples, event=brew_event, session=brew_session)
 
     for i, build in enumerate(latest_builds):
         if not build:
@@ -305,7 +305,7 @@ def _fetch_builds_by_kind_rpm(tag_pv_map, brew_event, brew_session):
         else:
             red_print("key of brew_tag_product_version_mapping in erratatool.yml must be candidate\n")
             continue
-        candidates = elliottlib.brew.find_unshipped_build_candidates(base_tag, brew_event, kind='rpm', brew_session=brew_session)
+        candidates = elliottlib.brew.find_unshipped_build_candidates(base_tag, event=brew_event, kind='rpm', session=brew_session)
         rpm_tuple.extend(_gen_nvrp_tuples(candidates, tag_pv_map, tag))
     return rpm_tuple
 

--- a/tests/test_brew.py
+++ b/tests/test_brew.py
@@ -266,7 +266,7 @@ class TestBrew(unittest.TestCase):
             {"name": "component6", "nvr": "component6-v1.0.0-1.faketag2"},
         ]
 
-        def fake_response(tag, package):
+        def fake_response(tag, package, event=None):
             return mock.MagicMock(result={"name": package, "nvr": f"{package}-v1.0.0-1.{tag}"})
 
         fake_session = mock.MagicMock()


### PR DESCRIPTION
This is a change that will help us not sweep the latest builds for all packages, which will help us in scenarios like we faced today (april 5th) when preparing 4.6 advisories. Which was that we had nightlies for 4.6 already that we wanted to use. But before automation could be frozen, ocp4 job triggered and started building again, it build some packages and then failed for some. Brew outage also responsible for other failures. 

The point is even if we had all success builds, we would still want the option of using builds from a point of time in the past. And in cases like partial builds succeeding, this would be critical.

---

In order to sweep latest builds for a (tag, package) combo we need to give an event id (similar to a timestamp) to brew methods. Luckily the method we are using for sweeping image builds supports it. 

This event id can be found by multiple ways, one of which is the creation_event_id of getBuild()

Todo:
[X] works with -k image
[X] works with -k rpm

Test
- `brew list-history --tag=rhaos-4.6-rhel-8-candidate --after="2021-04-27" -e`
- `./elliott -g openshift-4.6 find-builds -k image --brew-event 38753378`
- `./elliott -g openshift-4.6 find-builds -k rpm --brew-event 38753378`