### PR TITLE
art-3078: Add create text only cli

### DIFF
--- a/elliott
+++ b/elliott
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # # -*- coding: utf-8 -*-
 """
 Elliott is a CLI tool for managing Red Hat release advisories using the Erratatool

--- a/elliott
+++ b/elliott
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # # -*- coding: utf-8 -*-
 """
 Elliott is a CLI tool for managing Red Hat release advisories using the Erratatool

--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -239,7 +239,6 @@ def create_textonly(bz_data, bugtitle, bugdescription):
     :return: Text only Bug object
     """
 
-
     bzapi = get_bzapi(bz_data)
     version = bz_data['version'][0]
     target_release = bz_data['target_release'][0]

--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -229,6 +229,42 @@ def create_placeholder(bz_data, kind):
     return newbug
 
 
+def create_textonly(bz_data, bugtitle, bugdescription):
+    """Create a text only bug
+
+    :param bz_data: The Bugzilla data dump we got from our bugzilla.yaml file
+    :param bugtitle: The title of the bug to create
+    :param bugdescription: The description of the bug to create
+
+    :return: Text only Bug object
+    """
+
+
+    bzapi = get_bzapi(bz_data)
+    version = bz_data['version'][0]
+    target_release = bz_data['target_release'][0]
+
+    createinfo = bzapi.build_createbug(
+        product=bz_data['product'],
+        version=version,
+        component="Release",
+        summary=bugtitle,
+        description=bugdescription)
+
+    newbug = bzapi.createbug(createinfo)
+
+    # change state to VERIFIED, set target release
+    try:
+        update = bzapi.build_update(status="VERIFIED", target_release=target_release)
+        bzapi.update_bugs([newbug.id], update)
+    except Exception as ex:  # figure out the actual bugzilla error. it only happens sometimes
+        sleep(5)
+        bzapi.update_bugs([newbug.id], update)
+        print(ex)
+
+    return newbug
+
+
 def search_for_bugs(bz_data, status, search_filter='default', flag=None, filter_out_security_bugs=True, verbose=False):
     """Search the provided target_release's for bugs in the specified states
 

--- a/elliottlib/cli/__main__.py
+++ b/elliottlib/cli/__main__.py
@@ -63,6 +63,7 @@ from elliottlib.cli.attach_cve_flaws_cli import attach_cve_flaws_cli
 from elliottlib.cli.get_golang_versions_cli import get_golang_versions_cli
 from elliottlib.cli.validate_rhsa import validate_rhsa_cli
 from elliottlib.cli.rhcos_cli import rhcos_cli
+from elliottlib.cli.create_textonly_cli import create_textonly_cli
 
 # 3rd party
 import bugzilla
@@ -701,6 +702,7 @@ cli.add_command(advisory_drop_cli)
 cli.add_command(verify_attached_operators_cli)
 cli.add_command(verify_attached_bugs_cli)
 cli.add_command(attach_cve_flaws_cli)
+cli.add_command(create_textonly_cli)
 
 
 # -----------------------------------------------------------------------------

--- a/elliottlib/cli/create_textonly_cli.py
+++ b/elliottlib/cli/create_textonly_cli.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, print_function, unicode_literals
 import datetime
 
 from errata_tool import Erratum, ErrataException
@@ -100,12 +99,9 @@ def create_textonly_cli(ctx, runtime, errata_type, date, assigned_to, manager, p
             bug_id=newbug.id,
             text_only=1,
         )
-    except elliottlib.exceptions.ErrataToolUnauthorizedException:
-        exit_unauthorized()
     except elliottlib.exceptions.ErrataToolError as ex:
         raise ElliottFatalError(getattr(ex, 'message', repr(ex)))
 
-    # erratum.addBugs(newbug.id)
     if yes:
         erratum.commit()
         green_prefix("Created new text only advisory: ")

--- a/elliottlib/cli/create_textonly_cli.py
+++ b/elliottlib/cli/create_textonly_cli.py
@@ -99,8 +99,10 @@ def create_textonly_cli(ctx, runtime, errata_type, date, assigned_to, manager, p
             bug_id=newbug.id,
             text_only=1,
         )
+    except elliottlib.exceptions.ErrataToolUnauthorizedException:
+        exit_unauthorized()
     except elliottlib.exceptions.ErrataToolError as ex:
-        raise ElliottFatalError(getattr(ex, 'message', repr(ex)))
+        raise repr(ex)
 
     if yes:
         erratum.commit()

--- a/elliottlib/cli/create_textonly_cli.py
+++ b/elliottlib/cli/create_textonly_cli.py
@@ -1,0 +1,105 @@
+from __future__ import absolute_import, print_function, unicode_literals
+import datetime
+
+from errata_tool import Erratum, ErrataException
+from kerberos import GSSError
+import click
+
+from elliottlib.cli.common import cli
+from elliottlib import logutil, Runtime
+from elliottlib.exceptions import ElliottFatalError
+from elliottlib.util import exit_unauthorized, green_prefix, validate_release_date, \
+    YMD, validate_email_address
+import elliottlib
+
+LOGGER = logutil.getLogger(__name__)
+
+pass_runtime = click.make_pass_decorator(Runtime)
+
+#
+# Create Text only advisory
+# advisory:create-textonly
+
+
+@cli.command('create-textonly',
+             short_help='Create a textonly advisory along with notification bug attached')
+@click.option("--type", '-t', 'errata_type',
+              type=click.Choice(['RHBA', 'RHSA', 'RHEA']),
+              default='RHBA',
+              help="Type of Advisory to create.")
+@click.option("--date", required=True,
+              callback=validate_release_date,
+              help="Release date for the advisory. Format: YYYY-Mon-DD.")
+@click.option('--assigned-to', metavar="EMAIL_ADDR", required=True,
+              envvar="ELLIOTT_ASSIGNED_TO_EMAIL",
+              callback=validate_email_address,
+              help="The email address group to review and approve the advisory.")
+@click.option('--manager', metavar="EMAIL_ADDR", required=True,
+              envvar="ELLIOTT_MANAGER_EMAIL",
+              callback=validate_email_address,
+              help="The email address of the manager monitoring the advisory status.")
+@click.option('--package-owner', metavar="EMAIL_ADDR", required=True,
+              envvar="ELLIOTT_PACKAGE_OWNER_EMAIL",
+              callback=validate_email_address,
+              help="The email address of the person responsible managing the advisory.")
+@click.option('--topic', required=True,
+              help="Topic value for text only advisory")
+@click.option('--synopsis', required=True,
+              help="Synopsis value for text only advisory")
+@click.option('--description', required=True,
+              help="Description value for text only advisory")
+@click.option('--solution', required=True,
+              help="Solution value for text only advisory")
+@click.option('--bugtitle', required=True,
+              help="Bug title value for bug attached to text only advisory")
+@click.option('--bugdescription', required=True,
+              help="Description value for bug attached to text only advisory")
+@click.option('--yes', '-y', is_flag=True,
+              default=False, type=bool,
+              help="Create the advisory (by default only a preview is displayed)")
+@pass_runtime
+@click.pass_context
+def create_textonly_cli(ctx, runtime, errata_type, date, assigned_to, manager,
+        package_owner, topic, synopsis, description, solution, bugtitle, bugdescription, yes):
+
+
+    release_date = datetime.datetime.strptime(date, YMD)
+
+    #create textonly bug
+    bz_data = runtime.gitdata.load_data(key='bugzilla').data
+    newbug = elliottlib.bzutil.create_textonly(bz_data, bugtitle, bugdescription)
+    click.echo("Created BZ: {} {}".format(newbug.id, newbug.weburl))
+
+    #create textonly advisory
+    et_data = runtime.gitdata.load_data(key='erratatool').data
+    try:
+        erratum = Erratum(
+            product=et_data['product'],
+            release=et_data['release'],
+            qe_group=et_data['quality_responsibility_name'],
+            synopsis=synopsis,
+            topic=topic,
+            description=description,
+            solution=solution,
+            qe_email=assigned_to,
+            errata_type=errata_type,
+            owner_email=package_owner,
+            manager_email=manager,
+            date=release_date,
+            bug_id=newbug.id,
+            text_only=1,
+        )
+    except elliottlib.exceptions.ErrataToolUnauthorizedException:
+        exit_unauthorized()
+    except elliottlib.exceptions.ErrataToolError as ex:
+        raise ElliottFatalError(getattr(ex, 'message', repr(ex)))
+
+    #erratum.addBugs(newbug.id)
+    if yes:
+        erratum.commit()
+        green_prefix("Created new text only advisory: ")
+        click.echo(str(erratum))
+    else:
+        green_prefix("Would have created advisory: ")
+        click.echo("")
+        click.echo(erratum)

--- a/elliottlib/cli/create_textonly_cli.py
+++ b/elliottlib/cli/create_textonly_cli.py
@@ -59,18 +59,29 @@ pass_runtime = click.make_pass_decorator(Runtime)
               help="Create the advisory (by default only a preview is displayed)")
 @pass_runtime
 @click.pass_context
-def create_textonly_cli(ctx, runtime, errata_type, date, assigned_to, manager,
-        package_owner, topic, synopsis, description, solution, bugtitle, bugdescription, yes):
-
+def create_textonly_cli(ctx, runtime, errata_type, date, assigned_to, manager, package_owner, topic, synopsis, description, solution, bugtitle, bugdescription, yes):
+    """
+    Create a text only advisory with all required input passed from args, need to manually decide the statement for each release.
+    Also will create the notification bug along with the text only advisory, the bug also need some special comment and title.
+    These args need to be designated manually for text only advisory:
+    - topic
+    - synopsis
+    - description
+    - solution
+    - assigned
+    These args need to be designated manually for text only bug:
+    - bugtitle
+    - bugdescription
+    """
 
     release_date = datetime.datetime.strptime(date, YMD)
 
-    #create textonly bug
+    # create textonly bug
     bz_data = runtime.gitdata.load_data(key='bugzilla').data
     newbug = elliottlib.bzutil.create_textonly(bz_data, bugtitle, bugdescription)
     click.echo("Created BZ: {} {}".format(newbug.id, newbug.weburl))
 
-    #create textonly advisory
+    # create textonly advisory
     et_data = runtime.gitdata.load_data(key='erratatool').data
     try:
         erratum = Erratum(
@@ -94,7 +105,7 @@ def create_textonly_cli(ctx, runtime, errata_type, date, assigned_to, manager,
     except elliottlib.exceptions.ErrataToolError as ex:
         raise ElliottFatalError(getattr(ex, 'message', repr(ex)))
 
-    #erratum.addBugs(newbug.id)
+    # erratum.addBugs(newbug.id)
     if yes:
         erratum.commit()
         green_prefix("Created new text only advisory: ")


### PR DESCRIPTION
Add create text only cli for elliott it create a custom advisory and along with a custom bug in create text only advisory use case, all required data for advisory and bug need pass from jenkins job's parameters since each cases are different.