### PR TITLE
Set bugzilla query limit to infinite

### DIFF
--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -407,6 +407,7 @@ def _perform_query(bzapi, query_url, include_fields=None):
 
     query = bzapi.url_to_query(str(query_url))
     query["include_fields"] = include_fields
+    query["limit"] = 0
 
     return bzapi.query(query)
 


### PR DESCRIPTION
Since https://bugzilla.redhat.com/show_bug.cgi?id=2003517, bugzilla api returns maximum 20 bugs. This PR sets this limit to unlimited.