### PR TITLE
find-builds: Exclude builds that have been attached

### DIFF
--- a/elliottlib/cli/find_builds_cli.py
+++ b/elliottlib/cli/find_builds_cli.py
@@ -181,7 +181,7 @@ PRESENT advisory. Here are some examples:
             lambda nvrp: elliottlib.errata.get_brew_build('{}-{}-{}'.format(nvrp[0], nvrp[1], nvrp[2]), nvrp[3], session=requests.Session())
         )
         if not allow_attached:
-            unshipped_builds = _filter_out_inviable_builds(kind, unshipped_builds, elliottlib.errata)
+            unshipped_builds = _filter_out_attached_builds(kind, unshipped_builds, elliottlib.errata)
 
         _json_dump(as_json, unshipped_builds, kind, tag_pv_map)
 
@@ -414,27 +414,6 @@ def _fetch_builds_by_kind_rpm(runtime: Runtime, tag_pv_map: Dict[str, str], brew
     return nvrps
 
 
-def _filter_out_inviable_builds(kind, results, errata):
-    unshipped_builds = []
-    errata_version_cache = {}  # avoid reloading the same errata for multiple builds
-    for b in results:
-        # check if build is attached to any existing advisory for this version
-        in_same_version = False
-        for eid in [e['id'] for e in b.all_errata]:
-            if eid not in errata_version_cache:
-                metadata_comments_json = errata.get_metadata_comments_json(eid)
-                if not metadata_comments_json:
-                    # Does not contain ART metadata; consider it unversioned
-                    red_print("Errata {} Does not contain ART metadata\n".format(eid))
-                    errata_version_cache[eid] = ''
-                    continue
-                # it's possible for an advisory to have multiple metadata comments,
-                # though not very useful (there's a command for adding them,
-                # but not much point in doing it). just looking at the first one is fine.
-                errata_version_cache[eid] = metadata_comments_json[0]['release']
-            if errata_version_cache[eid] == get_release_version(b.product_version):
-                in_same_version = True
-                break
-        if not in_same_version:
-            unshipped_builds.append(b)
-    return unshipped_builds
+def _filter_out_attached_builds(kind, results, errata):
+    # filter out builds that have been attached to other advisories.
+    return [b for b in results if len(b.all_errata) == 0]

--- a/tests/test_find_builds_cli.py
+++ b/tests/test_find_builds_cli.py
@@ -1,5 +1,5 @@
 import unittest
-from elliottlib.cli.find_builds_cli import _filter_out_inviable_builds, _find_shipped_builds
+from elliottlib.cli.find_builds_cli import _find_shipped_builds
 from elliottlib.brew import Build
 import elliottlib
 from flexmock import flexmock
@@ -11,44 +11,6 @@ class TestFindBuildsCli(unittest.TestCase):
     """
     Test elliott find-builds command and internal functions
     """
-
-    def test_attached_errata_failed(self):
-        """
-        Test the internal wrapper function _attached_to_open_erratum_with_correct_product_version
-        attached_to_open_erratum = True, product_version is also the same:
-            _attached_to_open_erratum_with_correct_product_version() should return []
-        """
-        metadata_json_list = []
-        metadata = json.loads('''{"release": "4.1", "kind": "rpm", "impetus": "cve"}''')
-        metadata_json_list.append(metadata)
-
-        fake_errata = flexmock(model=elliottlib.errata, get_metadata_comments_json=lambda: 1234)
-        fake_errata.should_receive("get_metadata_comments_json").and_return(metadata_json_list)
-
-        builds = flexmock(Build(nvr="test-1.1.1", product_version="RHEL-7-OSE-4.1"))
-        builds.should_receive("all_errata").and_return([{"id": 12345}])
-
-        # expect return empty list []
-        self.assertEqual([], _filter_out_inviable_builds("image", [builds], fake_errata))
-
-    def test_attached_errata_succeed(self):
-        """
-        Test the internal wrapper function _attached_to_open_erratum_with_correct_product_version
-        attached_to_open_erratum = True but product_version is not same:
-            _attached_to_open_erratum_with_correct_product_version() should return [Build("test-1.1.1")]
-        """
-        metadata_json_list = []
-        metadata = json.loads('''{"release": "4.1", "kind": "rpm", "impetus": "cve"}''')
-        metadata_json_list.append(metadata)
-
-        fake_errata = flexmock(model=elliottlib.errata, get_metadata_comments_json=lambda: 1234)
-        fake_errata.should_receive("get_metadata_comments_json").and_return(metadata_json_list)
-
-        builds = flexmock(Build(nvr="test-1.1.1", product_version="RHEL-7-OSE-4.5"))
-        builds.should_receive("all_errata").and_return([{"id": 12345}])
-
-        # expect return list with one build
-        self.assertEqual([Build("test-1.1.1")], _filter_out_inviable_builds("image", [builds], fake_errata))
 
     @mock.patch("elliottlib.brew.get_builds_tags")
     def test_find_shipped_builds(self, get_builds_tags: mock.MagicMock):


### PR DESCRIPTION
Current behavior:
Only builds that are attached to other advisories that belong to the same
major.minor version will be excluded.

This PR:
Builds that are attached to any advisories will be excluded.