### PR TITLE
Deprecate create rhsa 

### DIFF
--- a/elliottlib/cli/create_cli.py
+++ b/elliottlib/cli/create_cli.py
@@ -1,17 +1,14 @@
 from __future__ import absolute_import, print_function, unicode_literals
 import click
 import datetime
-from kerberos import GSSError
 import elliottlib
 from elliottlib.cli.common import cli
 from elliottlib.cli.add_metadata_cli import add_metadata_cli
 from elliottlib.cli.create_placeholder_cli import create_placeholder_cli
 from elliottlib.exectools import cmd_assert
 from elliottlib.exceptions import ElliottFatalError
-from elliottlib.util import YMD, default_release_date, validate_release_date, \
-    validate_email_address, major_from_branch, minor_from_branch, \
-    exit_unauthenticated, exit_unauthorized, red_prefix, green_prefix, yellow_prefix, \
-    red_print, yellow_print, green_print
+from elliottlib.util import YMD, validate_release_date, \
+    validate_email_address, exit_unauthorized, green_prefix, yellow_print
 pass_runtime = click.make_pass_decorator(elliottlib.Runtime)
 
 LOGGER = elliottlib.logutil.getLogger(__name__)
@@ -23,7 +20,7 @@ LOGGER = elliottlib.logutil.getLogger(__name__)
 #
 @cli.command("create", short_help="Create a new advisory")
 @click.option("--type", '-t', 'errata_type',
-              type=click.Choice(['RHBA', 'RHSA', 'RHEA']),
+              type=click.Choice(['RHBA', 'RHEA']),
               default='RHBA',
               help="Type of Advisory to create.")
 @click.option("--kind", '-k', required=True,
@@ -31,8 +28,8 @@ LOGGER = elliottlib.logutil.getLogger(__name__)
               help="Kind of artifacts that will be attached to Advisory. Affects boilerplate text.")
 @click.option("--impetus",
               type=click.Choice(elliottlib.constants.errata_valid_impetus),
-              help="Impetus for the advisory creation [{}]".format(
-                  ', '.join(elliottlib.constants.errata_valid_impetus)))
+              default='standard',
+              help="Impetus for the advisory creation"
 @click.option("--date", required=True,
               callback=validate_release_date,
               help="Release date for the advisory. Format: YYYY-Mon-DD.")
@@ -76,7 +73,7 @@ advisory would look like. The raw JSON used to create the advisory
 will be printed to the screen instead of posted to the Errata Tool
 API.
 
-The impetus option only effects the metadata added to the new
+The impetus option only affects the metadata added to the new
 advisory and its synopsis.
 
 The --assigned-to, --manager and --package-owner options are required.
@@ -84,9 +81,7 @@ They are the email addresses of the parties responsible for managing and
 approving the advisory.
 
 Adding a list of bug ids with one or more --bugs arguments attaches those bugs to the
-advisory on creation. When creating a security advisory, the list of bugs will also be checked for any CVE flaw
-bugs which they are blocking, and those will be added as well. Any CVE flaw bugs
-being added will also calculate the Impact for the release if it's type is RHSA.
+advisory on creation.
 
 Provide the '--yes' or '-y' option to confirm creation of the
 advisory.
@@ -100,32 +95,16 @@ advisory.
 \b
     $ elliott --group openshift-3.5 create --yes -k image --date 2018-Mar-05
 """
-    # perform sanity checks and provide default values
-    if errata_type == 'RHSA':
-        if not bugs:
-            raise ElliottFatalError(
-                "When creating an RHSA, you must provide a list of bug id(s) using one or more `--bug` options.")
-        if not impetus:
-            impetus = 'cve'
-        elif impetus != 'cve':
-            raise ElliottFatalError("Invalid impetus")
-    elif not impetus:
-        impetus = 'standard'
-
     runtime.initialize()
 
     et_data = runtime.gitdata.load_data(key='erratatool').data
     bz_data = runtime.gitdata.load_data(key='bugzilla').data
-
-    impact = None
 
     # User entered a valid value for --date, set the release date
     release_date = datetime.datetime.strptime(date, YMD)
 
     ######################################################################
 
-    flaw_cve_map = {}
-    impact = None
     unique_bugs = set(bugs)
 
     if bugs:
@@ -135,13 +114,6 @@ advisory.
         bug_objects = bzapi.getbugs(bugs)
         # assert bugs are viable for a new advisory.
         _assert_bugs_are_viable(errata_type, bugs, bug_objects)
-        if errata_type == 'RHSA':
-            LOGGER.info("Fetching flaw bugs for trackers {}...".format(" ".join(map(str, bugs))))
-            tracker_flaws_map = elliottlib.bzutil.get_tracker_flaws_map(bzapi, bug_objects)
-            impact = elliottlib.bzutil.get_highest_impact(bug_objects, tracker_flaws_map)
-            flaw_bugs = [flaw for tracker, flaws in tracker_flaws_map.items() for flaw in flaws]
-            flaw_cve_map = elliottlib.bzutil.get_flaw_aliases(flaw_bugs)
-            unique_bugs |= set(flaw_cve_map.keys())
 
     ######################################################################
 
@@ -154,9 +126,7 @@ advisory.
             release_date=release_date.strftime(YMD),
             assigned_to=assigned_to,
             manager=manager,
-            package_owner=package_owner,
-            impact=impact,
-            cves=' '.join((alias) for alias in flaw_cve_map.values())
+            package_owner=package_owner
         )
     except elliottlib.exceptions.ErrataToolUnauthorizedException:
         exit_unauthorized()
@@ -169,8 +139,6 @@ advisory.
         erratum.commit()
         green_prefix("Created new advisory: ")
         click.echo(str(erratum))
-        if errata_type == 'RHSA':
-            yellow_print("Remember to manually set the Security Reviewer in the Errata Tool Web UI")
 
         # This is a little strange, I grant you that. For reference you
         # may wish to review the click docs
@@ -205,15 +173,13 @@ advisory.
         click.echo(erratum)
 
 
-def _assert_bugs_are_viable(errata_type, bugs, bug_objects):
+def _assert_bugs_are_viable(bugs, bug_objects):
     for index, bug in enumerate(bug_objects):
         bug_id = bugs[index]
         if not bug:
             raise ElliottFatalError("Couldn't find bug {}. Did you log in?".format(bug_id))
         if not elliottlib.bzutil.is_viable_bug(bug):
             raise ElliottFatalError("Bug {} is not viable: Status is {}.".format(bug_id, bug.status))
-        if errata_type == 'RHSA' and not elliottlib.bzutil.is_cve_tracker(bug):
-            raise ElliottFatalError("Bug {} is not a CVE tracker: Keywords are {}.".format(bug_id, bug.keywords))
         LOGGER.info("Checking if bug {} is already attached to an advisory...".format(bug_id))
         advisories = elliottlib.errata.get_advisories_for_bug(bug_id)
         if advisories:


### PR DESCRIPTION
This came out of a discussion here https://github.com/openshift/ocp-build-data/pull/1104#discussion_r719812266 re rhsa process update https://github.com/openshift/elliott/pull/231

Our rhsa advisory process flow has moved from
directly creating rhsa -> creating rhba and then updating it to rhsa
Since we are no longer doing that it seems appropriate to retire the functionality