### PR TITLE
Reduce bug lookup batch size

### DIFF
--- a/elliottlib/cli/find_bugs_cli.py
+++ b/elliottlib/cli/find_bugs_cli.py
@@ -232,6 +232,8 @@ advisory with the --add option.
             for chunk_of_bugs in chunk(bugs, constants.BUG_LOOKUP_CHUNK_SIZE):
                 qualified_bugs.extend(bzutil.filter_bugs_by_cutoff_event(bzapi, chunk_of_bugs, status,
                                                                          sweep_cutoff_timestamp))
+                print('.',end='')
+            print()
             click.echo(f"{len(qualified_bugs)} of {len(bugs)} bugs are qualified for the cutoff time {datetime.utcfromtimestamp(sweep_cutoff_timestamp)}...")
             bugs = qualified_bugs
 

--- a/elliottlib/cli/find_bugs_cli.py
+++ b/elliottlib/cli/find_bugs_cli.py
@@ -232,7 +232,7 @@ advisory with the --add option.
             for chunk_of_bugs in chunk(bugs, constants.BUG_LOOKUP_CHUNK_SIZE):
                 qualified_bugs.extend(bzutil.filter_bugs_by_cutoff_event(bzapi, chunk_of_bugs, status,
                                                                          sweep_cutoff_timestamp))
-                print('.',end='')
+                print('.', end='')
             print()
             click.echo(f"{len(qualified_bugs)} of {len(bugs)} bugs are qualified for the cutoff time {datetime.utcfromtimestamp(sweep_cutoff_timestamp)}...")
             bugs = qualified_bugs

--- a/elliottlib/cli/find_bugs_cli.py
+++ b/elliottlib/cli/find_bugs_cli.py
@@ -232,8 +232,6 @@ advisory with the --add option.
             for chunk_of_bugs in chunk(bugs, constants.BUG_LOOKUP_CHUNK_SIZE):
                 qualified_bugs.extend(bzutil.filter_bugs_by_cutoff_event(bzapi, chunk_of_bugs, status,
                                                                          sweep_cutoff_timestamp))
-                print('.', end='')
-            print()
             click.echo(f"{len(qualified_bugs)} of {len(bugs)} bugs are qualified for the cutoff time {datetime.utcfromtimestamp(sweep_cutoff_timestamp)}...")
             bugs = qualified_bugs
 

--- a/elliottlib/constants.py
+++ b/elliottlib/constants.py
@@ -21,7 +21,7 @@ BUG_SEVERITY_NUMBER_MAP = {
     "urgent": 4,
 }
 
-BUG_LOOKUP_CHUNK_SIZE = 500
+BUG_LOOKUP_CHUNK_SIZE = 100
 BUG_ATTACH_CHUNK_SIZE = 100
 
 # When severity isn't set on all tracking and flaw bugs, default to "Low"

--- a/elliottlib/errata.py
+++ b/elliottlib/errata.py
@@ -502,7 +502,7 @@ def add_bugs_with_retry(advisory, bugs, noop=False, batch_size=constants.BUG_ATT
         return
 
     bugs = list(new_bugs)
-    green_prefix(f"Adding bugs in batches of {batch_size}")
+    green_prefix(f"Adding bugs in batches of {batch_size}\n")
     for chunk_of_bugs in chunk(bugs, batch_size):
         if noop:
             print('Dry run: Would have attached bugs')
@@ -511,7 +511,7 @@ def add_bugs_with_retry(advisory, bugs, noop=False, batch_size=constants.BUG_ATT
             advs.addBugs(chunk_of_bugs)
             advs.commit()
         except ErrataException as e:
-            print("ErrataException Message: {}, retry it again".format(e))
+            print(f"ErrataException Message: {e}\nRetrying...")
             block_list = parse_exception_error_message(e)
             retry_list = [x for x in chunk_of_bugs if x not in block_list]
             if len(retry_list) == 0:


### PR DESCRIPTION
With current size of 500, still see bugzilla timing out - 
https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fprepare-release/227/console