### PR TITLE
verify-attached-bugs: Fix TypeError

### DIFF
--- a/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliottlib/cli/verify_attached_bugs_cli.py
@@ -35,7 +35,7 @@ async def verify_attached_bugs_cli(runtime: Runtime, verify_bug_status: bool, ad
     if not advisories:
         red_print("No advisories specified on command line or in group.yml")
         exit(1)
-    validator = BugValidator(runtime)
+    validator = BugValidator(runtime, output="text")
     try:
         await validator.errata_api.login()
         advisory_bugs = await validator.get_attached_bugs(advisories)


### PR DESCRIPTION
The signature of constructor for `class BugValidator` was changed by 5df92dd0bc3728a07c4172dff6966ffd76637b97

Fixes
```
Traceback (most recent call last):
  File "/mnt/workspace/jenkins/working/cd-builds_build_promote-assembly@2/art-tools/elliott/elliott", line 11, in <module>
    main()
  File "/mnt/workspace/jenkins/working/cd-builds_build_promote-assembly@2/art-tools/elliott/elliottlib/cli/__main__.py", line 737, in main
    cli(obj={})
  File "/home/jenkins/.local/lib/python3.6/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/jenkins/.local/lib/python3.6/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/jenkins/.local/lib/python3.6/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/jenkins/.local/lib/python3.6/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/jenkins/.local/lib/python3.6/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/jenkins/.local/lib/python3.6/site-packages/click/decorators.py", line 73, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/home/jenkins/.local/lib/python3.6/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/mnt/workspace/jenkins/working/cd-builds_build_promote-assembly@2/art-tools/elliott/elliottlib/cli/common.py", line 114, in wrapper
    return loop.run_until_complete(f(*args, **kwargs))
  File "/usr/lib64/python3.6/asyncio/base_events.py", line 484, in run_until_complete
    return future.result()
  File "/mnt/workspace/jenkins/working/cd-builds_build_promote-assembly@2/art-tools/elliott/elliottlib/cli/verify_attached_bugs_cli.py", line 38, in verify_attached_bugs_cli
    validator = BugValidator(runtime)
TypeError: __init__() missing 1 required positional argument: 'output'
```