### PR TITLE
Fix create verb crashes if the runtime assembly has a basis event

### DIFF
--- a/elliottlib/runtime.py
+++ b/elliottlib/runtime.py
@@ -192,6 +192,8 @@ class Runtime(object):
             self.brew_event = self.assembly_basis_event
             self.logger.warning(f'Constraining brew event to assembly basis for {self.assembly}: {self.brew_event}')
 
+        self.initialized = True
+
     def initialize_logging(self):
         if self.initialized:
             return


### PR DESCRIPTION
The error message is like

```
ElliottFatalError('Cannot run with assembly basis event 40126984 and --brew-event at the same time.',)
```

This is because the runtime is double initialized after create verbs
calls `ctx.invoke`.