### PR TITLE
fix indentation error

### DIFF
--- a/elliottlib/cli/validate_rhsa.py
+++ b/elliottlib/cli/validate_rhsa.py
@@ -41,6 +41,6 @@ def validate_rhsa_cli(runtime, advisory):
             if howto:
                 print(textwrap.indent(howto, "  > "))
             print()
-            exit(2)
+        exit(2)
     else:
         print("No issues found")


### PR DESCRIPTION
This caused elliott to exit on first Alert, rather than printing all alerts.

@vfreex @thegreyd 