### PR TITLE
Fix bug categorization issue with sub_components

### DIFF
--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -343,7 +343,7 @@ class BugzillaBugTracker(BugTracker):
 
     def search(self, status, search_filter='default', verbose=False):
         query = _construct_query_url(self.config, status, search_filter)
-        fields = ['id', 'status', 'summary', 'creation_time', 'cf_pm_score', 'component', 'external_bugs', 'whiteboard',
+        fields = ['id', 'status', 'summary', 'creation_time', 'cf_pm_score', 'component', 'sub_components', 'external_bugs', 'whiteboard',
                   'keywords', 'target_release']
         return self._search(query, fields, verbose)
 

--- a/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliottlib/cli/find_bugs_sweep_cli.py
@@ -268,7 +268,7 @@ def extras_bugs(bugs: type_bug_list) -> type_bug_list:
     for bug in bugs:
         if bug.component in extras_components:
             extra_bugs.add(bug)
-        elif hasattr(bug, 'sub_component') and (bug.component, bug.sub_component) in extras_subcomponents:
+        elif bug.sub_component and (bug.component, bug.sub_component) in extras_subcomponents:
             extra_bugs.add(bug)
     return extra_bugs
 


### PR DESCRIPTION
`sub_components` field is not in the bug query so `bug.sub_component` field is absent.