### PR TITLE
[rhcos] Support nightly and assembly

### DIFF
--- a/elliottlib/assembly.py
+++ b/elliottlib/assembly.py
@@ -86,7 +86,6 @@ def assembly_group_config(releases_config: Model, assembly: str, group_config: M
     target_assembly_group = target_assembly.group
     if not target_assembly_group:
         return group_config
-
     return Model(dict_to_model=merger(target_assembly_group.primitive(), group_config.primitive()))
 
 

--- a/elliottlib/cli/rhcos_cli.py
+++ b/elliottlib/cli/rhcos_cli.py
@@ -168,6 +168,7 @@ def _via_build_id(build_id, arch, version, packages, go, logger):
     if not build_id:
         Exception('Cannot find build_id')
 
+    arch = util.brew_arch_for_go_arch(arch)
     util.green_print(f'Build: {build_id} Arch: {arch}')
     nvrs = rhcos.get_rpm_nvrs(build_id, version, arch)
     if not nvrs:

--- a/elliottlib/util.py
+++ b/elliottlib/util.py
@@ -582,7 +582,7 @@ def get_golang_container_nvrs(nvrs, logger):
             'nvr': nvr,
             'go': go_version
         }
-        if not go_version:
+        if not go_version or go_version == 'N/A':
             logger.debug(f'Could not find parent Go builder image for {nvr}')
 
     return go_container_nvrs
@@ -618,13 +618,13 @@ def get_golang_rpm_nvrs(nvrs, logger):
             logger.debug(f'Could not find brew log for {nvr}')
         else:
             try:
-                go_version = get_golang_version_from_build_log(root_log)
+                go_version = get_golang_version_from_build_log(root_log)[2]
             except AttributeError:
                 logger.debug(f'Could not find go version in root log for {nvr}')
 
         go_rpm_nvrs[nvr[0]] = {
             'nvr': nvr,
-            'go': go_version[2]
+            'go': go_version
         }
     return go_rpm_nvrs
 


### PR DESCRIPTION
Summary:
This expands the elliott rhcos command to support nightly and assemblies lookup. 
Assembly lookup is useful when the release hasn't been promoted, and we want to verify some package.
Also removes latest and latest_ocp options - since they weren't essential to the command nor had enough utility to keep supporting the complexity they bring

Test
- `elliott -g openshift-4.9 rhcos -r 4.9.0-0.nightly-arm64-2021-12-20-082621 -p selinux-policy`
- `elliott -g openshift-4.9 --assembly 4.9.8 rhcos -p selinux-policy`