### PR TITLE
Remove rpm-py-installer

### DIFF
--- a/elliottlib/cli/get_golang_versions_cli.py
+++ b/elliottlib/cli/get_golang_versions_cli.py
@@ -1,8 +1,9 @@
-from elliottlib import errata, util, logutil
-from elliottlib.cli.common import cli
-from kobo.rpmlib import parse_nvr
 import click
-from elliottlib.cli.common import use_default_advisory_option, find_default_advisory
+
+from elliottlib import errata, logutil, util
+from elliottlib.cli.common import (cli, find_default_advisory,
+                                   use_default_advisory_option)
+from elliottlib.rpm_utils import parse_nvr
 
 logger = logutil.getLogger(__name__)
 

--- a/elliottlib/errata_async.py
+++ b/elliottlib/errata_async.py
@@ -6,7 +6,8 @@ from urllib.parse import quote, urlparse
 
 import aiohttp
 import gssapi
-from kobo.rpmlib import parse_nvr
+
+from elliottlib.rpm_utils import parse_nvr
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/elliottlib/rpm_utils.py
+++ b/elliottlib/rpm_utils.py
@@ -1,0 +1,68 @@
+from typing import Dict, Optional
+
+NVR = Dict[str, Optional[str]]
+
+
+def split_nvr_epoch(nvre: str):
+    """Split nvre to N-V-R and E.
+
+    This function is backported from `kobo.rpmlib.split_nvr_epoch`.
+
+    @param nvre: E:N-V-R or N-V-R:E string
+    @type nvre: str
+    @return: (N-V-R, E)
+    @rtype: (str, str)
+    """
+
+    if ":" in nvre:
+        if nvre.count(":") != 1:
+            raise ValueError("Invalid NVRE: %s" % nvre)
+
+        nvr, epoch = nvre.rsplit(":", 1)
+        if "-" in epoch:
+            if "-" not in nvr:
+                # switch nvr with epoch
+                nvr, epoch = epoch, nvr
+            else:
+                # it's probably N-E:V-R format, handle it after the split
+                nvr, epoch = nvre, ""
+    else:
+        nvr, epoch = nvre, ""
+
+    return (nvr, epoch)
+
+
+def parse_nvr(nvre: str):
+    """Split N-V-R into a dictionary.
+
+    This function is backported from `kobo.rpmlib.parse_nvr`.
+
+    @param nvre: N-V-R:E, E:N-V-R or N-E:V-R string
+    @type nvre: str
+    @return: {name, version, release, epoch}
+    @rtype: dict
+    """
+
+    if "/" in nvre:
+        nvre = nvre.split("/")[-1]
+
+    nvr, epoch = split_nvr_epoch(nvre)
+
+    nvr_parts = nvr.rsplit("-", 2)
+    if len(nvr_parts) != 3:
+        raise ValueError("Invalid NVR: %s" % nvr)
+
+    # parse E:V
+    if epoch == "" and ":" in nvr_parts[1]:
+        epoch, nvr_parts[1] = nvr_parts[1].split(":", 1)
+
+    # check if epoch is empty or numeric
+    if epoch != "":
+        try:
+            int(epoch)
+        except ValueError:
+            raise ValueError("Invalid epoch '%s' in '%s'" % (epoch, nvr))
+
+    result = dict(zip(["name", "version", "release"], nvr_parts))
+    result["epoch"] = epoch
+    return result

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,6 @@ contextvars; python_version < '3.7'
 errata-tool >= 1.22
 future
 koji >= 1.18
-kobo ~= 0.19.0
-rpm-py-installer
 semver
 pygit2 == 1.6.*
 python-bugzilla >= 3.2


### PR DESCRIPTION
This package is RHEL-only, which also caused a lot of build failures in
the past.

It doesn't seem to be actually used in Elliott.