### PR TITLE
Honor assembly.issues and calculate approximate sweep cutoff time from basis event

### DIFF
--- a/elliottlib/runtime.py
+++ b/elliottlib/runtime.py
@@ -241,7 +241,7 @@ class Runtime(object):
         self.logger.addHandler(debug_log_handler)
 
     def image_metas(self):
-        return self.image_map.values()
+        return list(self.image_map.values())
 
     def rpm_metas(self):
         return list(self.rpm_map.values())

--- a/elliottlib/util.py
+++ b/elliottlib/util.py
@@ -513,3 +513,21 @@ def total_size(o, handlers={}, verbose=False):
         return s
 
     return sizeof(o)
+
+
+def isolate_timestamp_in_release(release: str) -> Optional[str]:
+    """
+    Given a release field, determines whether is contains
+    a timestamp. If it does, it returns the timestamp.
+    If it is not found, None is returned.
+    """
+    match = re.search(r"(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})", release)  # yyyyMMddHHmm
+    if match:
+        year = int(match.group(1))
+        month = int(match.group(2))
+        day = int(match.group(3))
+        hour = int(match.group(4))
+        minute = int(match.group(5))
+        if year >= 2000 and month >= 1 and month <= 12 and day >= 1 and day <= 31 and hour <= 23 and minute <= 59:
+            return match.group(0)
+    return None

--- a/tests/test_bzutil.py
+++ b/tests/test_bzutil.py
@@ -244,6 +244,28 @@ class TestBZUtil(unittest.TestCase):
         actual = bzutil.filter_bugs_by_cutoff_event(bzapi, bugs, desired_statuses, sweep_cutoff_timestamp)
         self.assertListEqual([1, 2, 4, 5, 7, 8], [bug.id for bug in actual])
 
+    def test_approximate_cutoff_timestamp(self):
+        koji_api = mock.MagicMock()
+        koji_api.getEvent.return_value = {"ts": datetime(2021, 7, 3, 0, 0, 0, 0, tzinfo=timezone.utc).timestamp()}
+        metas = [
+            mock.MagicMock(),
+            mock.MagicMock(),
+            mock.MagicMock(),
+        ]
+        metas[0].get_latest_build.return_value = {"nvr": "a-4.9.0-202107020000.p0"}
+        metas[1].get_latest_build.return_value = {"nvr": "b-4.9.0-202107020100.p0"}
+        metas[2].get_latest_build.return_value = {"nvr": "c-4.9.0-202107020200.p0"}
+        actual = bzutil.approximate_cutoff_timestamp(mock.ANY, koji_api, metas)
+        self.assertEqual(datetime(2021, 7, 2, 2, 0, 0, 0, tzinfo=timezone.utc).timestamp(), actual)
+
+        koji_api.getEvent.return_value = {"ts": datetime(2021, 7, 1, 0, 0, 0, 0, tzinfo=timezone.utc).timestamp()}
+        actual = bzutil.approximate_cutoff_timestamp(mock.ANY, koji_api, metas)
+        self.assertEqual(datetime(2021, 7, 1, 0, 0, 0, 0, tzinfo=timezone.utc).timestamp(), actual)
+
+        koji_api.getEvent.return_value = {"ts": datetime(2021, 7, 4, 0, 0, 0, 0, tzinfo=timezone.utc).timestamp()}
+        actual = bzutil.approximate_cutoff_timestamp(mock.ANY, koji_api, [])
+        self.assertEqual(datetime(2021, 7, 4, 0, 0, 0, 0, tzinfo=timezone.utc).timestamp(), actual)
+
 
 class TestSearchFilter(unittest.TestCase):
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -37,3 +37,32 @@ class TestUtil(unittest.TestCase):
 
         actual = util.find_latest_builds(builds, None)
         self.assertEqual([13, 23, 33], [b["id"] for b in actual])
+
+    def test_isolate_timestamp_in_release(self):
+        actual = util.isolate_timestamp_in_release("foo-4.7.0-202107021813.p0.git.01c9f3f.el8")
+        expected = "202107021813"
+        self.assertEqual(actual, expected)
+
+        actual = util.isolate_timestamp_in_release("foo-container-v4.7.0-202107021907.p0.git.8b4b094")
+        expected = "202107021907"
+        self.assertEqual(actual, expected)
+
+        actual = util.isolate_timestamp_in_release("foo-container-v4.7.0-202107021907.p0.git.8b4b094")
+        expected = "202107021907"
+        self.assertEqual(actual, expected)
+
+        actual = util.isolate_timestamp_in_release("foo-container-v4.8.0-202106152230.p0.git.25122f5.assembly.stream")
+        expected = "202106152230"
+        self.assertEqual(actual, expected)
+
+        actual = util.isolate_timestamp_in_release("foo-container-v4.7.0-1.p0.git.8b4b094")
+        expected = None
+        self.assertEqual(actual, expected)
+
+        actual = util.isolate_timestamp_in_release("foo-container-v4.7.0-202199999999.p0.git.8b4b094")
+        expected = None
+        self.assertEqual(actual, expected)
+
+        actual = util.isolate_timestamp_in_release("")
+        expected = None
+        self.assertEqual(actual, expected)


### PR DESCRIPTION
Let:

- `t1` be the timestamp of basis Brew event;
- `t2` be the timestamp of sweep cutoff;
- `I` be the set of latest image builds in the stream assembly at the moment of the basis t1;
- `R` be the set of rpms builds in the stream assembly at the moment of the basis t1;
- `H(b)` is the timestamp in a component build's NVR.

Then:

`t2 = max( { H(i) | i ∈ (I ∪ R)  } )`