### PR TITLE
find-builds: Fix exception in log output

### DIFF
--- a/elliottlib/cli/find_builds_cli.py
+++ b/elliottlib/cli/find_builds_cli.py
@@ -333,9 +333,9 @@ def _fetch_builds_by_kind_image(runtime: Runtime, tag_pv_map: Dict[str, str], br
     brew_builds = brew.get_tagged_builds(tag_component_tuples, "image", event=brew_event, session=brew_session)
     brew_latest_builds = list(_find_latest_builds(brew_builds, runtime.assembly))
 
-    click.echo(f'Found {len(brew_latest_builds)} builds. Filtering out shipped builds...')
     shipped = _find_shipped_builds([b["id"] for b in brew_latest_builds], brew_session)
     unshipped = [b for b in brew_latest_builds if b["id"] not in shipped]
+    click.echo(f'Found {len(shipped)+len(unshipped)} builds, of which {len(unshipped)} are new.')
     nvrps = _gen_nvrp_tuples(unshipped, tag_pv_map)
     return nvrps
 
@@ -347,9 +347,9 @@ def _fetch_builds_by_kind_rpm(runtime: Runtime, tag_pv_map: Dict[str, str], brew
     brew_builds = brew.get_tagged_builds(tag_component_tuples, "rpm", event=brew_event, session=brew_session)
     brew_latest_builds = _find_latest_builds(brew_builds, runtime.assembly)
 
-    click.echo(f'Found {len(brew_latest_builds)} builds. Filtering out shipped builds...')
     shipped = _find_shipped_builds([b["id"] for b in brew_latest_builds], brew_session)
     unshipped = [b for b in brew_latest_builds if b["id"] not in shipped]
+    click.echo(f'Found {len(shipped)+len(unshipped)} builds, of which {len(unshipped)} are new.')
     nvrps = _gen_nvrp_tuples(unshipped, tag_pv_map)
     return nvrps
 


### PR DESCRIPTION
```
...
    click.echo(f'Found {len(brew_latest_builds)} builds. Filtering out shipped builds...')
TypeError: object of type 'generator' has no len()
```