### PR TITLE
verify-attached-bugs: Fix some --verify-flaws issues

### DIFF
--- a/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliottlib/cli/verify_attached_bugs_cli.py
@@ -90,7 +90,7 @@ class BugValidator:
         if self.problems:
             red_print("Some bug problems were listed above. Please investigate.")
             exit(1)
-        green_print("All bugs were verified.")
+        green_print("All bugs were verified. This check doesn't cover CVE flaw bugs.")
 
     async def verify_attached_flaws(self, advisory_bugs: Dict[int, List[Bug]]):
         futures = []
@@ -99,6 +99,10 @@ class BugValidator:
             attached_flaws = [b for b in attached_bugs if bzutil.is_flaw_bug(b)]
             futures.append(self._verify_attached_flaws_for(advisory_id, attached_trackers, attached_flaws))
         await asyncio.gather(*futures)
+        if self.problems:
+            red_print("Some bug problems were listed above. Please investigate.")
+            exit(1)
+        green_print("All CVE flaw bugs were verified.")
 
     async def _verify_attached_flaws_for(self, advisory_id: int, attached_trackers: Iterable[Bug], attached_flaws: Iterable[Bug]):
         # Retrieve flaw bugs in Bugzilla for attached_tracker_bugs

--- a/elliottlib/errata_async.py
+++ b/elliottlib/errata_async.py
@@ -14,7 +14,7 @@ _LOGGER = logging.getLogger(__name__)
 class AsyncErrataAPI:
     def __init__(self, url: str):
         self._errata_url = urlparse(url).geturl()
-        self._session = aiohttp.ClientSession(connector=aiohttp.TCPConnector(limit=32))
+        self._session = aiohttp.ClientSession(connector=aiohttp.TCPConnector(limit=32, force_close=True))
         self._gssapi_client_ctx = None
         self._headers = {
             "Content-Type": "application/json",


### PR DESCRIPTION
- The Errata server doesn't seem to support keep-alive. Using `force_close=True` option to solve the `aiohttp.client_exceptions.ServerDisconnectedError`.
- Exit with non-zero if `--verify-flaws` finds any issues.