### PR TITLE
ART-3057: find-bugs basis Brew event awareness

### DIFF
--- a/elliottlib/cli/find_bugs_cli.py
+++ b/elliottlib/cli/find_bugs_cli.py
@@ -1,9 +1,6 @@
-from __future__ import absolute_import, print_function, unicode_literals
-
 import datetime
-import itertools
 import re
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import List
 
 import click
@@ -18,7 +15,6 @@ from elliottlib.cli.common import (cli, find_default_advisory,
 from elliottlib.exceptions import ElliottFatalError
 from elliottlib.util import green_prefix, green_print, red_prefix
 
-LOGGER = logutil.getLogger(__name__)
 pass_runtime = click.make_pass_decorator(Runtime)
 
 
@@ -71,7 +67,7 @@ pass_runtime = click.make_pass_decorator(Runtime)
               is_flag=True,
               help='attaches bugs found to their correct default advisories, e.g. operator-related bugs go to "extras" instead of the default "image", bugs filtered into "none" are not attached at all.')
 @click.option('--brew-event', type=click.INT, required=False,
-              help='Query brew at this time in the past, defined by the eventID')
+              help='only sweep bugs that have changed to the desired status before the Brew event ID; not applies to list or diff mode')
 @click.option("--noop", "--dry-run",
               is_flag=True,
               default=False,
@@ -214,62 +210,11 @@ advisory with the --add option.
 
         if brew_event:
             brew_api = koji.ClientSession(runtime.group_config.urls.brewhub or constants.BREW_HUB)
-            basis_timestamp = brew_api.getEvent(brew_event)["ts"]
+            sweep_cutoff_timestamp = brew_api.getEvent(brew_event)["ts"]
 
-            def to_timestamp(dt):
-                """ Converts xmlrpc.client.DateTime to timestamp """
-                return datetime.strptime(dt.value, "%Y%m%dT%H:%M:%S").replace(tzinfo=timezone.utc).timestamp()
-
-            # Filters out bugs that are created after the basis event
-            bugs = [bug for bug in bugs if to_timestamp(bug.creation_time) <= basis_timestamp]
-
-            # Queries bug history
-            bugs_history = bzapi.bugs_history_raw([bug.id for bug in bugs])
-
-            class BugStatusChange:
-                def __init__(self, timestamp: int, old: str, new: str) -> None:
-                    self.timestamp = timestamp  # when this change is made?
-                    self.old = old  # old status
-                    self.new = new  # new status
-
-                @classmethod
-                def from_history_ent(cls, history):
-                    """ Converts from bug history dict returned from Bugzilla to BugStatusChange object.
-                    The history dict returned from Bugzilla includes bug changes on all fields, but we are only interested in the "status" field change.
-                    :return: BugStatusChange object, or None if the history doesn't include a "status" field change.
-                    """
-                    status_change = next(filter(lambda change: change["field_name"] == "status", history["changes"]), None)
-                    return cls(to_timestamp(history["when"]), status_change["removed"], status_change["added"]) if status_change else None
-
-            qualified_bugs = []
-
-            for bug, bug_history in zip(bugs, bugs_history["bugs"]):
-                assert bug.id == bug_history["id"]  # `bugs_history["bugs"]` returned by Bugzilla should have the same order as `bugs`, but to be safe
-
-                # We are only interested in "status" field changes
-                status_changes = filter(None, map(BugStatusChange.from_history_ent, bug_history["history"]))
-
-                # status changes after the basis event
-                after_basis_status_changes = list(itertools.dropwhile(lambda change: change.timestamp <= basis_timestamp, status_changes))
-
-                # `basis_status` is the status of the bug at the moment of the basis event
-                if not after_basis_status_changes:
-                    basis_status = bug.status  # no status change after the basis event; use current status
-                else:
-                    basis_status = after_basis_status_changes[0].old  # basis_status should be the old status of the first status change after the basis event
-
-                if basis_status not in status:
-                    click.echo(f"Ignore BZ {bug.id} because its status was {basis_status} at the moment of basis event {brew_event} ({datetime.utcfromtimestamp(basis_timestamp)})")
-                    continue
-
-                # Per @Justin Pierce: If a BZ seems to qualify for a sweep currently and at the basis event, then all state changes after the basis event must be to a greater than the state which qualified the BZ at the basis event.
-                regressed_changes = [change.new for change in after_basis_status_changes if constants.VALID_BUG_STATES.index(change.new) <= constants.VALID_BUG_STATES.index(basis_status)]
-                if regressed_changes:
-                    click.echo(f"Ignore BZ {bug.id} because its status was {basis_status} at the moment of basis event {brew_event} ({datetime.utcfromtimestamp(basis_timestamp)})"
-                               f", however the status changed back to {regressed_changes} afterwards")
-                    continue
-
-                qualified_bugs.append(bug)
+            green_print(f"Filtering bugs that have changed to one of the desired statuses before the given Brew event {brew_event} ({datetime.utcfromtimestamp(sweep_cutoff_timestamp)})...")
+            qualified_bugs = bzutil.filter_bugs_by_cutoff_event(bzapi, bugs, status, sweep_cutoff_timestamp)
+            click.echo(f"{len(qualified_bugs)} of {len(bugs)} bugs are qualified for the sweep cutoff Brew event {brew_event} ({datetime.utcfromtimestamp(sweep_cutoff_timestamp)})")
             bugs = qualified_bugs
 
     elif mode == 'list':

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,8 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Environment :: Console",
         "Operating System :: POSIX",
+        "Operating System :: POSIX :: Linux",
+        "Operating System :: MacOS",
         "License :: OSI Approved :: Apache Software License",
         "Intended Audience :: Developers",
         "Topic :: Software Development :: Build Tools",


### PR DESCRIPTION
According to @jupierce :

```
Let:
Z be a non-closed BZ in a monitored component
S2 be the current state (as in the moment we are scanning) of Z
S1 be the state of the Z at the moment of the basis
A be the set of state changes Z after the basis
F be the sweep states (MODIFIED, ON_QA, VERIFIED)
Then Z is swept in if all the following are true:
S1 ∈ F
S2 ∈ F
A | ∄v : v <= S1
In prose: if a BZ seems to qualify for a sweep currently and at the basis event, then all state changes after the basis event must be to a greater than the state which qualified the BZ at the basis event.
```

Note:
1. Because this PR is implemented before adding assembly lense to Elliott ([ART-3045](https://issues.redhat.com/browse/ART-3045)), the basis event in this PR is taken from the command line argument like `find-builds` verb. When [ART-3045](https://issues.redhat.com/browse/ART-3045) is landed, we can extend to read releases.yml for basis event and additional bugs defined in `assembly.issues`.
2. Unit tests will be added later.