### PR TITLE
Fail if placeholder cannot get substituted

### DIFF
--- a/elliottlib/gitdata.py
+++ b/elliottlib/gitdata.py
@@ -222,7 +222,7 @@ class GitData(object):
                             try:
                                 raw_text = raw_text.format(**replace_vars)
                             except KeyError as e:
-                                self.logger.warning('{} contains template key `{}` but no value was provided'.format(data_file, e.args[0]))
+                                raise ValueError(f'{data_file} contains template key `{e.args[0]}` but no value was provided')
                         data = yaml.full_load(raw_text)
                         use = True
                         if exclude and base_name in exclude:


### PR DESCRIPTION
In case there is a substitution where no key is provided, leave it alone