### PR TITLE
Use new git commit format in release field

### DIFF
--- a/elliottlib/cli/tag_builds_cli.py
+++ b/elliottlib/cli/tag_builds_cli.py
@@ -54,7 +54,7 @@ def tag_builds_cli(runtime: Runtime, advisories: Tuple[int], default_advisory_ty
 
     Example 3: Tag specified builds into rhaos-4.3-rhel-8-image-build
 
-    $ elliott --group=openshift-4.3 tag-builds --build buildah-1.11.6-6.rhaos4.3.el8 --build openshift-4.3.23-202005230952.git.1.b596217.el8 --tag rhaos-4.3-rhel-8-image-build
+    $ elliott --group=openshift-4.3 tag-builds --build buildah-1.11.6-6.rhaos4.3.el8 --build openshift-4.3.23-202005230952.g1.b596217.el8 --tag rhaos-4.3-rhel-8-image-build
     """
     if advisories and builds:
         raise click.BadParameter('Use only one of --build or --advisory/-a.')

--- a/elliottlib/metadata.py
+++ b/elliottlib/metadata.py
@@ -149,7 +149,7 @@ class Metadata(object):
         :param extra_pattern: An extra glob pattern that must be matched in the middle of the
                          build's release field. Pattern must match release timestamp and components
                          like p? and git commit (up to, but not including ".assembly.<name>" release
-                         component). e.g. "*.git.<commit>.*   or '*.p1.*'
+                         component). e.g. "*.g<commit>.*   or '*.p1.*'
         :param build_state: 0=BUILDING, 1=COMPLETE, 2=DELETED, 3=FAILED, 4=CANCELED
         :param el_target: In the case of an RPM, which can build for multiple targets, you can specify
                             '7' for el7, '8' for el8, etc. You can also pass in a brew target that
@@ -172,10 +172,10 @@ class Metadata(object):
         rpm_suffix = ''  # By default, find the latest RPM build - regardless of el7, el8, ...
 
         if self.meta_type == 'image':
-            ver_prefix = 'v'  # openshift-enterprise-console-container-v4.7.0-202106032231.p0.git.d9f4379
+            ver_prefix = 'v'  # openshift-enterprise-console-container-v4.7.0-202106032231.p0.gd9f4379
         else:
             # RPMs do not have a 'v' in front of their version; images do.
-            ver_prefix = ''  # openshift-clients-4.7.0-202106032231.p0.git.e29b355.el8
+            ver_prefix = ''  # openshift-clients-4.7.0-202106032231.p0.ge29b355.el8
             if el_target:
                 el_target = f'-rhel-{el_target}'  # Whether the incoming value is an int, decimal str, or a target, normalize for regex
                 target_match = re.match(r'.*-rhel-(\d+)(?:-|$)', str(el_target))  # tolerate incoming int with str()

--- a/functional_tests/test_verify_attached_operators.py
+++ b/functional_tests/test_verify_attached_operators.py
@@ -32,7 +32,7 @@ class TestVerifyAttachedOperators(TestCase):
 
         spec = "ose-csi-external-provisioner@sha256:cb191fcfe71ce6da60e73697aaa9b3164c1f0566150d3bffb8004598284d767a"
         self.assertEqual(
-            "csi-provisioner-container-v4.9.0-202109302317.p0.git.7736e72.assembly.stream",
+            "csi-provisioner-container-v4.9.0-202109302317.p0.g7736e72.assembly.stream",
             verify_attached_operators_cli._nvr_for_operand_pullspec(runtime, spec)
         )
 
@@ -53,5 +53,5 @@ class TestVerifyAttachedOperators(TestCase):
             capture_output=True,
             encoding='utf-8',
         )
-        self.assertIn("csi-provisioner-container-v4.9.0-202109302317.p0.git.7736e72.assembly.stream", out.stdout)
+        self.assertIn("csi-provisioner-container-v4.9.0-202109302317.p0.g7736e72.assembly.stream", out.stdout)
         self.assertEqual(1, out.returncode)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -60,7 +60,7 @@ class TestMetadata(unittest.TestCase):
             release += f'.{p}'
 
         if git_commit:
-            release += f'.git.{git_commit[:7]}'
+            release += f'.g{git_commit[:7]}'
 
         if assembly is not None:
             release += f'.assembly.{assembly}{release_suffix}'
@@ -196,12 +196,12 @@ class TestMetadata(unittest.TestCase):
         # Check whether extra pattern matching works
         builds = [
             self.build_record(now - datetime.timedelta(hours=5), assembly='stream'),
-            self.build_record(now - datetime.timedelta(hours=25), assembly='stream', release_prefix='99999.git.1234567', release_suffix='.el8'),
+            self.build_record(now - datetime.timedelta(hours=25), assembly='stream', release_prefix='99999.g1234567', release_suffix='.el8'),
             self.build_record(now - datetime.timedelta(hours=5), assembly=runtime.assembly),
             self.build_record(now, assembly='not_ours'),
             self.build_record(now - datetime.timedelta(hours=8), assembly=f'{runtime.assembly}')
         ]
-        self.assertEqual(meta.get_latest_build(koji_mock, default=None, extra_pattern='*.git.1234567.*'), builds[1])
+        self.assertEqual(meta.get_latest_build(koji_mock, default=None, extra_pattern='*.g1234567.*'), builds[1])
 
     def test_get_latest_build_multi_target(self):
         meta = self.meta

--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -712,8 +712,8 @@ ansible-kubernetes-modules-0.4.0-8.el7.src
 ansible-service-broker-1.1.17-1.el7.src
 apb-1.1.15-1.el7.src
 apb-base-scripts-1.1.5-1.el7.src
-atomic-openshift-3.9.15-1.git.0.3cffafd.el7.src
-atomic-openshift-descheduler-3.9.13-1.git.267.bb59a3f.el7.src
+atomic-openshift-3.9.15-1.g0.3cffafd.el7.src
+atomic-openshift-descheduler-3.9.13-1.g267.bb59a3f.el7.src
 atomic-openshift-dockerregistry-3.9.15-1.git.349.4cf0d1a.el7.src
 atomic-openshift-node-problem-detector-3.9.13-1.git.167.5d6b0d4.el7.src
 atomic-openshift-web-console-3.9.15-1.git.230.9dccb91.el7.src

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -50,27 +50,27 @@ class TestUtil(unittest.TestCase):
         self.assertEqual([13, 23, 33], [b["id"] for b in actual])
 
     def test_isolate_timestamp_in_release(self):
-        actual = util.isolate_timestamp_in_release("foo-4.7.0-202107021813.p0.git.01c9f3f.el8")
+        actual = util.isolate_timestamp_in_release("foo-4.7.0-202107021813.p0.g01c9f3f.el8")
         expected = "202107021813"
         self.assertEqual(actual, expected)
 
-        actual = util.isolate_timestamp_in_release("foo-container-v4.7.0-202107021907.p0.git.8b4b094")
+        actual = util.isolate_timestamp_in_release("foo-container-v4.7.0-202107021907.p0.g8b4b094")
         expected = "202107021907"
         self.assertEqual(actual, expected)
 
-        actual = util.isolate_timestamp_in_release("foo-container-v4.7.0-202107021907.p0.git.8b4b094")
+        actual = util.isolate_timestamp_in_release("foo-container-v4.7.0-202107021907.p0.g8b4b094")
         expected = "202107021907"
         self.assertEqual(actual, expected)
 
-        actual = util.isolate_timestamp_in_release("foo-container-v4.8.0-202106152230.p0.git.25122f5.assembly.stream")
+        actual = util.isolate_timestamp_in_release("foo-container-v4.8.0-202106152230.p0.g25122f5.assembly.stream")
         expected = "202106152230"
         self.assertEqual(actual, expected)
 
-        actual = util.isolate_timestamp_in_release("foo-container-v4.7.0-1.p0.git.8b4b094")
+        actual = util.isolate_timestamp_in_release("foo-container-v4.7.0-1.p0.g8b4b094")
         expected = None
         self.assertEqual(actual, expected)
 
-        actual = util.isolate_timestamp_in_release("foo-container-v4.7.0-202199999999.p0.git.8b4b094")
+        actual = util.isolate_timestamp_in_release("foo-container-v4.7.0-202199999999.p0.g8b4b094")
         expected = None
         self.assertEqual(actual, expected)
 


### PR DESCRIPTION
See https://github.com/openshift/doozer/pull/527.

There's no code in Elliott using the git commit hash. This PR just updates
comments and tests to keep consistency with Doozer.