### PR TITLE
fix sub_component check

### DIFF
--- a/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliottlib/cli/find_bugs_sweep_cli.py
@@ -268,7 +268,7 @@ def extras_bugs(bugs: type_bug_list) -> type_bug_list:
     for bug in bugs:
         if bug.component in extras_components:
             extra_bugs.add(bug)
-        elif bug.sub_component and (bug.component, bug.sub_component) in extras_subcomponents:
+        elif hasattr(bug, 'sub_component') and (bug.component, bug.sub_component) in extras_subcomponents:
             extra_bugs.add(bug)
     return extra_bugs
 


### PR DESCRIPTION
although we query the sub_component fields in search, it still may not exist
`If 'sub_component' is a bugzilla attribute, it may not have been cached when the bug was fetched. You may want to adjust your include_fields for getbug/query.`