### PR TITLE
[ART-3383] Verify bugs not (yet) attached to advisories

### DIFF
--- a/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliottlib/cli/verify_attached_bugs_cli.py
@@ -41,7 +41,7 @@ def verify_attached_bugs_cli(runtime, verify_bug_status, advisories):
 def verify_bugs_cli(runtime, verify_bug_status, bug_ids):
     runtime.initialize()
     validator = BugValidator(runtime)
-    bugs = list(bzutil.get_bugs(validator.bzapi, bug_ids, True).values())
+    bugs = validator._filter_bugs_by_product(list(bzutil.get_bugs(validator.bzapi, bug_ids, True).values()))
     validator.validate(bugs, verify_bug_status)
 
 

--- a/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliottlib/cli/verify_attached_bugs_cli.py
@@ -1,4 +1,5 @@
 import click
+import re
 from spnego.exceptions import GSSError
 
 from errata_tool import Erratum
@@ -107,12 +108,14 @@ class BugValidator:
         v = minor_version_tuple(self.target_releases[0])
         next_version = (v[0], v[1] + 1)
 
+        pattern = re.compile(r'^[0-9]+\.[0-9]+\.(0|z)$')
+
         # retrieve blockers and filter to those with correct product and target version
         blocking_bugs = {
             bug.id: bug
             for bug in bzutil.get_bugs(self.bzapi, list(candidate_blockers)).values()
             # b.target release is a list of size 0 or 1
-            if any(minor_version_tuple(target) == next_version for target in bug.target_release)
+            if any(minor_version_tuple(target) == next_version for target in bug.target_release if pattern.match(target))
             and bug.product == self.product
         }
 

--- a/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliottlib/cli/verify_attached_bugs_cli.py
@@ -81,10 +81,7 @@ class BugValidator:
 
     def _get_attached_filtered_bugs(self, advisories):
         # get bugs from advisories that are for the expected product and version
-        candidates = self._get_attached_bugs(advisories)
-
-        # filter out bugs for different product (presumably security flaw bugs)
-        candidates = [b for b in candidates if b.product == self.product]
+        candidates = self._filter_bugs_by_product(self._get_attached_bugs(advisories))
 
         # filter out bugs with an invalid target release (and complain)
         filtered_bugs = []
@@ -99,6 +96,10 @@ class BugValidator:
                 )
 
         return filtered_bugs
+
+    def _filter_bugs_by_product(self, bugs):
+        # filter out bugs for different product (presumably security flaw bugs)
+        return [b for b in bugs if b.product == self.product]
 
     def _get_blocking_bugs_for(self, bugs):
         # get blocker bugs in the next version for all bugs we are examining

--- a/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliottlib/cli/verify_attached_bugs_cli.py
@@ -28,7 +28,9 @@ def verify_attached_bugs_cli(runtime, verify_bug_status, advisories):
     if not advisories:
         red_print("No advisories specified on command line or in group.yml")
         exit(1)
-    BugValidator(runtime).validate(advisories, verify_bug_status)
+    validator = BugValidator(runtime)
+    bugs = validator._get_attached_filtered_bugs(advisories)
+    validator.validate(bugs, verify_bug_status)
 
 
 class BugValidator:
@@ -41,8 +43,7 @@ class BugValidator:
         self.bzapi = bzutil.get_bzapi(self.bz_data)
         self.problems = []
 
-    def validate(self, advisories, verify_bug_status):
-        bugs = self._get_attached_filtered_bugs(advisories)
+    def validate(self, bugs, verify_bug_status):
         blocking_bugs_for = self._get_blocking_bugs_for(bugs)
         self._verify_blocking_bugs(blocking_bugs_for)
 

--- a/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliottlib/cli/verify_attached_bugs_cli.py
@@ -33,6 +33,17 @@ def verify_attached_bugs_cli(runtime, verify_bug_status, advisories):
     validator.validate(bugs, verify_bug_status)
 
 
+@cli.command("verify-bugs", short_help="Same as verify-attached-bugs, but for bugs that are not (yet) attached to advisories")
+@click.option("--verify-bug-status", is_flag=True, help="Check that bugs of advisories are all VERIFIED or more", type=bool, default=False)
+@click.argument("bug_ids", nargs=-1, type=click.IntRange(1), required=False)
+@pass_runtime
+def verify_bugs_cli(runtime, verify_bug_status, bug_ids):
+    runtime.initialize()
+    validator = BugValidator(runtime)
+    bugs = list(bzutil.get_bugs(validator.bzapi, bug_ids, True).values())
+    validator.validate(bugs, verify_bug_status)
+
+
 class BugValidator:
 
     def __init__(self, runtime):

--- a/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliottlib/cli/verify_attached_bugs_cli.py
@@ -30,7 +30,7 @@ def verify_attached_bugs_cli(runtime, verify_bug_status, advisories):
         red_print("No advisories specified on command line or in group.yml")
         exit(1)
     validator = BugValidator(runtime)
-    bugs = validator._get_attached_filtered_bugs(advisories)
+    bugs = validator.get_attached_filtered_bugs(advisories)
     validator.validate(bugs, verify_bug_status)
 
 
@@ -41,7 +41,7 @@ def verify_attached_bugs_cli(runtime, verify_bug_status, advisories):
 def verify_bugs_cli(runtime, verify_bug_status, bug_ids):
     runtime.initialize()
     validator = BugValidator(runtime)
-    bugs = validator._filter_bugs_by_product(list(bzutil.get_bugs(validator.bzapi, bug_ids, True).values()))
+    bugs = validator.filter_bugs_by_product(list(bzutil.get_bugs(validator.bzapi, bug_ids, True).values()))
     validator.validate(bugs, verify_bug_status)
 
 
@@ -79,9 +79,9 @@ class BugValidator:
 
         return list(bzutil.get_bugs(self.bzapi, list(bugs)).values())
 
-    def _get_attached_filtered_bugs(self, advisories):
+    def get_attached_filtered_bugs(self, advisories):
         # get bugs from advisories that are for the expected product and version
-        candidates = self._filter_bugs_by_product(self._get_attached_bugs(advisories))
+        candidates = self.filter_bugs_by_product(self._get_attached_bugs(advisories))
 
         # filter out bugs with an invalid target release (and complain)
         filtered_bugs = []
@@ -97,7 +97,7 @@ class BugValidator:
 
         return filtered_bugs
 
-    def _filter_bugs_by_product(self, bugs):
+    def filter_bugs_by_product(self, bugs):
         # filter out bugs for different product (presumably security flaw bugs)
         return [b for b in bugs if b.product == self.product]
 


### PR DESCRIPTION
## What changed

Introduced a new CLI command, `verify-bugs`, that is similar to `verify-attached-bugs`, but without the need of advisories. It receives a list of bug IDs as arguments.

## Why

To be able to verify potential regressions before we prepare release. With this new command, we can verify bugs that will be swept to advisories, before the advisories even exist.

The intention is to use this command inside a scheduled job, that will check for potential regressions once a day and inform us the findings on Slack, so we can be aware and alert people earlier in the process, in the hopes that issues will be addressed before Wednesday, and not delay promotions.

## Usage example

```
$ bugs="$(elliott -g openshift-4.9 find-bugs --mode sweep | tail -n1 | cut -d':' -f2 | tr -d ,)"

$ echo $bugs
1954309 1972082 1973585 1989798 1992744 1995190 1996155 1997072 2000858 2002006 2002856 2002878 2002905 2003870 2003893 2004052 2004075 2004380 2004569 2004816 2005338 2008175 2008499 2008827 2009493 2009515 2009670 2009787 2009849 2009850 2009857 2010160 2010225 2010677 2010681 2011385 2011705 2012025 2012798 2013017 2013105 2013690 2014021 2014145 2014303 2014633 2014711 2015571 2015706 2015829 2016028 2016174 2016267 2016556 2016945 2017020 2017066 2017245 2017412 2017434 2017484 2017488 2017745 2017759 2017977 2017985 2018148 2018455 2018496 2018516 2018557 2018637 2019494 2019518 2019736 2019906 2019907

$ elliott -g openshift-4.9 verify-bugs $bugs
Regression possible: bug 2008175 is a backport of bug 2013646 which has status ON_QA
Regression possible: bug 2012025 is a backport of bug 2007443 which has status ON_QA
Regression possible: bug 2013690 is a backport of bug 2013273 which has status ON_QA
Some bug problems were listed above. Please investigate.
```