### PR TITLE
verify_attached_ops: lookup bundle-referenced NVRs

### DIFF
--- a/elliottlib/cli/verify_attached_operators_cli.py
+++ b/elliottlib/cli/verify_attached_operators_cli.py
@@ -5,20 +5,25 @@ from kerberos import GSSError
 import re
 import requests
 import yaml
+import json
 from zipfile import ZipFile
 
 from errata_tool import Erratum
 
-from elliottlib import brew, constants
+from elliottlib import brew, constants, exectools
 from elliottlib.cli.common import cli, pass_runtime
 from elliottlib.exceptions import ElliottFatalError
 from elliottlib.util import (exit_unauthenticated, red_print, green_print)
 
 
 @cli.command("verify-attached-operators", short_help="Verify attached operator manifest references are (being) shipped")
+@click.option("--exclude-shipped",
+              required=False,
+              is_flag=True,
+              help='Do not allow shipped images to satisfy manifest references')
 @click.argument("advisories", nargs=-1, type=click.IntRange(1), required=True)
 @pass_runtime
-def verify_attached_operators_cli(runtime, advisories):
+def verify_attached_operators_cli(runtime, exclude_shipped, advisories):
     """
     Verify attached operator manifest references are shipping or already shipped.
 
@@ -38,13 +43,23 @@ def verify_attached_operators_cli(runtime, advisories):
     referenced_specs = _extract_operator_manifest_image_references(image_builds)
     if not referenced_specs:
         # you are probably using this because you expect attached operator bundles or metadata
-        raise ElliottFatalError(f"No bundle or appregistry builds found in advisories {advisories}.")
+        adv_str = ", ".join(str(a) for a in advisories)
+        raise ElliottFatalError(f"No bundle or appregistry builds found in advisories ({adv_str}).")
+
+    if not exclude_shipped:
+        image_builds.extend(_get_shipped_images(runtime, brew_session))
 
     # check if references are satisfied by any image we are shipping or have shipped
-    image_builds.extend(_get_shipped_images(runtime, brew_session))
     available_shasums = _extract_available_image_shasums(image_builds)
-    if _any_references_are_missing(referenced_specs, available_shasums):
-        raise ElliottFatalError("Some references were missing. Ensure all manifest references are shipped or shipping.")
+    missing = _missing_references(runtime, referenced_specs, available_shasums)
+    if missing:
+        missing_str = "\n              ".join(missing)
+        red_print(f"""
+            Some references were missing:
+              {missing_str}
+            Ensure all manifest references are shipped or shipping.
+        """)
+        raise ElliottFatalError("Some bundle references were missing.")
     green_print("All operator manifest references were found.")
 
 
@@ -122,6 +137,7 @@ def _download_appregistry_image_references(appregistry_build):
 
 def _get_shipped_images(runtime, brew_session):
     # retrieve all image builds ever shipped for this version (potential operands)
+    # NOTE: this will tend to be the slow part, aside from querying ET
     tag = f"{runtime.branch}-container-released"
     tags = {tag, tag.replace('-rhel-7-', '-rhel-8-')}  # may be one or two depending
     released = brew.get_tagged_builds([(tag, None) for tag in tags], build_type='image', event=None, session=brew_session)
@@ -139,13 +155,32 @@ def _extract_available_image_shasums(image_builds):
     return image_digests
 
 
-def _any_references_are_missing(references, available):
+def _missing_references(runtime, references, available):
     # check that referenced are all attached
-    missing = False
+    missing = set()
     for image_pullspec, metadata in references.items():
         digest = image_pullspec.split("@")[1]  # just the shasum
         if digest not in available:
-            missing = True
             ref = image_pullspec.rsplit('/', 1)[1]  # cut off the registry/namespace, just need the name:shasum
+            try:
+                ref = _nvr_for_operand_pullspec(runtime, ref)
+            except RuntimeError:
+                pass  # just leave it as-is if something goes wrong with looking it up
+
+            missing.add(ref)
             red_print(f"{metadata} has a reference to {ref} not present in the advisories nor shipped images.")
+
     return missing
+
+
+def _nvr_for_operand_pullspec(runtime, spec):
+    # spec should just be the part after the final "/" e.g. "ose-kube-rbac-proxy@sha256:9211b70..."
+    # we can look it up in the internal proxy.
+    urls = runtime.group_config.urls
+    spec = f"{urls.brew_image_host}/{urls.brew_image_namespace}/openshift-{spec}"
+    info = exectools.cmd_assert(
+        f"oc image info -o json --filter-by-os=linux/amd64 {spec}",
+        retries=3, pollrate=5, text_mode=True,
+    )[0]
+    labels = json.loads(info)["config"]["config"]["Labels"]
+    return f"{labels['com.redhat.component']}-{labels['version']}-{labels['release']}"

--- a/elliottlib/exectools.py
+++ b/elliottlib/exectools.py
@@ -12,7 +12,7 @@ import subprocess
 import time
 import urllib
 
-from . import assertion, logutil, pushd
+from elliottlib import assertion, logutil, pushd
 
 SUCCESS = 0
 

--- a/functional_tests/test_verify_attached_operators.py
+++ b/functional_tests/test_verify_attached_operators.py
@@ -1,0 +1,57 @@
+from unittest import TestCase
+from mock import MagicMock, patch
+from functional_tests import constants
+import subprocess
+
+from elliottlib.cli import verify_attached_operators_cli
+from elliottlib.runtime import Runtime
+
+
+class TestVerifyAttachedOperators(TestCase):
+
+    def setUp(self):
+        self.patchers = [
+            patch(f"elliottlib.cli.verify_attached_operators_cli.{it}", lambda x: x)
+            for it in ["red_print", "green_print"]
+        ]
+        for p in self.patchers:
+            # disable the printed output during tests (remove this to debug...)
+            p.start()
+
+    def tearDown(self):
+        for p in self.patchers:
+            p.stop()
+
+    def test_nvr_for_operand_pullspec(self):
+        runtime = Runtime(group="openshift-4.9", working_dir="/tmp", debug=False)
+        runtime = MagicMock()
+        runtime.group_config = MagicMock(urls=MagicMock(
+            brew_image_host="registry-proxy.engineering.redhat.com",
+            brew_image_namespace="rh-osbs",
+        ))
+
+        spec = "ose-csi-external-provisioner@sha256:cb191fcfe71ce6da60e73697aaa9b3164c1f0566150d3bffb8004598284d767a"
+        self.assertEqual(
+            "csi-provisioner-container-v4.9.0-202109302317.p0.git.7736e72.assembly.stream",
+            verify_attached_operators_cli._nvr_for_operand_pullspec(runtime, spec)
+        )
+
+    def test_verify_attached_operators_ok(self):
+        out = subprocess.run(
+            constants.ELLIOTT_CMD
+            + ["--group", "openshift-4.9", "verify-attached-operators", "81215"],  # 4.9.0 advisories all GA
+            capture_output=True,
+            encoding='utf-8',
+        )
+        self.assertIn("All operator manifest references were found.", out.stdout)
+
+    def test_verify_attached_operators_wrong(self):
+        out = subprocess.run(
+            constants.ELLIOTT_CMD
+            + ["--group", "openshift-4.8", "verify-attached-operators", "--exclude-shipped", "81215"],
+            # 4.9.0 GA metadata advisory; will not find matches in 4.8 shipped
+            capture_output=True,
+            encoding='utf-8',
+        )
+        self.assertIn("csi-provisioner-container-v4.9.0-202109302317.p0.git.7736e72.assembly.stream", out.stdout)
+        self.assertEqual(1, out.returncode)

--- a/tests/test_verify_attached_operators.py
+++ b/tests/test_verify_attached_operators.py
@@ -1,0 +1,23 @@
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+from elliottlib.cli import verify_attached_operators_cli
+
+
+class TestVerifyAttachedOperators(unittest.TestCase):
+
+    @patch("elliottlib.exectools.cmd_assert", autospec=True)
+    def test_nvr_for_operand_pullspec(self, mock_cmd):
+        runtime = MagicMock()
+        img_info = dict(config=dict(config=dict(Labels={
+            "com.redhat.component": "csi-provisioner-container",
+            "release": "42",
+            "version": "v4.9.0",
+        })))
+        mock_cmd.return_value = (json.dumps(img_info), "")
+
+        self.assertEqual(
+            "csi-provisioner-container-v4.9.0-42",
+            verify_attached_operators_cli._nvr_for_operand_pullspec(runtime, "something")
+        )


### PR DESCRIPTION
if an operator is missing, look up its NVR, not just its shasum