### PR TITLE
Fix AttributeError: Bug object has no attribute 'target_release'

### DIFF
--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -83,7 +83,10 @@ class BugzillaBug(Bug):
     def __init__(self, bug_obj):
         super().__init__(bug_obj)
         self.id = self.bug.id
-        self.target_release = self.bug.target_release
+
+    @property
+    def target_release(self):
+        return self.bug.target_release
 
     def creation_time_parsed(self):
         return datetime.strptime(str(self.bug.creation_time), '%Y%m%dT%H:%M:%S').replace(tzinfo=timezone.utc)


### PR DESCRIPTION
Running create-placeholder got the following error:

```
  File "/mnt/workspace/jenkins/working/_cd-builds_build_prepare-release/art-tools/elliott/elliottlib/cli/create_placeholder_cli.py", line 60, in create_placeholder_cli
    newbug = elliottlib.bzutil.BugzillaBugTracker(bz_config).create_placeholder(kind)
  File "/mnt/workspace/jenkins/working/_cd-builds_build_prepare-release/art-tools/elliott/elliottlib/bzutil.py", line 319, in create_placeholder
    return self.create_bug(boilerplate, boilerplate, "VERIFIED", ["Automation"])
  File "/mnt/workspace/jenkins/working/_cd-builds_build_prepare-release/art-tools/elliott/elliottlib/bzutil.py", line 309, in create_bug
    return BugzillaBug(new_bug)
  File "/mnt/workspace/jenkins/working/_cd-builds_build_prepare-release/art-tools/elliott/elliottlib/bzutil.py", line 86, in __init__
    self.target_release = self.bug.target_release
  File "/home/jenkins/.local/lib/python3.6/site-packages/bugzilla/bug.py", line 101, in __getattr__
    raise AttributeError(msg)
AttributeError: Bug object has no attribute 'target_release'.
```

Looks like this line https://github.com/openshift/elliott/blob/065f87667d97b6e71c85dd207867c97fca045e70/elliottlib/bzutil.py#L86 assumes attribute target_release exists.
I didn’t see a reason to read that field in the constructor, especially class BugzillaBug already has __getattr__ magic function.

To have a quick fix, I am going to remove that line of code. However I didn’t read all of the related code so it might break somewhere else. If it doesn’t work, I will try an old version of Elliott in the automation.