### PR TITLE
Check go version in containers named "go-toolset"

### DIFF
--- a/elliottlib/util.py
+++ b/elliottlib/util.py
@@ -560,7 +560,7 @@ def get_golang_container_nvrs(nvrs, logger):
         go_version = 'N/A'
         nvr = (build['name'], build['version'], build['release'])
         name = nvr[0]
-        if 'golang-builder' in name:
+        if 'golang-builder' in name or 'go-toolset' in name:
             go_version = golang_builder_version(nvr, logger)
             go_container_nvrs[name] = {
                 'nvr': nvr,
@@ -575,7 +575,7 @@ def get_golang_container_nvrs(nvrs, logger):
             continue
 
         for p, pinfo in parents.items():
-            if 'builder' in p:
+            if 'builder' in p or 'go-toolset' in p:
                 go_version = pinfo.get('nvr')
 
         go_container_nvrs[name] = {


### PR DESCRIPTION
This helps for advisories for products like openshift serverless, e.g. 

```
$ ./elliott go -a 79064
Following nvrs are built with N/A:
openshift-serverless-1-kn-cli-artifacts-rhel8-container-0.23.2-1
openshift-serverless-1-must-gather-rhel8-container-1.17.0-5
openshift-serverless-1-serverless-operator-bundle-container-1.17.0-11
Following nvrs are built with go-toolset-container-1.15.14-3:
openshift-serverless-1-client-kn-rhel8-container-0.23.2-2
openshift-serverless-1-eventing-apiserver-receive-adapter-rhel8-container-0.23.0-5
openshift-serverless-1-eventing-controller-rhel8-container-0.23.0-5
openshift-serverless-1-eventing-in-memory-channel-controller-rhel8-container-0.23.0-5
openshift-serverless-1-eventing-in-memory-channel-dispatcher-rhel8-container-0.23.0-5
openshift-serverless-1-eventing-kafka-channel-controller-rhel8-container-0.23.0-4
openshift-serverless-1-eventing-kafka-channel-dispatcher-rhel8-container-0.23.0-4
openshift-serverless-1-eventing-kafka-channel-webhook-rhel8-container-0.23.0-4
openshift-serverless-1-eventing-kafka-source-controller-rhel8-container-0.23.0-4
openshift-serverless-1-eventing-kafka-source-receive-adapter-rhel8-container-0.23.0-4
openshift-serverless-1-eventing-kafka-storage-version-migration-rhel8-container-0.23.0-5
openshift-serverless-1-eventing-mtbroker-filter-rhel8-container-0.23.0-5
openshift-serverless-1-eventing-mtbroker-ingress-rhel8-container-0.23.0-5
openshift-serverless-1-eventing-mtchannel-broker-rhel8-container-0.23.0-5
openshift-serverless-1-eventing-mtping-rhel8-container-0.23.0-5
openshift-serverless-1-eventing-ping-source-cleanup-rhel8-container-0.23.0-2
openshift-serverless-1-eventing-storage-version-migration-rhel8-container-0.23.0-5
openshift-serverless-1-eventing-sugar-controller-rhel8-container-0.23.0-5
openshift-serverless-1-eventing-webhook-rhel8-container-0.23.0-5
openshift-serverless-1-ingress-rhel8-operator-container-1.17.0-5
openshift-serverless-1-knative-rhel8-operator-container-1.17.0-5
openshift-serverless-1-kourier-control-rhel8-container-0.23.0-4
openshift-serverless-1-net-istio-controller-rhel8-container-0.23.0-4
openshift-serverless-1-net-istio-webhook-rhel8-container-0.23.0-4
openshift-serverless-1-serverless-rhel8-operator-container-1.17.0-5
openshift-serverless-1-serving-activator-rhel8-container-0.23.1-2
openshift-serverless-1-serving-autoscaler-hpa-rhel8-container-0.23.1-2
openshift-serverless-1-serving-autoscaler-rhel8-container-0.23.1-2
openshift-serverless-1-serving-controller-rhel8-container-0.23.1-2
openshift-serverless-1-serving-domain-mapping-rhel8-container-0.23.1-2
openshift-serverless-1-serving-domain-mapping-webhook-rhel8-container-0.23.1-2
openshift-serverless-1-serving-queue-rhel8-container-0.23.1-2
openshift-serverless-1-serving-storage-version-migration-rhel8-container-0.23.1-2
openshift-serverless-1-serving-webhook-rhel8-container-0.23.1-2
```