### PR TITLE
ART-2718: When switching to RHSA set the appropriate Impact in the topic

### DIFF
--- a/elliottlib/cli/attach_cve_flaws_cli.py
+++ b/elliottlib/cli/attach_cve_flaws_cli.py
@@ -86,16 +86,17 @@ def attach_cve_flaws_cli(runtime, advisory_id, noop, default_advisory_type):
         runtime.logger.info('No "first-fix" bugs found, exiting')
         exit(0)
 
+    cve_boilerplate = runtime.gitdata.load_data(key='erratatool').data['boilerplates']['cve']
+
     advisory = Erratum(errata_id=advisory_id)
     if not is_security_advisory(advisory):
         runtime.logger.info('Advisory type is {}, converting it to RHSA'.format(advisory.errata_type))
-        cve_boilerplate = runtime.gitdata.load_data(key='erratatool').data['boilerplates']['cve']
         advisory.update(
             errata_type='RHSA',
             security_reviewer=cve_boilerplate['security_reviewer'],
             synopsis=cve_boilerplate['synopsis'],
             description=cve_boilerplate['description'],
-            topic=cve_boilerplate['topic'],
+            topic=cve_boilerplate['topic'].format(IMPACT="Low"),
             solution=cve_boilerplate['solution'],
             security_impact='Low',
         )
@@ -109,11 +110,15 @@ def attach_cve_flaws_cli(runtime, advisory_id, noop, default_advisory_type):
     runtime.logger.info('List of *new* CVEs: {}'.format(cves))
 
     highest_impact = get_highest_security_impact(first_fix_flaw_bugs)
-    if is_advisory_impact_smaller_than(advisory, highest_impact):
-        runtime.logger.info('Adjusting advisory security impact from {} to {}'.format(
-            advisory.security_impact, highest_impact
-        ))
-        advisory.update(security_impact=highest_impact)
+    runtime.logger.info('Adjusting advisory security impact from {} to {}'.format(
+        advisory.security_impact, highest_impact
+    ))
+    advisory.update(security_impact=highest_impact)
+
+    if highest_impact not in advisory.topic:
+        topic = cve_boilerplate['topic'].format(IMPACT=highest_impact)
+        runtime.logger.info('Topic updated to include impact of {}'.format(highest_impact))
+        advisory.update(topic=topic)
 
     flaw_ids = [flaw_bug.id for flaw_bug in first_fix_flaw_bugs]
 
@@ -128,7 +133,7 @@ def attach_cve_flaws_cli(runtime, advisory_id, noop, default_advisory_type):
 
     if noop:
         print('DRY-RUN: The following changes would have been applied to the advisory:')
-        print(advisory)
+        print(advisory.dump())
         return True
 
     return advisory.commit()


### PR DESCRIPTION
Reworking of https://github.com/openshift/elliott/pull/188 to use existing templating feature of ocp_build_data.