### PR TITLE
Ensure 3.2+ is used for python-bugzilla

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ kobo ~= 0.19.0
 rpm
 semver
 pygit2 == 1.6.*
-python-bugzilla >= 3.0.2
+python-bugzilla >= 3.2
 pyyaml
 requests
 requests_kerberos >= 0.13


### PR DESCRIPTION
Soon, Authentication will change for bugzilla. Release 3.2.0 of
python-bugzilla accomodates for this change by removing cookiefile
support and adding an `Authorization: Bearer <blurp>` to the request
headers.

Target Dates:
dev: Mon 17th Jan 00:00 UTC (Completed)
qa: Mon 31st Jan 00:00 UTC
stage: Mon 07th Feb 00:00 UTC
prod: Mon 28th Feb 00:00 UTC

From https://mailman-int.corp.redhat.com/archives/bugzilla-list/2022-January/msg00004.html