### PR TITLE
[ART-3400] find-builds: Change advisory state only when needed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ cover
 
 # Ignore ocp-build-data
 ocp-build-data/
+
+# Ignore functional tests artifacts
+summary_results.json

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
                 script {
                     catchError(stageResult: 'FAILURE') {
                         sh """
-                            tox_args="\$(git diff --name-only HEAD~5 | grep -Fxq -e requirements.txt -e requirements-dev.txt -e MANIFEST.in -e setup.py && echo '--recreate' || true)"
+                            tox_args="\$(git diff --name-only HEAD~10 | grep -Fxq -e requirements.txt -e requirements-dev.txt -e MANIFEST.in -e setup.py && echo '--recreate' || true)"
                             tox \$tox_args > results.txt 2>&1
                         """
                     }

--- a/elliottlib/cli/__main__.py
+++ b/elliottlib/cli/__main__.py
@@ -70,7 +70,7 @@ import bugzilla
 import click
 import requests
 import errata_tool.build
-from errata_tool import Erratum, ErrataException
+from errata_tool import ErrataException
 from spnego.exceptions import GSSError
 
 
@@ -129,7 +129,7 @@ def remove_bugs(runtime, advisory, default_advisory_type, id):
 
     if advisory:
         try:
-            advs = Erratum(errata_id=advisory)
+            advs = elliottlib.errata.Advisory(errata_id=advisory)
         except GSSError:
             exit_unauthenticated()
 
@@ -202,7 +202,7 @@ Fields for the short format: Release date, State, Synopsys, URL
         return
 
     try:
-        advisory = Erratum(errata_id=advisory)
+        advisory = elliottlib.errata.Advisory(errata_id=advisory)
     except GSSError:
         exit_unauthenticated()
 
@@ -331,8 +331,8 @@ providing an advisory with the -a/--advisory option.
 
     raw_bug_list = []
     if auto:
-        click.echo("Fetching Erratum(errata_id={})".format(advisory))
-        e = Erratum(errata_id=advisory)
+        click.echo("Fetching Advisory(errata_id={})".format(advisory))
+        e = elliottlib.errata.Advisory(errata_id=advisory)
         raw_bug_list = e.errata_bugs
     else:
         click.echo("Bypassed fetching erratum, using provided BZs")
@@ -630,7 +630,7 @@ unsigned builds.
         click.echo("Polling up to {} minutes for all RPMs to be signed".format(minutes))
 
     try:
-        e = Erratum(errata_id=advisory)
+        e = elliottlib.errata.Advisory(errata_id=advisory)
         all_builds = set([])
         all_signed = False
         # `errata_builds` is a dict with brew tags as keys, values are

--- a/elliottlib/constants.py
+++ b/elliottlib/constants.py
@@ -58,6 +58,8 @@ errata_inactive_advisory_labels = [
     "DROPPED_NO_SHIP"
 ]
 
+errata_states = errata_active_advisory_labels + errata_inactive_advisory_labels
+
 errata_shipped_advisory_label = "SHIPPED_LIVE"
 
 errata_valid_impetus = [
@@ -156,4 +158,3 @@ errata_get_comments_url = errata_url + "/api/v1/comments"
 errata_get_erratum_url = errata_url + "/api/v1/erratum/{id}"
 errata_post_erratum_url = errata_url + "/api/v1/erratum"
 errata_get_advisories_for_bug_url = errata_url + "/bugs/{id}/advisories.json"
-errata_remove_build_url = errata_url + "/api/v1/erratum/{id}/remove_build"

--- a/functional_tests/test_advisory_images.py
+++ b/functional_tests/test_advisory_images.py
@@ -24,3 +24,7 @@ class AdvisoryImagesTestCase(unittest.TestCase):
             ]
         )
         self.assertIn("\n#########\n", out.decode("utf-8"))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/functional_tests/test_change_state.py
+++ b/functional_tests/test_change_state.py
@@ -14,3 +14,7 @@ class ChangeStateTestCase(unittest.TestCase):
         )
         out, _ = p.communicate()
         self.assertIn("current state is SHIPPED_LIVE", out.decode("utf-8"))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/functional_tests/test_create.py
+++ b/functional_tests/test_create.py
@@ -13,3 +13,7 @@ class GreateTestCase(unittest.TestCase):
             ]
         )
         self.assertIn("Would have created advisory:", out.decode("utf-8"))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/functional_tests/test_find_bugs.py
+++ b/functional_tests/test_find_bugs.py
@@ -13,3 +13,7 @@ class FindBugsTestCase(unittest.TestCase):
             ]
         )
         six.assertRegex(self, out.decode("utf-8"), "Found \\d+ bugs")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/functional_tests/test_find_builds.py
+++ b/functional_tests/test_find_builds.py
@@ -25,3 +25,7 @@ class FindBuildsTestCase(unittest.TestCase):
             ]
         )
         self.assertIn("may be attached to an advisory", out.decode("utf-8"))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/functional_tests/test_find_builds.py
+++ b/functional_tests/test_find_builds.py
@@ -26,6 +26,23 @@ class FindBuildsTestCase(unittest.TestCase):
         )
         self.assertIn("may be attached to an advisory", out.decode("utf-8"))
 
+    def test_change_state(self):
+        """To attach a build to an advisory, it will be attempted to set the
+        advisory to NEW_FILES. This advisory is already SHIPPED_LIVE, and the
+        attempted change should fail"""
+
+        command = constants.ELLIOTT_CMD + [
+            f'--group=openshift-{version}',
+            '--images=openshift-enterprise-cli',
+            'find-builds',
+            '--kind=image',
+            '--attach=57899'
+        ]
+        result = subprocess.run(command, capture_output=True)
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn('Cannot change state', result.stdout.decode())
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/functional_tests/test_find_cve_trackers.py
+++ b/functional_tests/test_find_cve_trackers.py
@@ -13,3 +13,7 @@ class FindCVETrackersTestCase(unittest.TestCase):
             ]
         )
         six.assertRegex(self, out.decode("utf-8"), "Found \\d+ bugs")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/functional_tests/test_get.py
+++ b/functional_tests/test_get.py
@@ -11,3 +11,7 @@ class GetTestCase(unittest.TestCase):
     def test_get_errutum_with_group(self):
         out = subprocess.check_output(constants.ELLIOTT_CMD + ["--group=openshift-4.2", "get", "--use-default-advisory", "rpm"])
         self.assertIn(constants.ERRATA_TOOL_URL, out.decode("utf-8"))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/functional_tests/test_list.py
+++ b/functional_tests/test_list.py
@@ -12,3 +12,7 @@ class ListTestCase(unittest.TestCase):
             ]
         )
         self.assertIn(constants.ERRATA_TOOL_URL, out.decode("utf-8"))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/functional_tests/test_poll_signed.py
+++ b/functional_tests/test_poll_signed.py
@@ -13,3 +13,7 @@ class PollSignedTestCase(unittest.TestCase):
             ]
         )
         six.assertRegex(self, out.decode("utf-8"), "All builds signed|Signing incomplete")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/functional_tests/test_rpmdiff.py
+++ b/functional_tests/test_rpmdiff.py
@@ -22,3 +22,7 @@ class RPMDiffTestCase(unittest.TestCase):
             ]
         )
         six.assertRegex(self, out.decode("utf-8"), "good: \\d+, bad: \\d+, incomplete: \\d+")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/functional_tests/test_tarball_sources.py
+++ b/functional_tests/test_tarball_sources.py
@@ -21,3 +21,7 @@ class TarballSourcesTestCase(unittest.TestCase):
             ]
         )
         self.assertIn("All tarball sources are successfully created.", out.decode("utf-8"))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/functional_tests/test_verify_attached_bugs.py
+++ b/functional_tests/test_verify_attached_bugs.py
@@ -1,4 +1,4 @@
-from unittest import TestCase
+import unittest
 from mock import MagicMock, patch
 from functional_tests import constants
 import subprocess
@@ -7,7 +7,7 @@ from elliottlib.cli.verify_attached_bugs_cli import BugValidator
 from elliottlib import bzutil
 
 
-class VerifyBugs(TestCase):
+class VerifyBugs(unittest.TestCase):
 
     def setUp(self):
         self.patchers = [
@@ -103,3 +103,7 @@ class VerifyBugs(TestCase):
         )
         self.assertIn("bug 1856529 target release ['4.5.z'] is not in", out.stdout)
         self.assertEqual(1, out.returncode)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/functional_tests/test_verify_payload.py
+++ b/functional_tests/test_verify_payload.py
@@ -14,3 +14,7 @@ class VerifyPayloadTestCase(unittest.TestCase):
             ]
         )
         self.assertIn("Summary results:", out.decode("utf-8"))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -8,9 +8,9 @@ setenv =
     PYTHONPATH={toxinidir}/elliottlib
     PYTHONDONTWRITEBYTECODE=1
 commands =
-    flake8
     coverage run --branch --source elliottlib -m unittest discover -t . -s tests/
     coverage report
+    flake8
 
 [flake8]
 ignore =


### PR DESCRIPTION
This commit:
- Refactors Errata by extending the Errata class from errata_tool. Some
  common operations can now be executed on the advisory itself.
- Gets some testing in place for common advisory actions
- Calls `advisory.commit()` once, and not for each Product Version
- Changes the state of the advisory to NEW_FILES when builds need to get
  attached and the advisory is not in that state