### PR TITLE
find-bugs list mode report can use jira

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ venv:
 
 lint:
 	./venv/bin/python -m flake8
+
+pylint:
 	./venv/bin/python -m pylint elliottlib/
 
 test: lint

--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -18,7 +18,6 @@ import click
 import os
 from bugzilla.bug import Bug
 from koji import ClientSession
-from abc import ABC, abstractmethod
 
 from elliottlib import constants, exceptions, exectools, logutil
 from elliottlib.metadata import Metadata
@@ -27,7 +26,7 @@ from elliottlib.util import isolate_timestamp_in_release, red_print
 logger = logutil.getLogger(__name__)
 
 
-class Bug(ABC):
+class Bug:
     def __init__(self, bug_obj):
         self.bug = bug_obj
 
@@ -58,7 +57,7 @@ class JIRABug(Bug):
         self.summary = self.bug.fields.summary
 
 
-class BugTracker(ABC):
+class BugTracker:
     def __init__(self, config):
         self.config = config
         self._server = config.get('server')
@@ -66,7 +65,6 @@ class BugTracker(ABC):
     def target_release(self):
         return self.config.get('target_release')
 
-    @abstractmethod
     def search(self):
         raise NotImplementedError
 

--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -1,6 +1,6 @@
 """
 Utility functions and object abstractions for general interactions
-with Red Hat Bugzilla
+with BugTrackers
 """
 import asyncio
 import itertools
@@ -9,12 +9,15 @@ import urllib.parse
 import xmlrpc.client
 from datetime import datetime, timezone
 from time import sleep
-from typing import Dict, Iterable, List
+from typing import Dict, Iterable, List, Optional
+from jira import JIRA, Issue
 
 import bugzilla
 import click
+import os
 from bugzilla.bug import Bug
 from koji import ClientSession
+from abc import ABC, abstractmethod
 
 from elliottlib import constants, exceptions, exectools, logutil
 from elliottlib.metadata import Metadata
@@ -23,31 +26,111 @@ from elliottlib.util import isolate_timestamp_in_release, red_print
 logger = logutil.getLogger(__name__)
 
 
-class BugzillaBugTracker:
-    def login(self, interactive_login):
-        client = bugzilla.Bugzilla(self._server)
-        if not client.logged_in:
-            print(f"elliott requires cached login credentials for {self._server}")
-            if interactive_login:
-                self._client.interactive_login()
-            else:
-                red_print("Login using 'bugzilla login --api-key'")
-                exit(1)
-        return client
+class Bug(ABC):
+    def __init__(self, bug_obj):
+        self.bug = bug_obj
 
-    def __init__(self, config, interactive_login=False):
+    def __getattr__(self, attr):
+        if attr in self.__dict__:
+            return getattr(self, attr)
+        return getattr(self.bug, attr)
+
+
+class BugzillaBug(Bug):
+    def __init__(self, bug_obj):
+        super().__init__(bug_obj)
+        self.id = self.bug.bug_id
+        self.url = self.bug.weburl
+
+
+class JIRABug(Bug):
+    def __init__(self, bug_obj):
+        super().__init__(bug_obj)
+        self.id = self.bug.key
+        self.url = ''
+
+
+class BugTracker(ABC):
+    def __init__(self, config):
         self.config = config
         self._server = config.get('server')
-        self._client = self.login(interactive_login)
 
     def target_release(self):
         return self.config.get('target_release')
 
+    @abstractmethod
+    def search(self):
+        raise NotImplementedError
+
+
+class JIRABugTracker(BugTracker):
+    @staticmethod
+    def get_config(runtime):
+        return runtime.gitdata.load_data(key='jira').data
+
+    def login(self, token_auth=None) -> JIRA:
+        if not token_auth:
+            token_auth = os.environ.get("JIRA_TOKEN")
+            if not token_auth:
+                raise ValueError(f"elliott requires login credentials for {self._server}. Set a JIRA_TOKEN env var ")
+        client = JIRA(self._server, token_auth=token_auth)
+        return client
+
+    def __init__(self, config):
+        super().__init__(config)
+        self._project = config.get('project')
+        self._client: JIRA = self.login()
+
+    def target_release(self):
+        return self.config.get('target_release')
+
+    def get_bug(self, bugid, **kwargs) -> JIRABug:
+        return JIRABug(self._client.issue(bugid, **kwargs))
+
+    def get_bugs(self, bugids):
+        return self.search(bug_list=bugids)
+
+    def search(self,
+               bug_list: Optional[List] = None,
+               status: Optional[List] = None,
+               target_release: Optional[List] = None,
+               include_labels: Optional[List] = None,
+               exclude_labels: Optional[List] = None) -> List[Issue]:
+        query = f"project={self._project}"
+        if bug_list:
+            query += f" and issue in ({','.join(bug_list)})"
+        if status:
+            query += f" and status in ({','.join(status)})"
+        if target_release:
+            query += f" and fixVersion in ({','.join(target_release)})"
+        if include_labels:
+            query += f" and labels in ({','.join(exclude_labels)})"
+        if exclude_labels:
+            query += f" and labels not in ({','.join(exclude_labels)})"
+        return [JIRABug(j) for j in self._client.search_issues(query, maxResults=False)]
+
+
+class BugzillaBugTracker(BugTracker):
+    @staticmethod
+    def get_config(runtime):
+        return runtime.gitdata.load_data(key='bugzilla').data
+
+    def login(self):
+        client = bugzilla.Bugzilla(self._server)
+        if not client.logged_in:
+            raise ValueError(f"elliott requires cached login credentials for {self._server}. Login using 'bugzilla "
+                             "login --api-key")
+        return client
+
+    def __init__(self, config):
+        super().__init__(config)
+        self._client = self.login()
+
     def get_bug(self, bugid, **kwargs):
         return self._client.getbug(bugid, **kwargs)
 
-    def get_bugs(self, idlist, **kwargs):
-        return self._client.getbugs(idlist, **kwargs)
+    def get_bugs(self, bugids, **kwargs):
+        return self._client.getbugs(bugids, **kwargs)
 
     def client(self):
         return self._client
@@ -106,7 +189,6 @@ class BugzillaBugTracker:
     def create_placeholder(self, kind):
         """Create a placeholder bug
 
-        :param bz_data: The Bugzilla data dump we got from our bugzilla.yaml file
         :param kind: The "kind" of placeholder to create. Generally 'rpm' or 'image'
 
         :return: Placeholder Bug object
@@ -116,7 +198,6 @@ class BugzillaBugTracker:
 
     def create_textonly(self, bugtitle, bugdescription):
         """Create a text only bug
-        :param bz_data: The Bugzilla data dump we got from our bugzilla.yaml file
         :param bugtitle: The title of the bug to create
         :param bugdescription: The description of the bug to create
 

--- a/elliottlib/cli/cli_opts.py
+++ b/elliottlib/cli/cli_opts.py
@@ -18,9 +18,9 @@ CLI_ENV_VARS = {k: v['env'] for (k, v) in CLI_OPTS.items()}
 CLI_CONFIG_TEMPLATE = '\n'.join(['#{}\n{}:\n'.format(v['help'], k) for (k, v) in CLI_OPTS.items()])
 
 
-def id_convert(ids):
+def id_convert_str(ids):
     # this function convert string list param --id "1" --id "2" --id "3,4,5"
-    # to int list [1,2,3,4,5]
+    # to string list ['1','2','3','4','5']
     id_str = []
     for id in ids:
         # id = "1234,42345,1234,"
@@ -30,4 +30,8 @@ def id_convert(ids):
         # id = 123  no ','
         else:
             id_str.append(id)
-    return [int(s) for s in id_str]
+    return [s for s in id_str]
+
+
+def id_convert(ids):
+    return [int(s) for s in id_convert_str(ids)]

--- a/elliottlib/cli/find_bugs_cli.py
+++ b/elliottlib/cli/find_bugs_cli.py
@@ -431,17 +431,17 @@ def print_report(bugs: type_bug_list, output: str = 'text') -> None:
     else:  # output == 'text'
         green_print(
             "{:<13s} {:<25s} {:<12s} {:<7s} {:<10s} {:60s}".format("ID", "COMPONENT", "STATUS", "SCORE", "AGE",
-                                                                  "SUMMARY"))
+                                                                   "SUMMARY"))
         for bug in bugs:
             created_date = bug.creation_time_parsed
             days_ago = (datetime.now(timezone.utc) - created_date).days
+            cf_pm_score = bug.cf_pm_score if hasattr(bug, "cf_pm_score") else '?'
             click.echo("{:<13s} {:<25s} {:<12s} {:<7s} {:<3d} days   {:60s} ".format(bug.bug_id,
-                                                                                    bug.component,
-                                                                                    bug.status,
-                                                                                    bug.cf_pm_score if hasattr(bug,
-                                                                                                               "cf_pm_score") else '?',
-                                                                                    days_ago,
-                                                                                    bug.summary[:60]))
+                                                                                     bug.component,
+                                                                                     bug.status,
+                                                                                     cf_pm_score,
+                                                                                     days_ago,
+                                                                                     bug.summary[:60]))
 
 
 def mode_list(advisory: str, bugs: type_bug_list, report: bool, noop: bool, output: str) -> None:

--- a/elliottlib/cli/find_bugs_cli.py
+++ b/elliottlib/cli/find_bugs_cli.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from typing import List, Set
 
 import click
-from bugzilla import bug as bug_module
+from elliottlib.bzutil import BugzillaBugTracker, JIRABugTracker, BugTracker, Bug
 
 from elliottlib import (Runtime, bzutil, constants, errata, logutil)
 from elliottlib.cli import cli_opts
@@ -32,7 +32,7 @@ class FindBugsMode:
     def exclude_status(self, status: List):
         self.status -= set(status)
 
-    def search(self, bug_tracker_obj: bzutil.BugzillaBugTracker, verbose: bool = False):
+    def search(self, bug_tracker_obj: BugTracker, verbose: bool = False):
         return bug_tracker_obj.search(
             self.status,
             flag=self.search_flag,
@@ -110,13 +110,17 @@ class FindBugsBlocker(FindBugsMode):
 @click.option('--brew-event', type=click.INT, required=False,
               help='Only SWEEP bugs that have changed to the desired status before the Brew event ID; does not apply '
                    'to list or diff mode')
+@click.option("--jira", 'use_jira',
+              is_flag=True,
+              default=False,
+              help="Use jira in combination with bugzilla (https://issues.redhat.com/browse/ART-3818)")
 @click.option("--noop", "--dry-run",
               is_flag=True,
               default=False,
               help="Don't change anything")
 @pass_runtime
 def find_bugs_cli(runtime: Runtime, advisory, default_advisory_type, mode, check_builds, include_status, exclude_status,
-                  bug_ids, cve_trackers, report, output, into_default_advisories, brew_event, noop):
+                  bug_ids, cve_trackers, report, output, into_default_advisories, brew_event, use_jira, noop):
     """Find OCP bugs and (optional) add them to ADVISORY. Bugs can be
 "swept" into advisories either automatically (--mode sweep), or by
 manually specifying one or more bugs using --mode list with the --id option.
@@ -206,8 +210,16 @@ advisory with the --add option.
 
     runtime.initialize(mode="both")
 
-    bz_config = runtime.gitdata.load_data(key='bugzilla').data
-    bugzilla = bzutil.BugzillaBugTracker(bz_config)
+    bz_config = BugzillaBugTracker.get_config(runtime)
+    bugzilla = BugzillaBugTracker(bz_config)
+
+    # object used in cases where we need a single bug tracker
+    bug_tracker = bugzilla
+
+    if use_jira:
+        jira_config = JIRABugTracker.get_config(runtime)
+        jira = JIRABugTracker(jira_config)
+        bug_tracker = jira
 
     # filter out bugs ART does not manage
     m = re.match(r"rhaos-(\d+).(\d+)",
@@ -221,7 +233,7 @@ advisory with the --add option.
         advisory = find_default_advisory(runtime, default_advisory_type)
 
     if mode == 'list':
-        bugs = [bugzilla.get_bug(i) for i in cli_opts.id_convert(bug_ids)]
+        bugs = bug_tracker.get_bugs(cli_opts.id_convert_str(bug_ids))
         if not into_default_advisories:
             mode_list(advisory=advisory, bugs=bugs, report=report, noop=noop)
             return
@@ -348,7 +360,7 @@ advisory with the --add option.
                 errata.add_bugs_with_retry(runtime.group_config.advisories[impetus], bugs, noop=noop)
 
 
-type_bug_list = List[bug_module.Bug]
+type_bug_list = List[Bug]
 
 
 def extras_bugs(bugs: type_bug_list) -> type_bug_list:
@@ -399,7 +411,7 @@ def filter_bugs(bugs: type_bug_list, major_version: int, minor_version: int, run
 def print_report(bugs: type_bug_list, output: str = 'text') -> None:
     if output == 'slack':
         for bug in bugs:
-            click.echo("<{}|{}> - {:<25s} ".format(bug.weburl, bug.id, bug.component))
+            click.echo("<{}|{}> - {:<25s} ".format(bug.url, bug.id, bug.component))
 
     elif output == 'json':
         print(json.dumps(
@@ -434,7 +446,7 @@ def print_report(bugs: type_bug_list, output: str = 'text') -> None:
 
 def mode_list(advisory: str, bugs: type_bug_list, report: bool, noop: bool) -> None:
     LOGGER.info(f"Found {len(bugs)} bugs: ")
-    LOGGER.info(", ".join(sorted(str(b.bug_id) for b in bugs)))
+    LOGGER.info(", ".join(sorted(str(b.id) for b in bugs)))
     if report:
         print_report(bugs)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ ruamel.yaml
 six
 typing ; python_version <= '3.4'
 tenacity
+jira

--- a/tests/test_find_bugs_cli.py
+++ b/tests/test_find_bugs_cli.py
@@ -22,7 +22,7 @@ class TestFindBugsCli(unittest.TestCase):
             should_receive("add_bugs_with_retry").\
             once()
 
-        mode_list(advisory, bugs, report, noop)
+        mode_list(advisory, bugs, report, 'text', noop)
 
     @patch.object(BugzillaBugTracker, 'login', return_value=None, autospec=True)
     @patch.object(BugzillaBugTracker, 'search', return_value=[1, 2], autospec=True)


### PR DESCRIPTION
Test:
- Set your JIRA_TOKEN and `export https_proxy=http://squid.corp.redhat.com:3128`
- elliott -g openshift-4.11 find-bugs --mode list --id OCPBUGS-10 --jira -o text --report
- elliott -g openshift-4.11 find-bugs --mode list --id OCPBUGS-10 --jira -o json --report
- elliott -g openshift-4.11 find-bugs --mode list --id OCPBUGS-10 --jira -o slack --report

```json
[
    {
        "id": "OCPBUGS-10",
        "component": "OLM/OperatorHub",
        "status": "New",
        "date": "2022-03-23 19:49:49+00:00",
        "summary": "[2034409] Default CatalogSources should be pointing to 4.10 ",
        "url": "https://issues.stage.redhat.com/browse/OCPBUGS-10"
    }
]
```

