### PR TITLE
ART-3277: Fix a build sweep issue

### DIFF
--- a/elliottlib/cli/__main__.py
+++ b/elliottlib/cli/__main__.py
@@ -530,7 +530,7 @@ written out to summary_results.json.
             # filter out dropped advisories
             advisories = [ad for ad in build.all_errata if ad["status"] != "DROPPED_NO_SHIP"]
             if not advisories:
-                red_print("Build {nvr} is not attached to any advisories.")
+                red_print(f"Build {nvr} is not attached to any advisories.")
                 continue
             for advisory in advisories:
                 if advisory["status"] == "SHIPPED_LIVE":

--- a/elliottlib/cli/find_builds_cli.py
+++ b/elliottlib/cli/find_builds_cli.py
@@ -269,9 +269,10 @@ def _find_shipped_builds(build_ids: List[Union[str, int]], brew_session: koji.Cl
     """
     shipped_ids = set()
     tag_lists = brew.get_builds_tags(build_ids, brew_session)
+    released_tag_pattern = re.compile(r"^RH[BSE]A-.+-released$")  # https://issues.redhat.com/browse/ART-3277
     for build_id, tags in zip(build_ids, tag_lists):
         # a shipped build with OCP Errata should have a Brew tag ending with `-released`, like `RHBA-2020:2713-released`
-        shipped = any(map(lambda tag: tag["name"].endswith("-released"), tags))
+        shipped = any(map(lambda tag: released_tag_pattern.match(tag["name"]), tags))
         if shipped:
             shipped_ids.add(build_id)
     return shipped_ids

--- a/tests/test_find_builds_cli.py
+++ b/tests/test_find_builds_cli.py
@@ -51,14 +51,16 @@ class TestFindBuildsCli(unittest.TestCase):
 
     @mock.patch("elliottlib.brew.get_builds_tags")
     def test_find_shipped_builds(self, get_builds_tags: mock.MagicMock):
-        build_ids = [11, 12, 13]
+        build_ids = [11, 12, 13, 14, 15]
         build_tags = [
             [{"name": "foo-candidate"}],
             [{"name": "bar-candidate"}, {"name": "bar-released"}],
+            [{"name": "bar-candidate"}, {"name": "RHBA-2077:1001-released"}],
+            [{"name": "bar-candidate"}, {"name": "RHSA-2077:1002-released"}],
             [],
         ]
         get_builds_tags.return_value = build_tags
-        expected = {12}
+        expected = {13, 14}
         actual = _find_shipped_builds(build_ids, mock.MagicMock())
         self.assertEqual(expected, actual)
         get_builds_tags.assert_called_once_with(build_ids, mock.ANY)


### PR DESCRIPTION
Currently Elliott build sweep excludes shipped builds by checking if a build has a tag that ends with `-released`.
However we noticed an exception when preparing 4.7.26.

This PR updates the `_find_shipped_builds` function to use a more
precise check.