### PR TITLE
Enable onlyjira mode for testing

### DIFF
--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -141,6 +141,7 @@ class JIRABug(Bug):
 
     @property
     def sub_component(self):
+        # TODO: See usage. this can be correct or incorrect based in usage.
         return [c.name for c in self.bug.fields.components]
 
     @property
@@ -165,10 +166,12 @@ class JIRABug(Bug):
 
     @property
     def alias(self):
+        # TODO: See usage. this can be correct or incorrect based in usage.
         return self.bug.fields.labels
 
     @property
     def whiteboard(self):
+        # TODO: See usage. this can be correct or incorrect based in usage.
         return self.bug.fields.labels
 
     def _get_release_blocker(self):
@@ -478,7 +481,7 @@ class BugzillaBugTracker(BugTracker):
     def get_bug(self, bugid, **kwargs):
         return BugzillaBug(self._client.getbug(bugid, **kwargs))
 
-    def get_bugs(self, bugids, permissive=False, check_tracker=False, **kwargs):
+    def get_bugs(self, bugids, permissive=False, **kwargs):
         if 'verbose' in kwargs:
             kwargs.pop('verbose')
         bugs = [BugzillaBug(b) for b in self._client.getbugs(bugids, permissive=permissive, **kwargs)]
@@ -861,16 +864,16 @@ def get_bzapi(bz_data, interactive_login=False):
     return bzapi
 
 
-def _construct_query_url(bz_data, status, search_filter='default', flag=None):
-    query_url = SearchURL(bz_data)
+def _construct_query_url(config, status, search_filter='default', flag=None):
+    query_url = SearchURL(config)
     query_url.fields = ['id', 'status', 'summary', 'creation_time', 'cf_pm_score', 'component', 'sub_component',
                         'external_bugs', 'whiteboard', 'keywords', 'target_release']
 
     filter_list = []
-    if bz_data.get('filter'):
-        filter_list = bz_data.get('filter')
-    elif bz_data.get('filters'):
-        filter_list = bz_data.get('filters').get(search_filter)
+    if config.get('filter'):
+        filter_list = config.get('filter')
+    elif config.get('filters'):
+        filter_list = config.get('filters').get(search_filter)
 
     for f in filter_list:
         query_url.addFilter('component', 'notequals', f)
@@ -878,7 +881,7 @@ def _construct_query_url(bz_data, status, search_filter='default', flag=None):
     for s in status:
         query_url.addBugStatus(s)
 
-    for r in bz_data.get('target_release', []):
+    for r in config.get('target_release', []):
         query_url.addTargetRelease(r)
 
     if flag:

--- a/elliottlib/cli/attach_cve_flaws_cli.py
+++ b/elliottlib/cli/attach_cve_flaws_cli.py
@@ -1,5 +1,6 @@
 from typing import Dict, List, Set
 import click
+import sys
 from errata_tool import Erratum
 
 from elliottlib import bzutil, constants
@@ -49,8 +50,14 @@ async def attach_cve_flaws_cli(runtime: Runtime, advisory_id: int, noop: bool, d
 
     runtime.logger.info("Getting advisory %s", advisory_id)
     advisory = Erratum(errata_id=advisory_id)
+    exit_code = 0
     for b in runtime.bug_trackers.values():
-        await attach_cve_flaws(runtime, advisory_id, noop, advisory, b)
+        try:
+            await attach_cve_flaws(runtime, advisory_id, noop, advisory, b)
+        except Exception as e:
+            runtime.logger.error(f'exception with {b.type} bug tracker: {e}')
+            exit_code = 1
+    sys.exit(exit_code)
 
 
 async def attach_cve_flaws(runtime, advisory_id, noop, advisory, bug_tracker):

--- a/elliottlib/cli/find_bugs_blocker_cli.py
+++ b/elliottlib/cli/find_bugs_blocker_cli.py
@@ -1,7 +1,7 @@
 import click
 
 from elliottlib.cli.find_bugs_sweep_cli import print_report, FindBugsMode
-from elliottlib.bzutil import BugzillaBugTracker, BugTracker, JIRABugTracker
+from elliottlib.bzutil import BugTracker
 from elliottlib import (Runtime, constants)
 from elliottlib.cli.common import cli
 from elliottlib.util import green_prefix
@@ -54,10 +54,8 @@ Use --exclude_status to filter out from default status list.
     $ elliott -g openshift-4.6 find-bugs:blocker --output json
 """
     runtime.initialize()
-    if runtime.use_jira:
-        find_bugs_blocker(runtime, output, include_status, exclude_status, JIRABugTracker(JIRABugTracker.get_config(runtime)))
-    find_bugs_blocker(runtime, output, include_status, exclude_status, BugzillaBugTracker(
-        BugzillaBugTracker.get_config(runtime)))
+    for b in runtime.bug_trackers.values():
+        find_bugs_blocker(runtime, output, include_status, exclude_status, b)
 
 
 def find_bugs_blocker(runtime, output, include_status, exclude_status, bug_tracker):
@@ -66,8 +64,9 @@ def find_bugs_blocker(runtime, output, include_status, exclude_status, bug_track
     find_bugs_obj.exclude_status(exclude_status)
 
     if output == 'text':
-        green_prefix(f"Searching for bugs with status {' '.join(sorted(find_bugs_obj.status))} and target release(s):")
-        click.echo(" {tr}".format(tr=", ".join(bug_tracker.target_release())))
+        statuses = sorted(find_bugs_obj.status)
+        tr = bug_tracker.target_release()
+        green_prefix(f"Searching {bug_tracker.type} for bugs with status {statuses} and target releases: {tr}\n")
 
     bugs = find_bugs_obj.search(bug_tracker_obj=bug_tracker, verbose=runtime.debug)
 

--- a/elliottlib/cli/find_bugs_blocker_cli.py
+++ b/elliottlib/cli/find_bugs_blocker_cli.py
@@ -54,15 +54,14 @@ Use --exclude_status to filter out from default status list.
     $ elliott -g openshift-4.6 find-bugs:blocker --output json
 """
     runtime.initialize()
-    for b in runtime.bug_trackers.values():
-        find_bugs_blocker(runtime, output, include_status, exclude_status, b)
-
-
-def find_bugs_blocker(runtime, output, include_status, exclude_status, bug_tracker):
     find_bugs_obj = FindBugsBlocker()
     find_bugs_obj.include_status(include_status)
     find_bugs_obj.exclude_status(exclude_status)
+    for b in runtime.bug_trackers.values():
+        find_bugs_blocker(runtime, output, find_bugs_obj, b)
 
+
+def find_bugs_blocker(runtime, output, find_bugs_obj, bug_tracker):
     if output == 'text':
         statuses = sorted(find_bugs_obj.status)
         tr = bug_tracker.target_release()

--- a/elliottlib/cli/find_bugs_blocker_cli.py
+++ b/elliottlib/cli/find_bugs_blocker_cli.py
@@ -1,4 +1,5 @@
 import click
+import sys
 
 from elliottlib.cli.find_bugs_sweep_cli import print_report, FindBugsMode
 from elliottlib.bzutil import BugTracker
@@ -57,8 +58,14 @@ Use --exclude_status to filter out from default status list.
     find_bugs_obj = FindBugsBlocker()
     find_bugs_obj.include_status(include_status)
     find_bugs_obj.exclude_status(exclude_status)
+    exit_code = 0
     for b in runtime.bug_trackers.values():
-        find_bugs_blocker(runtime, output, find_bugs_obj, b)
+        try:
+            find_bugs_blocker(runtime, output, find_bugs_obj, b)
+        except Exception as e:
+            runtime.logger.error(f'exception with {b.type} bug tracker: {e}')
+            exit_code = 1
+    sys.exit(exit_code)
 
 
 def find_bugs_blocker(runtime, output, find_bugs_obj, bug_tracker):

--- a/elliottlib/cli/find_bugs_qe_cli.py
+++ b/elliottlib/cli/find_bugs_qe_cli.py
@@ -1,9 +1,9 @@
 import click
 
-from elliottlib.bzutil import BugzillaBugTracker, JIRABugTracker
 from elliottlib import (Runtime, bzutil, logutil)
 from elliottlib.cli.common import cli
 from elliottlib.cli.find_bugs_sweep_cli import FindBugsMode
+from elliottlib.util import green_prefix
 
 LOGGER = logutil.getLogger(__name__)
 
@@ -30,16 +30,18 @@ def find_bugs_qe_cli(runtime: Runtime, noop):
 
 """
     runtime.initialize()
-    if runtime.use_jira:
-        find_bugs_qe(runtime, noop, JIRABugTracker(JIRABugTracker.get_config(runtime)))
-    find_bugs_qe(runtime, noop, BugzillaBugTracker(BugzillaBugTracker.get_config(runtime)))
+    find_bugs_obj = FindBugsQE()
+    for b in runtime.bug_trackers.values():
+        find_bugs_qe(runtime, find_bugs_obj, noop, b)
 
 
-def find_bugs_qe(runtime, noop, bug_tracker):
+def find_bugs_qe(runtime, find_bugs_obj, noop, bug_tracker):
     major_version, minor_version = runtime.get_major_minor()
-    click.echo(f"Searching for bugs with status MODIFIED and target release(s): {', '.join(bug_tracker.target_release())}")
+    statuses = sorted(find_bugs_obj.status)
+    tr = bug_tracker.target_release()
+    green_prefix(f"Searching {bug_tracker.type} for bugs with status {statuses} and target releases: {tr}\n")
 
-    bugs = FindBugsQE().search(bug_tracker_obj=bug_tracker, verbose=runtime.debug)
+    bugs = find_bugs_obj.search(bug_tracker_obj=bug_tracker, verbose=runtime.debug)
     click.echo(f"Found {len(bugs)} bugs: {', '.join(sorted(str(b.id) for b in bugs))}")
 
     release_comment = f"This bug is expected to ship in the next {major_version}.{minor_version} release."

--- a/elliottlib/cli/find_bugs_qe_cli.py
+++ b/elliottlib/cli/find_bugs_qe_cli.py
@@ -1,4 +1,5 @@
 import click
+import sys
 
 from elliottlib import (Runtime, bzutil, logutil)
 from elliottlib.cli.common import cli
@@ -31,8 +32,14 @@ def find_bugs_qe_cli(runtime: Runtime, noop):
 """
     runtime.initialize()
     find_bugs_obj = FindBugsQE()
+    exit_code = 0
     for b in runtime.bug_trackers.values():
-        find_bugs_qe(runtime, find_bugs_obj, noop, b)
+        try:
+            find_bugs_qe(runtime, find_bugs_obj, noop, b)
+        except Exception as e:
+            runtime.logger.error(f'exception with {b.type} bug tracker: {e}')
+            exit_code = 1
+    sys.exit(exit_code)
 
 
 def find_bugs_qe(runtime, find_bugs_obj, noop, bug_tracker):

--- a/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliottlib/cli/find_bugs_sweep_cli.py
@@ -1,5 +1,6 @@
 import json
 import click
+import sys
 from datetime import datetime
 from typing import List, Set, Optional
 
@@ -118,9 +119,15 @@ advisory with the --add option.
     find_bugs_obj.include_status(include_status)
     find_bugs_obj.exclude_status(exclude_status)
 
+    exit_code = 0
     for b in runtime.bug_trackers.values():
-        find_bugs_sweep(runtime, advisory_id, default_advisory_type, check_builds, major_version, find_bugs_obj,
-                        report, output, brew_event, noop, count_advisory_attach_flags, b)
+        try:
+            find_bugs_sweep(runtime, advisory_id, default_advisory_type, check_builds, major_version, find_bugs_obj,
+                            report, output, brew_event, noop, count_advisory_attach_flags, b)
+        except Exception as e:
+            runtime.logger.error(f'exception with {b.type} bug tracker: {e}')
+            exit_code = 1
+    sys.exit(exit_code)
 
 
 def find_bugs_sweep(runtime: Runtime, advisory_id, default_advisory_type, check_builds, major_version, find_bugs_obj,

--- a/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliottlib/cli/find_bugs_sweep_cli.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import List, Set, Optional
 
 from elliottlib.assembly import assembly_issues_config
-from elliottlib.bzutil import BugzillaBugTracker, BugTracker, Bug, JIRABugTracker
+from elliottlib.bzutil import BugTracker, Bug
 from elliottlib import (Runtime, bzutil, constants, errata, logutil)
 from elliottlib.cli import common
 from elliottlib.util import green_prefix, green_print, red_prefix, yellow_print, chunk
@@ -113,24 +113,23 @@ advisory with the --add option.
         raise click.BadParameter("Use only one of --use-default-advisory, --add, or --into-default-advisories")
 
     runtime.initialize(mode="both")
-
-    if runtime.use_jira:
-        find_bugs_sweep(runtime, advisory_id, default_advisory_type, check_builds, include_status, exclude_status, report, output, into_default_advisories, brew_event, noop, count_advisory_attach_flags,
-                        JIRABugTracker(JIRABugTracker.get_config(runtime)))
-    find_bugs_sweep(runtime, advisory_id, default_advisory_type, check_builds, include_status, exclude_status, report, output, into_default_advisories, brew_event, noop, count_advisory_attach_flags,
-                    BugzillaBugTracker(BugzillaBugTracker.get_config(runtime)))
-
-
-def find_bugs_sweep(runtime: Runtime, advisory_id, default_advisory_type, check_builds, include_status, exclude_status,
-                    report, output, into_default_advisories, brew_event, noop, count_advisory_attach_flags, bug_tracker):
-    major_version, minor_version = runtime.get_major_minor()
+    major_version, _ = runtime.get_major_minor()
     find_bugs_obj = FindBugsSweep()
     find_bugs_obj.include_status(include_status)
     find_bugs_obj.exclude_status(exclude_status)
 
+    for b in runtime.bug_trackers.values():
+        find_bugs_sweep(runtime, advisory_id, default_advisory_type, check_builds, major_version, find_bugs_obj,
+                        report, output, brew_event, noop, count_advisory_attach_flags, b)
+
+
+def find_bugs_sweep(runtime: Runtime, advisory_id, default_advisory_type, check_builds, major_version, find_bugs_obj,
+                    report, output, brew_event, noop, count_advisory_attach_flags, bug_tracker):
     if output == 'text':
-        green_prefix(f"Searching for bugs with status {' '.join(sorted(find_bugs_obj.status))} and target release(s):")
-        click.echo(" {tr}".format(tr=", ".join(bug_tracker.target_release())))
+        statuses = sorted(find_bugs_obj.status)
+        tr = bug_tracker.target_release()
+        green_prefix(f"Searching {bug_tracker.type} for bugs with status {statuses} and target releases: {tr}\n")
+
     bugs = find_bugs_obj.search(bug_tracker_obj=bug_tracker, verbose=runtime.debug)
 
     sweep_cutoff_timestamp = get_sweep_cutoff_timestamp(runtime, cli_brew_event=brew_event)

--- a/elliottlib/cli/remove_bugs_cli.py
+++ b/elliottlib/cli/remove_bugs_cli.py
@@ -3,7 +3,6 @@ from elliottlib import logutil, errata
 from elliottlib.cli import cli_opts
 from elliottlib.cli.common import cli, use_default_advisory_option, find_default_advisory
 from elliottlib.exceptions import ElliottFatalError
-from elliottlib.bzutil import BugzillaBugTracker, JIRABugTracker
 from elliottlib.util import exit_unauthenticated
 from elliottlib.util import green_prefix
 
@@ -56,16 +55,15 @@ def remove_bugs_cli(runtime, advisory_id, default_advisory_type, bug_ids, remove
     if default_advisory_type is not None:
         advisory_id = find_default_advisory(runtime, default_advisory_type)
 
-    if runtime.use_jira:
+    bug_trackers = runtime.bug_trackers
+    if runtime.use_jira or runtime.only_jira:
         bug_ids = cli_opts.id_convert_str(bug_ids)
-        bug_tracker = JIRABugTracker(JIRABugTracker.get_config(runtime))
         remove_bugs(advisory_id, bug_ids, remove_all,
-                    bug_tracker, noop)
+                    bug_trackers['jira'], noop)
     else:
         bug_ids = cli_opts.id_convert(bug_ids)
-        bug_tracker = BugzillaBugTracker(BugzillaBugTracker.get_config(runtime))
         remove_bugs(advisory_id, bug_ids, remove_all,
-                    bug_tracker, noop)
+                    bug_trackers['bugzilla'], noop)
 
 
 def remove_bugs(advisory_id, bug_ids, remove_all, bug_tracker, noop):

--- a/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliottlib/cli/verify_attached_bugs_cli.py
@@ -70,8 +70,8 @@ async def verify_attached_bugs(runtime: Runtime, verify_bug_status: bool, adviso
 async def verify_bugs_cli(runtime, verify_bug_status, output, bug_ids):
     runtime.initialize()
     if runtime.use_jira:
-        verify_bugs(runtime, verify_bug_status, output, bug_ids, True)
-    verify_bugs(runtime, verify_bug_status, output, bug_ids, False)
+        await verify_bugs(runtime, verify_bug_status, output, bug_ids, True)
+    await verify_bugs(runtime, verify_bug_status, output, bug_ids, False)
 
 
 async def verify_bugs(runtime, verify_bug_status, output, bug_ids, use_jira):

--- a/tests/test_find_bugs_qe_cli.py
+++ b/tests/test_find_bugs_qe_cli.py
@@ -26,10 +26,8 @@ class FindBugsQETestCase(unittest.TestCase):
         )
 
         result = runner.invoke(cli, ['-g', 'openshift-4.6', 'find-bugs:qe', '--noop'])
-        search_string1 = 'Searching for bugs with status MODIFIED and target release(s): 4.6.z'
-        search_string2 = 'Found 1 bugs: 123'
+        search_string1 = 'Found 1 bugs: 123'
         self.assertIn(search_string1, result.output)
-        self.assertIn(search_string2, result.output)
         self.assertEqual(result.exit_code, 0)
 
     @patch.dict(os.environ, {"USEJIRA": "True"})

--- a/tests/test_remove_bugs_cli.py
+++ b/tests/test_remove_bugs_cli.py
@@ -4,7 +4,6 @@ import traceback
 from mock import patch
 from click.testing import CliRunner
 from elliottlib import errata
-from elliottlib.cli import common
 from elliottlib.cli.common import cli, Runtime
 import elliottlib.cli.remove_bugs_cli
 from elliottlib.bzutil import BugzillaBugTracker, JIRABugTracker
@@ -30,7 +29,7 @@ class RemoveBugsTestCase(unittest.TestCase):
         self.assertIn("Found 2 bugs", result.output)
         self.assertIn("Removing bugs from advisory 99999", result.output)
 
-    @patch.dict(os.environ, {"USEJIRA": "True"})
+    @patch.dict(os.environ, {"ONLYJIRA": "True"})
     def test_remove_jira_bug(self):
         runner = CliRunner()
 


### PR DESCRIPTION
Note: I'm breaking changes in this PR into several self-contained ones. After those merge, this should be the PR which has only 'onlyjira' changes
- https://github.com/openshift/elliott/pull/350
- https://github.com/openshift/elliott/pull/351
- https://github.com/openshift/elliott/pull/352
- https://github.com/openshift/elliott/pull/354
- https://github.com/openshift/elliott/pull/353

We want 3 modes when working with jira and bugzilla
1) Strictly use bugzilla only
    - This is activated when no env var from USEJIRA/ONLYJIRA is set=True
2) Use jira and bugzilla in combo - whichever makes sense however. This is our auto mode, where we figure out how to use both of them in combination. Stuff where it doesn't make sense to use both like creating a bug, removing/repairing bugs - where we need to specify a single bug tracker, it would either error out or auto-detect or do something in an opinionated manner (like placeholder bugs being created in jira only from a certain date forward)
    - Activated when USEJIRA=True
3) Strictly use jira only - this would mainly be for testing, or for running commands where we intentionally don't want to have bugzilla bugs factored in.
    - Activated when ONLYJIRA=True

We have mode 1 and 2 in place, this PR puts in place 3, and also the logical behavior of 2.

Test
- `make test`
- `ONLYJIRA=True ./elliott -g openshift-4.10 remove-bugs --advisory 96435 OCPBUGS-3`
- `ONLYJIRA=True ./elliott -g openshift-4.11 attach-bugs --advisory 96435 OCPBUGS-3`
- `ONLYJIRA=true elliott -g openshift-4.11 find-bugs:qe --noop`
- `ONLYJIRA=true elliott -g openshift-4.11 find-bugs:sweep --report`
- `ONLYJIRA=true elliott -g openshift-4.6 find-bugs:blocker`
- `ONLYJIRA=true elliott --group=openshift-4.11 attach-cve-flaws --advisory=97035 --noop`