### PR TITLE
Exit code 1 prevents capturing stdout in Jenkins

### DIFF
--- a/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliottlib/cli/verify_attached_bugs_cli.py
@@ -89,7 +89,7 @@ class BugValidator:
 
         if self.problems:
             red_print("Some bug problems were listed above. Please investigate.")
-            exit(1)
+            exit(0)
         green_print("All bugs were verified.")
 
     async def verify_attached_flaws(self, advisory_bugs: Dict[int, List[Bug]]):


### PR DESCRIPTION
Currently, Jenkins does not allow capturing the `stdout` of a failing command, even when the exception is caught. This prevents our automation from notifying the details of the issue encountered. Specifically, the `elliott verify-bugs` command output will not be available when regressions are found. I suggest we change this behavior until this bug is fixed in Jenkins:

https://issues.jenkins.io/browse/JENKINS-44930