### PR TITLE
ART-2927: find-builds basic assembly awareness

### DIFF
--- a/.devcontainer/dev.Dockerfile
+++ b/.devcontainer/dev.Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:33
+FROM fedora:34
 LABEL name="elliott-dev" \
   description="Elliott development container image" \
   maintainer="OpenShift Automated Release Tooling (ART) Team <aos-team-art@redhat.com>"

--- a/elliottlib/cli/common.py
+++ b/elliottlib/cli/common.py
@@ -36,6 +36,9 @@ context_settings = dict(help_option_names=['-h', '--help'])
     '--group', '-g',
     default=None, metavar='NAME',
     help='The group of images on which to operate.')
+@click.option("--assembly", metavar="ASSEMBLY_NAME", default='stream',
+              help="The name of an assembly to rebase & build for. Assemblies must be enabled in group.yml or with --enable-assemblies.")
+@click.option('--enable-assemblies', default=False, is_flag=True, help='Enable assemblies even if not enabled in group.yml. Primarily for testing purposes.')
 @click.option(
     '--branch',
     default=None, metavar='BRANCH',

--- a/elliottlib/cli/verify_attached_operators_cli.py
+++ b/elliottlib/cli/verify_attached_operators_cli.py
@@ -124,7 +124,7 @@ def _get_shipped_images(runtime, brew_session):
     # retrieve all image builds ever shipped for this version (potential operands)
     tag = f"{runtime.branch}-container-released"
     tags = {tag, tag.replace('-rhel-7-', '-rhel-8-')}  # may be one or two depending
-    released = brew.get_tagged_builds(tags, build_type='image', event=None, session=brew_session)
+    released = brew.get_tagged_builds([(tag, None) for tag in tags], build_type='image', event=None, session=brew_session)
     released = brew.get_build_objects([b['build_id'] for b in released], session=brew_session)
     return [b for b in released if _is_image(b)]  # filter out source images
 

--- a/elliottlib/runtime.py
+++ b/elliottlib/runtime.py
@@ -42,6 +42,7 @@ class Runtime(object):
         self.verbose = False
         self.quiet = False
         self.data_path = None
+        self.assembly = 'stream'
 
         for key, val in kwargs.items():
             self.__dict__[key] = val
@@ -109,6 +110,14 @@ class Runtime(object):
         if self.group_config.name != self.group:
             raise IOError(
                 "Name in group.yml does not match group name. Someone may have copied this group without updating group.yml (make sure to check branch)")
+
+        if self.group_config.assemblies.enabled or self.enable_assemblies:
+            if re.fullmatch(r'[\w.]+', self.assembly) is None or self.assembly[0] == '.' or self.assembly[-1] == '.':
+                raise ValueError('Assembly names may only consist of alphanumerics, ., and _, but not start or end with a dot (.).')
+        else:
+            # If assemblies are not enabled for the group,
+            # ignore this argument throughout doozer.
+            self.assembly = None
 
         if self.branch is not None:
             self.logger.info("Using branch from command line: %s" % self.branch)

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Environment :: Console",
         "Operating System :: POSIX",
         "License :: OSI Approved :: Apache Software License",

--- a/tests/test_find_builds_cli.py
+++ b/tests/test_find_builds_cli.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 import unittest
-from elliottlib.cli.find_builds_cli import _filter_out_inviable_builds
+from elliottlib.cli.find_builds_cli import _filter_out_inviable_builds, _find_latest_builds, _find_shipped_builds
 from elliottlib.brew import Build
 import elliottlib
 import flexmock, json, mock
@@ -48,6 +48,47 @@ class TestFindBuildsCli(unittest.TestCase):
 
         # expect return list with one build
         self.assertEqual([Build("test-1.1.1")], _filter_out_inviable_builds("image", [builds], fake_errata))
+
+    def test_find_latest_builds(self):
+        builds = [
+            {"id": 13, "name": "a-container", "version": "v1.2.3", "release": "3.assembly.stream", "tag_name": "tag1"},
+            {"id": 12, "name": "a-container", "version": "v1.2.3", "release": "2.assembly.hotfix_a", "tag_name": "tag1"},
+            {"id": 11, "name": "a-container", "version": "v1.2.3", "release": "1.assembly.hotfix_a", "tag_name": "tag1"},
+            {"id": 23, "name": "b-container", "version": "v1.2.3", "release": "3.assembly.test", "tag_name": "tag1"},
+            {"id": 22, "name": "b-container", "version": "v1.2.3", "release": "2.assembly.hotfix_b", "tag_name": "tag1"},
+            {"id": 21, "name": "b-container", "version": "v1.2.3", "release": "1.assembly.stream", "tag_name": "tag1"},
+            {"id": 33, "name": "c-container", "version": "v1.2.3", "release": "3", "tag_name": "tag1"},
+            {"id": 32, "name": "c-container", "version": "v1.2.3", "release": "2.assembly.hotfix_b", "tag_name": "tag1"},
+            {"id": 31, "name": "c-container", "version": "v1.2.3", "release": "1", "tag_name": "tag1"},
+        ]
+        actual = _find_latest_builds(builds, "stream")
+        self.assertEqual([13, 21, 33], [b["id"] for b in actual])
+
+        actual = _find_latest_builds(builds, "hotfix_a")
+        self.assertEqual([12, 21, 33], [b["id"] for b in actual])
+
+        actual = _find_latest_builds(builds, "hotfix_b")
+        self.assertEqual([13, 22, 32], [b["id"] for b in actual])
+
+        actual = _find_latest_builds(builds, "test")
+        self.assertEqual([13, 23, 33], [b["id"] for b in actual])
+
+        actual = _find_latest_builds(builds, None)
+        self.assertEqual([13, 23, 33], [b["id"] for b in actual])
+
+    @mock.patch("elliottlib.brew.get_builds_tags")
+    def test_find_shipped_builds(self, get_builds_tags: mock.MagicMock):
+        build_ids = [11, 12, 13]
+        build_tags = [
+            [{"name": "foo-candidate"}],
+            [{"name": "bar-candidate"}, {"name": "bar-released"}],
+            [],
+        ]
+        get_builds_tags.return_value = build_tags
+        expected = {12}
+        actual = _find_shipped_builds(build_ids, mock.MagicMock())
+        self.assertEqual(expected, actual)
+        get_builds_tags.assert_called_once_with(build_ids, mock.ANY)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- If assemblies feature is disabled, find-builds should keep the current
  behavior (attaching latest builds in -candidate Brew tags).

- Running elliott, without an assembly parameter should only attach images/rpms to advisories if they have .assembly.stream or, if no .assembly.stream exists, then the latest build without .assembly in the RELEASE field.

- Running elliott with an assembly parameter should prefer builds with that assembly in the RELEASE field.