### PR TITLE
WIP: ART-3099 Sweep ignores placeholder bugs

### DIFF
--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -365,7 +365,7 @@ def get_valid_rpm_cves(bugs):
             component_name = get_whiteboard_component(b)
             # filter out non-rpm suffixes
             if component_name and not re.search(r'-(apb|container)$', component_name):
-                rpm_cves[b] = component_name
+                rpm_cves[b.id] = {'bug': b, 'component': component_name}
     return rpm_cves
 
 

--- a/elliottlib/cli/attach_cve_flaws_cli.py
+++ b/elliottlib/cli/attach_cve_flaws_cli.py
@@ -1,4 +1,5 @@
-import bugzilla, click, re
+import bugzilla
+import click
 from errata_tool import Erratum
 from elliottlib import util, attach_cve_flaws, errata
 from elliottlib.cli.common import cli, use_default_advisory_option, find_default_advisory

--- a/elliottlib/cli/attach_cve_flaws_cli.py
+++ b/elliottlib/cli/attach_cve_flaws_cli.py
@@ -94,9 +94,13 @@ def attach_cve_flaws_cli(runtime, advisory_id, noop, default_advisory_type):
     if not bugs:
         return
 
-    cve_boilerplate = runtime.gitdata.load_data(key='erratatool').data['boilerplates']['cve']
+    cve_boilerplate = get_boilerplate(runtime.gitdata)
     advisory = get_updated_advisory_rhsa(runtime.logger, cve_boilerplate, advisory, bugs)
     return errata.add_bugs(advisory, bugs, noop)
+
+
+def get_boilerplate(gitdata):
+    return gitdata.load_data(key='erratatool').data['boilerplates']['cve']
 
 
 def get_updated_advisory_rhsa(logger, cve_boilerplate, advisory, flaw_bugs):

--- a/elliottlib/cli/find_bugs_cli.py
+++ b/elliottlib/cli/find_bugs_cli.py
@@ -1,14 +1,10 @@
 import datetime
-from subprocess import run
-from elliottlib.assembly import assembly_issues_config
+import click
 import re
 from datetime import datetime
 from typing import List, Set
-
-import click
-import koji
 from bugzilla import bug as bug_module
-
+from elliottlib.assembly import assembly_issues_config
 from elliottlib import (Runtime, bzutil, constants, errata, logutil,
                         openshiftclient)
 from elliottlib.cli import cli_opts
@@ -16,8 +12,6 @@ from elliottlib.cli.common import (cli, find_default_advisory,
                                    use_default_advisory_option)
 from elliottlib.exceptions import ElliottFatalError
 from elliottlib.util import green_prefix, green_print, red_prefix, yellow_print
-
-pass_runtime = click.make_pass_decorator(Runtime)
 
 
 @cli.command("find-bugs", short_help="Find or add MODIFED/VERIFIED bugs to ADVISORY")
@@ -74,7 +68,7 @@ pass_runtime = click.make_pass_decorator(Runtime)
               is_flag=True,
               default=False,
               help="Don't change anything")
-@pass_runtime
+@click.pass_obj
 def find_bugs_cli(runtime: Runtime, advisory, default_advisory_type, mode, check_builds, status, exclude_status, id, cve_trackers, from_diff,
                   flag, report, into_default_advisories, brew_event, noop):
     """Find Red Hat Bugzilla bugs or add them to ADVISORY. Bugs can be
@@ -176,10 +170,9 @@ advisory with the --add option.
                                  "`--use-default-advisory`, `--add`, or `--into-default-advisories`")
 
     runtime.initialize(mode="both")
-    bz_data = runtime.gitdata.load_data(key='bugzilla').data
+    bz_data = runtime.gitdata.bz().data
     bzapi = bzutil.get_bzapi(bz_data)
 
-    # filter out bugs ART does not manage
     m = re.match(r"rhaos-(\d+).(\d+)",
                  runtime.branch)  # extract OpenShift version from the branch name. there should be a better way...
     if not m:

--- a/elliottlib/constants.py
+++ b/elliottlib/constants.py
@@ -14,6 +14,8 @@ RESULTSDB_API_URL = "https://resultsdb-api.engineering.redhat.com/api/v2.0"
 VALID_BUG_STATES = ['NEW', 'ASSIGNED', 'POST', 'MODIFIED', 'ON_QA', 'VERIFIED', 'RELEASE_PENDING', 'CLOSED']
 TRACKER_BUG_KEYWORDS = ['Security', 'SecurityTracking']
 BUGZILLA_PRODUCT_OCP = 'OpenShift Container Platform'
+BUGZILLA_PLACEHOLDER_BUG_TITLE = 'Placeholder bug for OCP'
+BUGZILLA_ERRATA_LINK_STRING = 'Red Hat Errata Tool'
 BUG_SEVERITY_NUMBER_MAP = {
     "unspecified": 0,
     "low": 1,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ setuptools~=41.6.0
 -rrequirements.txt
 
 # test reqs
-flexmock~=0.10.4
+flexmock>=0.10.4
 mock~=4.0.3
 
 # tox reqs

--- a/tests/test_attach_cve_flaws_cli.py
+++ b/tests/test_attach_cve_flaws_cli.py
@@ -1,10 +1,35 @@
 import unittest
-
 import mock
+import flexmock
+from bugzilla import Bugzilla
+from errata_tool import Erratum
+from elliottlib.runtime import Runtime
+from click.testing import CliRunner
+from elliottlib.cli.common import cli
 from elliottlib.cli import attach_cve_flaws_cli
 
 
 class TestAttachCVEFlawsCLI(unittest.TestCase):
+    def test_attach_cve_flaws_cli(self):
+        runner = CliRunner()
+        # mock Runtime obj
+        runtime = flexmock(initialize=lambda: None, gitdata=flexmock(bz_server_url=lambda: "bz"))
+        flexmock(Runtime, __new__=runtime)
+
+        # mock bugzilla obj
+        bzapi = flexmock()
+        flexmock(Bugzilla, __new__=bzapi)
+
+        # mock Errata obj
+        errata = flexmock()
+        flexmock(Erratum, __new__=errata)
+
+        result = runner.invoke(cli, ['--group=openshift-17.44', 'attach-cve-flaws', '-a', 'foobar'])
+        #self.assertEqual('', result.stderr)
+        self.assertEqual('', result.exception)
+        self.assertEqual("hello", result.stdout)
+        self.assertEqual(0, result.exit_code)
+
     def test_get_updated_advisory_rhsa(self):
         boilerplate = {
             'security_reviewer': 'some reviewer',

--- a/tests/test_attach_cve_flaws_cli.py
+++ b/tests/test_attach_cve_flaws_cli.py
@@ -64,7 +64,7 @@ class TestAttachCVEFlawsCLI(unittest.TestCase):
             should_receive("add_bugs"). \
             and_return(None)
 
-        result = runner.invoke(cli, ['--group=openshift-17.44', 'attach-cve-flaws', '-a', 'foobar'])
+        result = runner.invoke(cli, ['--group=openshift-17.44', 'attach-cve-flaws', '-a', '123'])
         expected_output = '''found 1 tracker bugs attached to the advisory: [123]
 current_target_release: 4.8.z
 found 2 corresponding flaw bugs: [1, 2]

--- a/tests/test_attach_cve_flaws_cli.py
+++ b/tests/test_attach_cve_flaws_cli.py
@@ -7,13 +7,23 @@ from elliottlib.runtime import Runtime
 from click.testing import CliRunner
 from elliottlib.cli.common import cli
 from elliottlib.cli import attach_cve_flaws_cli
+from elliottlib import attach_cve_flaws
+from elliottlib import constants, util
+from elliottlib import errata as erratalib
 
 
 class TestAttachCVEFlawsCLI(unittest.TestCase):
-    def test_attach_cve_flaws_cli(self):
+    def test_attach_cve_flaws_cli_z(self):
         runner = CliRunner()
         # mock Runtime obj
-        runtime = flexmock(initialize=lambda: None, gitdata=flexmock(bz_server_url=lambda: "bz"))
+        runtime = flexmock(
+            initialize=lambda: None,
+            gitdata=flexmock(bz_server_url=lambda: "bz"),
+            logger=flexmock(
+                info=lambda x: print(x),
+                error=lambda x: print(x),
+                debug=lambda x: print(x))
+        )
         flexmock(Runtime, __new__=runtime)
 
         # mock bugzilla obj
@@ -24,10 +34,44 @@ class TestAttachCVEFlawsCLI(unittest.TestCase):
         errata = flexmock()
         flexmock(Erratum, __new__=errata)
 
+        tracker_bugs = [
+            flexmock(id=123, keywords=constants.TRACKER_BUG_KEYWORDS)
+        ]
+        flaw_bugs = [
+            flexmock(id=1), flexmock(id=2)
+        ]
+
+        flexmock(attach_cve_flaws).\
+            should_receive("get_tracker_bugs").\
+            and_return(tracker_bugs)
+        flexmock(util).\
+            should_receive("get_target_release").\
+            with_args(tracker_bugs).\
+            and_return(('4.8.z', False))
+        flexmock(attach_cve_flaws).\
+            should_receive("get_corresponding_flaw_bugs").\
+            and_return(flaw_bugs)
+        flexmock(erratalib). \
+            should_receive("filter_advisory_bugs"). \
+            and_return(flaw_bugs)
+        flexmock(attach_cve_flaws_cli).\
+            should_receive("get_boilerplate").\
+            and_return(None)
+        flexmock(attach_cve_flaws_cli). \
+            should_receive("get_updated_advisory_rhsa"). \
+            and_return(None)
+        flexmock(erratalib). \
+            should_receive("add_bugs"). \
+            and_return(None)
+
         result = runner.invoke(cli, ['--group=openshift-17.44', 'attach-cve-flaws', '-a', 'foobar'])
-        #self.assertEqual('', result.stderr)
-        self.assertEqual('', result.exception)
-        self.assertEqual("hello", result.stdout)
+        expected_output = '''found 1 tracker bugs attached to the advisory: [123]
+current_target_release: 4.8.z
+found 2 corresponding flaw bugs: [1, 2]
+detected z-stream target release, every flaw bug is considered first-fix
+2 out of 2 flaw bugs considered "first-fix"
+'''
+        self.assertEqual(expected_output, result.stdout)
         self.assertEqual(0, result.exit_code)
 
     def test_get_updated_advisory_rhsa(self):

--- a/tests/test_find_bugs_cli.py
+++ b/tests/test_find_bugs_cli.py
@@ -52,7 +52,8 @@ class TestFindBugsCli(unittest.TestCase):
         expected_output = ''
         self.assertEqual('', result.exception)
         self.assertEqual(expected_output, result.stdout)
-        #self.assertEqual(0, result.exit_code)
+        # self.assertEqual(0, result.exit_code)
+
 
 class TestExtrasBugs(unittest.TestCase):
     def test_payload_bug(self):

--- a/tests/test_find_bugs_cli.py
+++ b/tests/test_find_bugs_cli.py
@@ -11,12 +11,13 @@ class TestFindBugsCli(unittest.TestCase):
         report = False
         flags = []
         noop = False
+        bzapi = None
 
         flexmock(errata_module).\
-            should_receive("add_bugs_with_retry").\
+            should_receive("filter_and_add_bugs").\
             once()
 
-        mode_list(advisory, bugs, report, flags, noop)
+        mode_list(advisory, bugs, bzapi, report, flags, noop)
 
 
 class TestExtrasBugs(unittest.TestCase):


### PR DESCRIPTION
Sometimes when an advisory is dropped because of no shipping bugs/rpms/images, the placeholder bug lingers on if it is not closed, and unintentionally attached to an advisory. So let's avoid placeholder bugs in sweep

Another need when preparing GA advisories is to get accurate sweep dry-run output. Right now dry-run doesn't account for bugs that will fail to be attached that are already attached to another advisory. So we try to fetch advisory link from proposed bugs and filter out those that will fail anyways to provide a more accurate dry-run output.