### PR TITLE
ART-3045: Assembly lense

### DIFF
--- a/elliottlib/assembly.py
+++ b/elliottlib/assembly.py
@@ -1,0 +1,173 @@
+import copy
+import typing
+
+from elliottlib.model import Missing, Model
+
+
+def merger(a, b):
+    """
+    Merges two, potentially deep, objects into a new one and returns the result.
+    Conceptually, 'a' is layered over 'b' and is dominant when
+    necessary. The output is 'c'.
+    1. if 'a' specifies a primitive value, regardless of depth, 'c' will contain that value.
+    2. if a key in 'a' specifies a list and 'b' has the same key/list, a's list will be appended to b's for c's list.
+       Duplicates entries will be removed and primitive (str, int, ..) lists will be returned in sorted order).
+    3. if a key ending with '!' in 'a' specifies a value, c's key-! will be to set that value exactly.
+    4. if a key ending with a '?' in 'a' specifies a value, c's key-? will be set to that value is 'c' does not contain the key.
+    """
+
+    if type(a) in [bool, int, float, str, bytes, type(None)]:
+        return a
+
+    c = copy.deepcopy(b)
+
+    if type(a) is list:
+        if type(c) is not list:
+            return a
+        for entry in a:
+            if entry not in c:  # do not include duplicates
+                c.append(entry)
+
+        if c and type(c[0]) in [str, int, float]:
+            return sorted(c)
+        return c
+
+    if type(a) is dict:
+        if type(c) is not dict:
+            return a
+        for k, v in a.items():
+            if k.endswith('!'):  # full dominant key
+                k = k[:-1]
+                c[k] = v
+            elif k.endswith('?'):  # default value key
+                k = k[:-1]
+                if k not in c:
+                    c[k] = v
+            else:
+                if k in c:
+                    c[k] = merger(a[k], c[k])
+                else:
+                    c[k] = a[k]
+        return c
+
+    raise TypeError(f'Unexpected value type: {type(a)}: {a}')
+
+
+def _check_recursion(releases_config: Model, assembly: str):
+    found = []
+    next_assembly = assembly
+    while next_assembly and isinstance(releases_config, Model):
+        if next_assembly in found:
+            raise ValueError(f'Infinite recursion in {assembly} detected; {next_assembly} detected twice in chain')
+        found.append(next_assembly)
+        target_assembly = releases_config.releases[next_assembly].assembly
+        next_assembly = target_assembly.basis.assembly
+
+
+def assembly_group_config(releases_config: Model, assembly: str, group_config: Model) -> Model:
+    """
+    Returns a group config based on the assembly information
+    and the input group config.
+    :param releases_config: A Model for releases.yaml.
+    :param assembly: The name of the assembly
+    :param group_config: The group config to merge into a new group config (original Model will not be altered)
+    :param _visited: Keeps track of visited assembly definitions to prevent infinite recursion.
+    """
+    if not assembly or not isinstance(releases_config, Model):
+        return group_config
+
+    _check_recursion(releases_config, assembly)
+    target_assembly = releases_config.releases[assembly].assembly
+
+    if target_assembly.basis.assembly:  # Does this assembly inherit from another?
+        # Recursively apply ancestor assemblies
+        group_config = assembly_group_config(releases_config, target_assembly.basis.assembly, group_config)
+
+    target_assembly_group = target_assembly.group
+    if not target_assembly_group:
+        return group_config
+
+    return Model(dict_to_model=merger(target_assembly_group.primitive(), group_config.primitive()))
+
+
+def assembly_metadata_config(releases_config: Model, assembly: str, meta_type: str, distgit_key: str, meta_config: Model) -> Model:
+    """
+    Returns a group member's metadata configuration based on the assembly information
+    and the initial file-based config.
+    :param releases_config: A Model for releases.yaml.
+    :param assembly: The name of the assembly
+    :param meta_type: 'rpm' or 'image'
+    :param distgit_key: The member's distgit_key
+    :param meta_config: The meta's config object
+    :return: Returns a computed config for the metadata (e.g. value for meta.config).
+    """
+    if not assembly or not isinstance(releases_config, Model):
+        return meta_config
+
+    _check_recursion(releases_config, assembly)
+    target_assembly = releases_config.releases[assembly].assembly
+
+    if target_assembly.basis.assembly:  # Does this assembly inherit from another?
+        # Recursive apply ancestor assemblies
+        meta_config = assembly_metadata_config(releases_config, target_assembly.basis.assembly, meta_type, distgit_key, meta_config)
+
+    config_dict = meta_config.primitive()
+
+    component_list = target_assembly.members[f'{meta_type}s']
+    for component_entry in component_list:
+        if component_entry.distgit_key == '*' or component_entry.distgit_key == distgit_key and component_entry.metadata:
+            config_dict = merger(component_entry.metadata.primitive(), config_dict)
+
+    return Model(dict_to_model=config_dict)
+
+
+def assembly_rhcos_config(releases_config: Model, assembly: str) -> Model:
+    """
+    :param releases_config: The content of releases.yml in Model form.
+    :param assembly: The name of the assembly to assess
+    Returns the a computed rhcos config model for a given assembly.
+    """
+    if not assembly or not isinstance(releases_config, Model):
+        return Missing
+
+    _check_recursion(releases_config, assembly)
+    target_assembly = releases_config.releases[assembly].assembly
+    rhcos_config_dict = target_assembly.get("rhcos", {})
+    if target_assembly.basis.assembly:  # Does this assembly inherit from another?
+        # Recursive apply ancestor assemblies
+        basis_rhcos_config = assembly_rhcos_config(releases_config, target_assembly.basis.assembly)
+        rhcos_config_dict = merger(rhcos_config_dict, basis_rhcos_config.primitive())
+    return Model(dict_to_model=rhcos_config_dict)
+
+
+def assembly_basis_event(releases_config: Model, assembly: str) -> typing.Optional[int]:
+    """
+    :param releases_config: The content of releases.yml in Model form.
+    :param assembly: The name of the assembly to assess
+    Returns the basis event for a given assembly. If the assembly has no basis event,
+    None is returned.
+    """
+    if not assembly or not isinstance(releases_config, Model):
+        return None
+
+    _check_recursion(releases_config, assembly)
+    target_assembly = releases_config.releases[assembly].assembly
+    if target_assembly.basis.brew_event:
+        return int(target_assembly.basis.brew_event)
+
+    return assembly_basis_event(releases_config, target_assembly.basis.assembly)
+
+
+def assembly_config_finalize(releases_config: Model, assembly: str, rpm_metas, ordered_image_metas):
+    """
+    Some metadata cannot be finalized until all metadata is read in by doozer. This method
+    uses that interpreted metadata set to go through and adjust assembly information
+    within it.
+    :param releases_config: The releases.yml Model
+    :param assembly: The name of the assembly to apply
+    :param rpm_metas: A list of rpm metadata to update relative to the assembly.
+    :param ordered_image_metas: A list of image metadata to update relative to the assembly.
+    :return: N/A. Metas are updated in-place. Only call during runtime.initialize.
+    """
+    _check_recursion(releases_config, assembly)
+    pass

--- a/elliottlib/cli/find_bugs_cli.py
+++ b/elliottlib/cli/find_bugs_cli.py
@@ -208,6 +208,10 @@ advisory with the --add option.
         bugs = bzutil.search_for_bugs(bz_data, status, flag=search_flag, filter_out_security_bugs=not(cve_trackers),
                                       verbose=runtime.debug)
 
+        if runtime.assembly_basis_event:
+            if not brew_event:
+                raise NotImplementedError("Computing sweep cutoff timestamp from a basis event is not implemented yet.")
+
         if brew_event:
             brew_api = koji.ClientSession(runtime.group_config.urls.brewhub or constants.BREW_HUB)
             sweep_cutoff_timestamp = brew_api.getEvent(brew_event)["ts"]

--- a/elliottlib/cli/find_builds_cli.py
+++ b/elliottlib/cli/find_builds_cli.py
@@ -133,6 +133,7 @@ PRESENT advisory. Here are some examples:
         raise click.BadParameter('Use only one of --payload or --non-payload.')
 
     runtime.initialize(mode='images' if kind == 'image' else 'none')
+    brew_event = brew_event or runtime.assembly_basis_event
     replace_vars = runtime.group_config.vars.primitive() if runtime.group_config.vars else {}
     et_data = runtime.gitdata.load_data(key='erratatool', replace_vars=replace_vars).data
     tag_pv_map = et_data.get('brew_tag_product_version_mapping')

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -1,0 +1,358 @@
+from unittest import TestCase
+
+import yaml
+
+from elliottlib.assembly import (assembly_basis_event, assembly_group_config,
+                                 assembly_metadata_config,
+                                 assembly_rhcos_config, merger)
+from elliottlib.model import Missing, Model
+
+
+class TestAssembly(TestCase):
+
+    def setUp(self) -> None:
+        releases_yml = """
+releases:
+  ART_1:
+    assembly:
+      members:
+        rpms:
+        - distgit_key: openshift-kuryr
+          metadata:  # changes to make the metadata
+            content:
+              source:
+                git:
+                  url: git@github.com:jupierce/kuryr-kubernetes.git
+                  branch:
+                    target: 1_hash
+      group:
+        arches:
+        - x86_64
+        - ppc64le
+        - s390x
+        advisories:
+          image: 11
+          extras: 12
+
+  ART_2:
+    assembly:
+      basis:
+        brew_event: 5
+      members:
+        rpms:
+        - distgit_key: openshift-kuryr
+          metadata:  # changes to make the metadata
+            content:
+              source:
+                git:
+                  url: git@github.com:jupierce/kuryr-kubernetes.git
+                  branch:
+                    target: 2_hash
+      group:
+        arches:
+        - x86_64
+        - s390x
+        advisories:
+          image: 21
+
+  ART_3:
+    assembly:
+      basis:
+        assembly: ART_2
+      group:
+        advisories:
+          image: 31
+
+  ART_4:
+    assembly:
+      basis:
+        assembly: ART_3
+      group:
+        advisories!:
+          image: 41
+
+  ART_5:
+    assembly:
+      basis:
+        assembly: ART_4
+      group:
+        arches!:
+        - s390x
+        advisories!:
+          image: 51
+
+  ART_6:
+    assembly:
+      basis:
+        assembly: ART_5
+      members:
+        rpms:
+        - distgit_key: '*'
+          metadata:
+            content:
+              source:
+                git:
+                  branch:
+                    target: customer_6
+
+  ART_7:
+    assembly:
+      basis:
+        brew_event: 5
+      members:
+        images:
+        - distgit_key: openshift-kuryr
+          metadata:
+            content:
+              source:
+                git:
+                  url: git@github.com:jupierce/kuryr-kubernetes.git
+                  branch:
+                    target: 1_hash
+            is: kuryr-nvr
+            dependencies:
+              rpms:
+              - el7: some-nvr-1
+                non_gc_tag: some-tag-1
+      group:
+        dependencies:
+          rpms:
+            - el7: some-nvr-3
+              non_gc_tag: some-tag-3
+      rhcos:
+        machine-os-content:
+          images:
+            x86_64: registry.example.com/rhcos-x86_64:test
+        dependencies:
+          rpms:
+            - el7: some-nvr-4
+              non_gc_tag: some-tag-4
+            - el8: some-nvr-5
+              non_gc_tag: some-tag-4
+
+  ART_8:
+    assembly:
+      basis:
+        assembly: ART_7
+      members:
+        images:
+        - distgit_key: openshift-kuryr
+          metadata:
+            is: kuryr-nvr2
+            dependencies:
+              rpms:
+              - el7: some-nvr-2
+                non_gc_tag: some-tag-2
+      group:
+        dependencies:
+          rpms:
+            - el7: some-nvr-4
+              non_gc_tag: some-tag-4
+      rhcos:
+        machine-os-content:
+          images: {}
+        dependencies:
+          rpms:
+            - el8: some-nvr-6
+              non_gc_tag: some-tag-6
+
+  ART_INFINITE:
+    assembly:
+      basis:
+        assembly: ART_INFINITE
+      members:
+        rpms:
+        - distgit_key: '*'
+          metadata:
+            content:
+              source:
+                git:
+                  branch:
+                    target: customer_6
+
+"""
+        self.releases_config = Model(dict_to_model=yaml.safe_load(releases_yml))
+
+    def test_merger(self):
+        # First value dominates on primitive
+        self.assertEqual(merger(4, 5), 4)
+        self.assertEqual(merger('4', '5'), '4')
+        self.assertEqual(merger(None, '5'), None)
+        self.assertEqual(merger(True, None), True)
+
+        # Dicts are additive
+        self.assertEqual(
+            merger({'x': 5}, None),
+            {'x': 5}
+        )
+
+        self.assertEqual(
+            merger({'x': 5}, {'y': 6}),
+            {'x': 5, 'y': 6}
+        )
+
+        # Depth does not matter
+        self.assertEqual(
+            merger({'r': {'x': 5}}, {'r': {'y': 6}}),
+            {'r': {'x': 5, 'y': 6}}
+        )
+
+        self.assertEqual(
+            merger({'r': {'x': 5, 'y': 7}}, {'r': {'y': 6}}),
+            {'r': {'x': 5, 'y': 7}}
+        )
+
+        # ? key provides default only
+        self.assertEqual(
+            merger({'r': {'x': 5, 'y?': 7}}, {'r': {'y': 6}}),
+            {'r': {'x': 5, 'y': 6}}
+        )
+
+        # ! key dominates completely
+        self.assertEqual(
+            merger({'r!': {'x': 5}}, {'r': {'y': 6}}),
+            {'r': {'x': 5}}
+        )
+
+        # Lists are combined, dupes eliminated, and results sorted
+        self.assertEqual(
+            merger({'r': [1, 2]}, {'r': [1, 3, 4]}),
+            {'r': [1, 2, 3, 4]}
+        )
+
+        # ! key dominates completely
+        self.assertEqual(
+            merger({'r!': [1, 2]}, {'r': [3, 4]}),
+            {'r': [1, 2]}
+        )
+
+    def test_assembly_basis_event(self):
+        self.assertEqual(assembly_basis_event(self.releases_config, 'ART_1'), None)
+        self.assertEqual(assembly_basis_event(self.releases_config, 'ART_6'), 5)
+
+        try:
+            assembly_basis_event(self.releases_config, 'ART_INFINITE')
+            self.fail('Expected ValueError on assembly infinite recursion')
+        except ValueError:
+            pass
+        except Exception as e:
+            self.fail(f'Expected ValueError on assembly infinite recursion but got: {type(e)}: {e}')
+
+    def test_assembly_group_config(self):
+
+        group_config = Model(dict_to_model={
+            'arches': [
+                'x86_64'
+            ],
+            'advisories': {
+                'image': 1,
+                'extras': 1,
+            }
+        })
+
+        config = assembly_group_config(self.releases_config, 'ART_1', group_config)
+        self.assertEqual(len(config.arches), 3)
+
+        config = assembly_group_config(self.releases_config, 'ART_2', group_config)
+        self.assertEqual(len(config.arches), 2)
+
+        # 3 inherits from 2 an only overrides advisory value
+        config = assembly_group_config(self.releases_config, 'ART_3', group_config)
+        self.assertEqual(len(config.arches), 2)
+        self.assertEqual(config.advisories.image, 31)
+        self.assertEqual(config.advisories.extras, 1)  # Extras never override, so should be from group_config
+
+        # 4 inherits from 3, but sets "advsories!"
+        config = assembly_group_config(self.releases_config, 'ART_4', group_config)
+        self.assertEqual(len(config.arches), 2)
+        self.assertEqual(config.advisories.image, 41)
+        self.assertEqual(config.advisories.extras, Missing)
+
+        # 5 inherits from 4, but sets "advsories!" (overriding 4's !) and "arches!"
+        config = assembly_group_config(self.releases_config, 'ART_5', group_config)
+        self.assertEqual(len(config.arches), 1)
+        self.assertEqual(config.advisories.image, 51)
+
+        config = assembly_group_config(self.releases_config, 'not_defined', group_config)
+        self.assertEqual(len(config.arches), 1)
+
+        config = assembly_group_config(self.releases_config, 'ART_7', group_config)
+        self.assertEqual(len(config.dependencies.rpms), 1)
+
+        config = assembly_group_config(self.releases_config, 'ART_8', group_config)
+        self.assertEqual(len(config.dependencies.rpms), 2)
+
+        try:
+            assembly_group_config(self.releases_config, 'ART_INFINITE', group_config)
+            self.fail('Expected ValueError on assembly infinite recursion')
+        except ValueError:
+            pass
+        except Exception as e:
+            self.fail(f'Expected ValueError on assembly infinite recursion but got: {type(e)}: {e}')
+
+    def test_asembly_metadata_config(self):
+
+        meta_config = Model(dict_to_model={
+            'owners': ['kuryr-team@redhat.com'],
+            'content': {
+                'source': {
+                    'git': {
+                        'url': 'git@github.com:openshift-priv/kuryr-kubernetes.git',
+                        'branch': {
+                            'target': 'release-4.8',
+                        }
+                    },
+                    'specfile': 'openshift-kuryr-kubernetes-rhel8.spec'
+                }
+            },
+            'name': 'openshift-kuryr'
+        })
+
+        config = assembly_metadata_config(self.releases_config, 'ART_1', 'rpm', 'openshift-kuryr', meta_config)
+        # Ensure no loss
+        self.assertEqual(config.name, 'openshift-kuryr')
+        self.assertEqual(len(config.owners), 1)
+        self.assertEqual(config.owners[0], 'kuryr-team@redhat.com')
+        # Check that things were overridden
+        self.assertEqual(config.content.source.git.url, 'git@github.com:jupierce/kuryr-kubernetes.git')
+        self.assertEqual(config.content.source.git.branch.target, '1_hash')
+
+        config = assembly_metadata_config(self.releases_config, 'ART_5', 'rpm', 'openshift-kuryr', meta_config)
+        # Ensure no loss
+        self.assertEqual(config.name, 'openshift-kuryr')
+        self.assertEqual(len(config.owners), 1)
+        self.assertEqual(config.owners[0], 'kuryr-team@redhat.com')
+        # Check that things were overridden
+        self.assertEqual(config.content.source.git.url, 'git@github.com:jupierce/kuryr-kubernetes.git')
+        self.assertEqual(config.content.source.git.branch.target, '2_hash')
+
+        config = assembly_metadata_config(self.releases_config, 'ART_6', 'rpm', 'openshift-kuryr', meta_config)
+        # Ensure no loss
+        self.assertEqual(config.name, 'openshift-kuryr')
+        self.assertEqual(len(config.owners), 1)
+        self.assertEqual(config.owners[0], 'kuryr-team@redhat.com')
+        # Check that things were overridden. 6 changes branches for all rpms
+        self.assertEqual(config.content.source.git.url, 'git@github.com:jupierce/kuryr-kubernetes.git')
+        self.assertEqual(config.content.source.git.branch.target, 'customer_6')
+
+        config = assembly_metadata_config(self.releases_config, 'ART_8', 'image', 'openshift-kuryr', meta_config)
+        # Ensure no loss
+        self.assertEqual(config.name, 'openshift-kuryr')
+        self.assertEqual(config.content.source.git.url, 'git@github.com:jupierce/kuryr-kubernetes.git')
+        self.assertEqual(config.content.source.git.branch.target, '1_hash')
+        # Ensure that 'is' comes from ART_8 and not ART_7
+        self.assertEqual(config['is'], 'kuryr-nvr2')
+        # Ensure that 'dependencies' were accumulate
+        self.assertEqual(len(config.dependencies.rpms), 2)
+
+        try:
+            assembly_metadata_config(self.releases_config, 'ART_INFINITE', 'rpm', 'openshift-kuryr', meta_config)
+            self.fail('Expected ValueError on assembly infinite recursion')
+        except ValueError:
+            pass
+        except Exception as e:
+            self.fail(f'Expected ValueError on assembly infinite recursion but got: {type(e)}: {e}')
+
+    def test_assembly_rhcos_config(self):
+        rhcos_config = assembly_rhcos_config(self.releases_config, "ART_8")
+        self.assertEqual(len(rhcos_config.dependencies.rpms), 3)


### PR DESCRIPTION
- Copies assembly.py from https://github.com/openshift/doozer/pull/431.
- Loads group config from releases.yml
- Loads basis event from releases.yml

Note:
1. Computing cutoff timestamp from basis event in `find-bugs` is not covered.
2. Honoring `is` in `find-builds` is not covered.
3. I didn't introduce the global `--brew-event` option because Elliott doesn't have a global koji wrapper that injecting global event Id like Doozer. If we need that, we can introduce that in a separate PR.
4. Please also look at https://github.com/openshift/ocp-build-data/pull/979. It adds add -hotfix tag to Errata product version mapping. We need that mapping to attach builds.