### PR TITLE
Apply slack formatting to URL

### DIFF
--- a/elliottlib/cli/find_bugs_cli.py
+++ b/elliottlib/cli/find_bugs_cli.py
@@ -409,7 +409,7 @@ def add_flags(bugs: type_bug_list, flags: List[str], noop: bool) -> None:
 def print_report(bugs: type_bug_list, output: str = 'text') -> None:
     if output == 'slack':
         for bug in bugs:
-            click.echo("[{}]({:<12s}) {:<25s} ".format(bug.id, bug.weburl, bug.component))
+            click.echo("<{}|{}> - {:<25s} ".format(bug.weburl, bug.id, bug.component))
 
     elif output == 'json':
         print(json.dumps(


### PR DESCRIPTION
Current formatting does not pretty print URLs to Slack channels; this PR applies <url|link text> format instead.

See https://github.com/openshift/doozer/blob/master/doozerlib/cli/images_health.py#L51 for details