### PR TITLE
Consolidate get_latest_build and call it in parallel

### DIFF
--- a/elliottlib/cli/find_builds_cli.py
+++ b/elliottlib/cli/find_builds_cli.py
@@ -311,9 +311,6 @@ def _fetch_builds_by_kind_image(runtime: Runtime, tag_pv_map: Dict[str, str],
         f'Hold on a moment, fetching Brew builds for {len(image_metas)} components...')
 
     brew_latest_builds: List[Dict] = asyncio.get_event_loop().run_until_complete(asyncio.gather(*[exectools.to_thread(progress_func, image.get_latest_build) for image in image_metas]))
-    # for image in image_metas:
-    #     LOGGER.info("Getting latest build for %s...", image.distgit_key)
-    #     brew_latest_builds.append(image.get_latest_build())
 
     _ensure_accepted_tags(brew_latest_builds, brew_session, tag_pv_map)
 

--- a/elliottlib/metadata.py
+++ b/elliottlib/metadata.py
@@ -1,7 +1,7 @@
 import re
 import time
 from builtins import object
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple, Union
 
 import yaml
 from koji import ClientSession
@@ -10,6 +10,7 @@ from elliottlib import logutil
 from elliottlib.assembly import assembly_basis_event, assembly_metadata_config
 from elliottlib.brew import BuildStates
 from elliottlib.model import Missing, Model
+from elliottlib.util import isolate_el_version_in_brew_tag
 
 CONFIG_MODES = [
     'enable',  # business as usual
@@ -138,10 +139,10 @@ class Metadata(object):
         split = self.branch().split('-')  # e.g. ['rhaos', '4.8', 'rhel', '8']
         return split[1]
 
-    def get_latest_build(self, koji_api: ClientSession, event: Optional[int] = None, default=-1, assembly=None, extra_pattern='*', build_state: BuildStates = BuildStates.COMPLETE, el_target=None, honor_is=True):
+    def get_latest_build(self, default: Optional[Any] = -1, assembly: Optional[str] = None, extra_pattern: str = '*',
+                         build_state: BuildStates = BuildStates.COMPLETE, component_name: Optional[str] = None,
+                         el_target: Optional[Union[str, int]] = None, honor_is: bool = True, complete_before_event: Optional[int] = None):
         """
-        :param koji_api: An instance of koji.ClientSession
-        :param event: Brew event ID
         :param default: A value to return if no latest is found (if not specified, an exception will be thrown)
         :param assembly: A non-default assembly name to search relative to. If not specified, runtime.assembly
                          will be used. If runtime.assembly is also None, the search will return true latest.
@@ -151,151 +152,167 @@ class Metadata(object):
                          like p? and git commit (up to, but not including ".assembly.<name>" release
                          component). e.g. "*.g<commit>.*   or '*.p1.*'
         :param build_state: 0=BUILDING, 1=COMPLETE, 2=DELETED, 3=FAILED, 4=CANCELED
+        :param component_name: If not specified, looks up builds for self component.
         :param el_target: In the case of an RPM, which can build for multiple targets, you can specify
                             '7' for el7, '8' for el8, etc. You can also pass in a brew target that
-                            contains '....-rhel-?..' and the number will be extraced. If you want the true
+                            contains '....-rhel-?..' and the number will be extracted. If you want the true
                             latest, leave as None.
         :param honor_is: If True, and an assembly component specifies 'is', that nvr will be returned.
-        :return: Returns the most recent build object from koji for this package & assembly.
+        :param complete_before_event: If a value is specified >= 0, the search will be constrained to builds which completed before
+                                      the specified brew_event. If a value is specified < 0, the search will be conducted with no constraint on
+                                      brew event. If no value is specified, the search will be relative to the current assembly's basis event.
+        :return: Returns the most recent build object from koji for the specified component & assembly.
                  Example https://gist.github.com/jupierce/57e99b80572336e8652df3c6be7bf664
         """
-        component_name = self.get_component_name()
+        if not component_name:
+            component_name = self.get_component_name()
         builds = []
 
-        package_info = koji_api.getPackage(component_name)  # e.g. {'id': 66873, 'name': 'atomic-openshift-descheduler-container'}
-        if not package_info:
-            raise IOError(f'No brew package is defined for {component_name}')
-        package_id = package_info['id']  # we could just constrain package name using pattern glob, but providing package ID # should be a much more efficient DB query.
-        # listBuilds returns all builds for the package; We need to limit the query to the builds
-        # relevant for our major/minor.
+        with self.runtime.pooled_koji_client_session(caching=True) as koji_api:
+            package_info = koji_api.getPackage(component_name)  # e.g. {'id': 66873, 'name': 'atomic-openshift-descheduler-container'}
+            if not package_info:
+                raise IOError(f'No brew package is defined for {component_name}')
+            package_id = package_info['id']  # we could just constrain package name using pattern glob, but providing package ID # should be a much more efficient DB query.
+            # listBuilds returns all builds for the package; We need to limit the query to the builds
+            # relevant for our major/minor.
 
-        rpm_suffix = ''  # By default, find the latest RPM build - regardless of el7, el8, ...
+            rpm_suffix = ''  # By default, find the latest RPM build - regardless of el7, el8, ...
 
-        if self.meta_type == 'image':
-            ver_prefix = 'v'  # openshift-enterprise-console-container-v4.7.0-202106032231.p0.gd9f4379
-        else:
-            # RPMs do not have a 'v' in front of their version; images do.
-            ver_prefix = ''  # openshift-clients-4.7.0-202106032231.p0.ge29b355.el8
-            if el_target:
-                el_target = f'-rhel-{el_target}'  # Whether the incoming value is an int, decimal str, or a target, normalize for regex
-                target_match = re.match(r'.*-rhel-(\d+)(?:-|$)', str(el_target))  # tolerate incoming int with str()
-                if target_match:
-                    rpm_suffix = f'.el{target_match.group(1)}'
+            el_ver = None
+            if self.meta_type == 'image':
+                ver_prefix = 'v'  # openshift-enterprise-console-container-v4.7.0-202106032231.p0.git.d9f4379
+            else:
+                # RPMs do not have a 'v' in front of their version; images do.
+                ver_prefix = ''  # openshift-clients-4.7.0-202106032231.p0.git.e29b355.el8
+                if el_target:
+                    el_ver = isolate_el_version_in_brew_tag(el_target)
+                    if el_ver:
+                        rpm_suffix = f'.el{el_ver}'
+                    else:
+                        raise IOError(f'Unable to determine rhel version from specified el_target: {el_target}')
+
+            pattern_prefix = f'{component_name}-{ver_prefix}{self.branch_major_minor()}.'
+
+            if assembly is None:
+                assembly = self.runtime.assembly
+
+            list_builds_kwargs = {}  # extra kwargs that will be passed to koji_api.listBuilds invocations
+            if complete_before_event is not None:
+                if complete_before_event < 0:
+                    # By setting the parameter to None, it tells the koji wrapper to not bound the brew event.
+                    list_builds_kwargs['completeBefore'] = None
                 else:
-                    raise IOError(f'Unable to determine rhel version from specified el_target: {el_target}')
+                    # listBuilds accepts timestamps, not brew events, so convert brew event into seconds since the epoch
+                    complete_before_ts = koji_api.getEvent(complete_before_event)['ts']
+                    list_builds_kwargs['completeBefore'] = complete_before_ts
 
-        pattern_prefix = f'{component_name}-{ver_prefix}{self.branch_major_minor()}.'
+            def default_return():
+                msg = f"No builds detected for using prefix: '{pattern_prefix}', extra_pattern: '{extra_pattern}', assembly: '{assembly}', build_state: '{build_state.name}', el_target: '{el_target}'"
+                if default != -1:
+                    self.logger.info(msg)
+                    return default
+                raise IOError(msg)
 
-        if assembly is None:
-            assembly = self.runtime.assembly
+            def latest_build_list(pattern_suffix):
+                # Include * after pattern_suffix to tolerate:
+                # 1. Matching an unspecified RPM suffix (e.g. .el7).
+                # 2. Other release components that might be introduced later.
+                builds = koji_api.listBuilds(packageID=package_id,
+                                             state=None if build_state is None else build_state.value,
+                                             pattern=f'{pattern_prefix}{extra_pattern}{pattern_suffix}*{rpm_suffix}',
+                                             queryOpts={'limit': 1, 'order': '-creation_event_id'},
+                                             **list_builds_kwargs)
 
-        def default_return():
-            msg = f"No builds detected for using prefix: '{pattern_prefix}', extra_pattern: '{extra_pattern}', assembly: '{assembly}', build_state: '{build_state.name}', el_target: '{el_target}'"
-            if default != -1:
-                self.logger.info(msg)
-                return default
-            raise IOError(msg)
+                # Ensure the suffix ends the string OR at least terminated by a '.' .
+                # This latter check ensures that 'assembly.how' doesn't not match a build from
+                # "assembly.howdy'.
+                refined = [b for b in builds if b['nvr'].endswith(pattern_suffix) or f'{pattern_suffix}.' in b['nvr']]
 
-        def latest_build_list(pattern_suffix):
-            # Include * after pattern_suffix to tolerate:
-            # 1. Matching an unspecified RPM suffix (e.g. .el7).
-            # 2. Other release components that might be introduced later.
-            builds = koji_api.listBuilds(packageID=package_id,
-                                         state=None if build_state is None else build_state.value,
-                                         pattern=f'{pattern_prefix}{extra_pattern}{pattern_suffix}*{rpm_suffix}',
-                                         queryOpts={'limit': 1, 'order': '-creation_event_id'})
+                if refined and build_state == BuildStates.COMPLETE:
+                    # A final sanity check to see if the build is tagged with something we
+                    # respect. There is a chance that a human may untag a build. There
+                    # is no standard practice at present in which they should (they should just trigger
+                    # a rebuild). If we find the latest build is not tagged appropriately, blow up
+                    # and let a human figure out what happened.
+                    check_nvr = refined[0]['nvr']
+                    for i in range(2):
+                        tags = {tag['name'] for tag in koji_api.listTags(build=check_nvr)}
+                        if tags:
+                            refined[0]['_tags'] = tags  # save tag names to dict for future use
+                            break
+                        # Observed that a complete build needs some time before it gets tagged. Give it some
+                        # time if not immediately available.
+                        time.sleep(60)
 
-            # Ensure the suffix ends the string OR at least terminated by a '.' .
-            # This latter check ensures that 'assembly.how' doesn't not match a build from
-            # "assembly.howdy'.
-            refined = [b for b in builds if b['nvr'].endswith(pattern_suffix) or f'{pattern_suffix}.' in b['nvr']]
+                    # RPMS have multiple targets, so our self.branch() isn't perfect.
+                    # We should permit rhel-8/rhel-7/etc.
+                    tag_prefix = self.branch().rsplit('-', 1)[0] + '-'   # String off the rhel version.
+                    accepted_tags = [name for name in tags if name.startswith(tag_prefix)]
+                    if not accepted_tags:
+                        self.logger.warning(f'Expected to find at least one tag starting with {self.branch()} on latest build {check_nvr} but found [{tags}]; tagging failed after build or something has changed tags in an unexpected way')
 
-            if refined and build_state == BuildStates.COMPLETE:
-                # A final sanity check to see if the build is tagged with something we
-                # respect. There is a chance that a human may untag a build. There
-                # is no standard practice at present in which they should (they should just trigger
-                # a rebuild). If we find the latest build is not tagged appropriately, blow up
-                # and let a human figure out what happened.
-                check_nvr = refined[0]['nvr']
-                for i in range(2):
-                    tags = {tag['name'] for tag in koji_api.listTags(build=check_nvr)}
-                    if tags:
-                        refined[0]['_tags'] = tags  # save tag names to dict for future use
-                        break
-                    # Observed that a complete build needs some time before it gets tagged. Give it some
-                    # time if not immediately available.
-                    time.sleep(60)
+                return refined
 
-                # RPMS have multiple targets, so our self.branch() isn't perfect.
-                # We should permit rhel-8/rhel-7/etc.
-                tag_prefix = self.branch().rsplit('-', 1)[0] + '-'   # String off the rhel version.
-                accepted_tags = [name for name in tags if name.startswith(tag_prefix)]
-                if not accepted_tags:
-                    raise IOError(f'Expected to find at least one tag starting with {self.branch()} on latest build {check_nvr} but found [{tags}]; something has changed tags in an unexpected way')
+            if honor_is and self.config['is']:
+                if build_state != BuildStates.COMPLETE:
+                    # If this component is defined by 'is', history failures, etc, do not matter.
+                    return default_return()
 
-            return refined
+                # under 'is' for RPMs, we expect 'el7' and/or 'el8', etc. For images, just 'nvr'.
+                isd = self.config['is']
+                if self.meta_type == 'rpm':
+                    if el_ver is None:
+                        raise ValueError(f'Expected el_target to be set when querying a pinned RPM component {self.distgit_key}')
+                    is_nvr = isd[f'el{el_ver}']
+                    if not is_nvr:
+                        return default_return()
+                else:
+                    # The image metadata (or, more likely, the currently assembly) has the image
+                    # pinned. Return only the pinned NVR. When a child image is being rebased,
+                    # it uses get_latest_build to find the parent NVR to use (if it is not
+                    # included in the "-i" doozer argument). We need it to find the pinned NVR
+                    # to place in its Dockerfile.
+                    # Pinning also informs gen-payload when attempting to assemble a release.
+                    is_nvr = isd.nvr
+                    if not is_nvr:
+                        raise ValueError(f'Did not find nvr field in pinned Image component {self.distgit_key}')
 
-        if honor_is and self.config['is']:
-            if build_state != BuildStates.COMPLETE:
-                # If this component is defined by 'is', history failures, etc, do not matter.
+                # strict means raise an exception if not found.
+                found_build = koji_api.getBuild(is_nvr, strict=True)
+                # Different brew apis return different keys here; normalize to make the rest of doozer not need to change.
+                found_build['id'] = found_build['build_id']
+                return found_build
+
+            if not assembly:
+                # if assembly is '' (by parameter) or still None after runtime.assembly,
+                # we are returning true latest.
+                builds = latest_build_list('')
+            else:
+                basis_event = assembly_basis_event(self.runtime.get_releases_config(), assembly=assembly)
+                if basis_event:
+                    # If an assembly has a basis event, its latest images can only be sourced from
+                    # "is:" or the stream assembly. We've already checked for "is" above.
+                    assembly = 'stream'
+
+                # Assemblies without a basis will return assembly qualified builds for their
+                # latest images. This includes "stream" and "test", but could also include
+                # an assembly that is customer specific  with its own branch.
+                builds = latest_build_list(f'.assembly.{assembly}')
+                if not builds:
+                    if assembly != 'stream':
+                        builds = latest_build_list('.assembly.stream')
+                    if not builds:
+                        # Fall back to true latest
+                        builds = latest_build_list('')
+                        if builds and '.assembly.' in builds[0]['release']:
+                            # True latest belongs to another assembly. In this case, just return
+                            # that they are no builds for this assembly.
+                            builds = []
+
+            if not builds:
                 return default_return()
 
-            # under 'is' for RPMs, we expect 'el7' and/or 'el8', etc. For images, just 'nvr'.
-            isd = self.config['is']
-            if self.meta_type == 'rpm':
-                if el_target is None:
-                    raise ValueError(f'Expected el_target to be set when querying a pinned RPM component {self.distgit_key}')
-                is_nvr = isd[f'el{el_target}']
-                if not is_nvr:
-                    return default_return()
-            else:
-                # The image metadata (or, more likely, the currently assembly) has the image
-                # pinned. Return only the pinned NVR. When a child image is being rebased,
-                # it uses get_latest_build to find the parent NVR to use (if it is not
-                # included in the "-i" doozer argument). We need it to find the pinned NVR
-                # to place in its Dockerfile.
-                # Pinning also informs gen-payload when attempting to assemble a release.
-                is_nvr = isd.nvr
-                if not is_nvr:
-                    raise ValueError(f'Did not find nvr field in pinned Image component {self.distgit_key}')
-
-            # strict means raise an exception if not found.
-            found_build = koji_api.getBuild(is_nvr, strict=True)
+            found_build = builds[0]
             # Different brew apis return different keys here; normalize to make the rest of doozer not need to change.
             found_build['id'] = found_build['build_id']
             return found_build
-
-        if not assembly:
-            # if assembly is '' (by parameter) or still None after runtime.assembly,
-            # we are returning true latest.
-            builds = latest_build_list('')
-        else:
-            basis_event = assembly_basis_event(self.runtime.get_releases_config(), assembly=assembly)
-            if basis_event:
-                self.logger.warning(f'Constraining image search to stream assembly due to assembly basis event {basis_event}')
-                # If an assembly has a basis event, its latest images can only be sourced from
-                # "is:" or the stream assembly. We've already checked for "is" above.
-                assembly = 'stream'
-
-            # Assemblies without a basis will return assembly qualified builds for their
-            # latest images. This includes "stream" and "test", but could also include
-            # an assembly that is customer specific  with its own branch.
-            builds = latest_build_list(f'.assembly.{assembly}')
-            if not builds:
-                if assembly != 'stream':
-                    builds = latest_build_list('.assembly.stream')
-                if not builds:
-                    # Fall back to true latest
-                    builds = latest_build_list('')
-                    if builds and '.assembly.' in builds[0]['release']:
-                        # True latest belongs to another assembly. In this case, just return
-                        # that they are no builds for this assembly.
-                        builds = []
-
-        if not builds:
-            return default_return()
-
-        found_build = builds[0]
-        # Different brew apis return different keys here; normalize to make the rest of doozer not need to change.
-        found_build['id'] = found_build['build_id']
-        return found_build

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 aiohttp[speedups] >= 3.6
 click
+contextvars; python_version < '3.7'
 errata-tool >= 1.22
 future
 koji >= 1.18


### PR DESCRIPTION
- Sync get_latest_build and brew wrapper related code from doozerlib.
- Call get_latest_build in parallel. This will significantly improve the
  performance for commands like `find-builds` and `find-bugs`.