### PR TITLE
Fix CVE tracker bug sweep

### DIFF
--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -341,7 +341,7 @@ def get_whiteboard_component(bug):
     :param bug: bug object
     :returns: a string if a value is found, otherwise False
     """
-    marker = r'component:\s*([-\w]+)'
+    marker = r'component:\s*(\S+)'
     tmp = re.search(marker, bug.whiteboard)
     if tmp and len(tmp.groups()) == 1:
         component_name = tmp.groups()[0]

--- a/tests/test_bzutil.py
+++ b/tests/test_bzutil.py
@@ -31,10 +31,11 @@ class TestBZUtil(unittest.TestCase):
         bug = mock.MagicMock(whiteboard="component: ")
         self.assertFalse(bzutil.get_whiteboard_component(bug))
 
-        expected = "something"
-        bug = mock.MagicMock(whiteboard=f"component: {expected}")
-        actual = bzutil.get_whiteboard_component(bug)
-        self.assertEqual(actual, expected)
+        for expected in ["something", "openvswitch2.15", "trailing_blank 	"]:
+            bug = mock.MagicMock(whiteboard=f"component: {expected}")
+            expected = expected.strip()
+            actual = bzutil.get_whiteboard_component(bug)
+            self.assertEqual(actual, expected.strip())
 
     def test_get_bugs(self):
         bug_ids = [1, 2]


### PR DESCRIPTION
A tracker bug for component with a `.` in its name could not be swept
into the advisory, as it could not be verified that a build with that
name was attached. This commit relaxes the regex, and includes also
`dots` in the component name.