### PR TITLE
Fix failing unit tests

### DIFF
--- a/tests/test_find_bugs_qe_cli.py
+++ b/tests/test_find_bugs_qe_cli.py
@@ -1,5 +1,6 @@
 import unittest
 import os
+from mock import patch
 from click.testing import CliRunner
 from elliottlib.cli.common import cli, Runtime
 from elliottlib.cli.find_bugs_qe_cli import FindBugsQE
@@ -31,38 +32,38 @@ class FindBugsQETestCase(unittest.TestCase):
         self.assertIn(search_string2, result.output)
         self.assertEqual(result.exit_code, 0)
 
+    @patch.dict(os.environ, {"USEJIRA": "True"})
     def test_find_bugs_qe_jira(self):
         runner = CliRunner()
-        bug = flexmock(id='OCPBUGS-123', status="MODIFIED")
-        bugs = [bug]
+        jira_bug = flexmock(id='OCPBUGS-123', status="MODIFIED")
+        bz_bug = flexmock(id='BZ-123', status="MODIFIED")
+
         flexmock(Runtime).should_receive("initialize").and_return(None)
         flexmock(Runtime).should_receive("get_major_minor").and_return(4, 6)
         flexmock(JIRABugTracker).should_receive("get_config").and_return({
             'target_release': ['4.6.z'], 'server': "server"
         })
         flexmock(JIRABugTracker).should_receive("login").and_return(None)
-        flexmock(FindBugsQE).should_receive("search").and_return(bugs)
+        flexmock(JIRABugTracker).should_receive("search").and_return([jira_bug])
         expected_comment = 'This bug is expected to ship in the next 4.6 release.'
         flexmock(JIRABugTracker).should_receive("update_bug_status").with_args(
-            bug, 'ON_QA', comment=expected_comment, noop=True
+            jira_bug, 'ON_QA', comment=expected_comment, noop=True
         )
 
         flexmock(BugzillaBugTracker).should_receive("get_config").and_return({
             'target_release': ['4.6.z'], 'server': "bugzilla.redhat.com"
         })
         flexmock(BugzillaBugTracker).should_receive("login").and_return(None)
-        flexmock(FindBugsQE).should_receive("search").and_return(bugs)
+        flexmock(BugzillaBugTracker).should_receive("search").and_return([bz_bug])
         flexmock(BugzillaBugTracker).should_receive("update_bug_status").with_args(
-            bug, 'ON_QA', comment=expected_comment, noop=True
+            bz_bug, 'ON_QA', comment=expected_comment, noop=True
         )
-        os.environ['USEJIRA'] = "True"
         result = runner.invoke(cli, ['-g', 'openshift-4.6', 'find-bugs:qe', '--noop'])
-        search_string1 = 'Searching for bugs with status MODIFIED and target release(s): 4.6.z'
-        search_string2 = 'Found 1 bugs: OCPBUGS-123'
+        search_string1 = 'Found 1 bugs: OCPBUGS-123'
+        search_string2 = 'Found 1 bugs: BZ-123'
         self.assertIn(search_string1, result.output)
         self.assertIn(search_string2, result.output)
         self.assertEqual(result.exit_code, 0)
-        del(os.environ['USEJIRA'])
 
 
 if __name__ == '__main__':

--- a/tests/test_repair_bugs_cli.py
+++ b/tests/test_repair_bugs_cli.py
@@ -1,12 +1,11 @@
 import unittest
 import os
+from mock import patch
 from click.testing import CliRunner
-from elliottlib import errata
-from elliottlib.cli import common
 from elliottlib.cli.common import cli, Runtime
 import elliottlib.cli.repair_bugs_cli
 from elliottlib.bzutil import BugzillaBugTracker, JIRABugTracker
-from elliottlib import bzutil
+
 from flexmock import flexmock
 
 
@@ -23,6 +22,7 @@ class RepairBugsTestCase(unittest.TestCase):
         self.assertIn("1 bugs successfully modified", result.output)
         self.assertEqual(result.exit_code, 0)
 
+    @patch.dict(os.environ, {"USEJIRA": "True"})
     def test_repair_jira_bug(self):
         runner = CliRunner()
         bug = flexmock(id=1, status="MODIFIED", summary="")
@@ -35,12 +35,11 @@ class RepairBugsTestCase(unittest.TestCase):
         flexmock(BugzillaBugTracker).should_receive("login")
         flexmock(BugzillaBugTracker).should_receive("get_bug").with_args(1).and_return(bug)
         flexmock(BugzillaBugTracker).should_receive("update_bug_status").once()
-        os.environ['USEJIRA'] = "True"
         result = runner.invoke(cli, ['-g', 'openshift-4.6', 'repair-bugs', '--id', '1', '--to', 'ON_QA', '-a', '99999'])
         self.assertIn("1 bugs successfully modified", result.output)
         self.assertEqual(result.exit_code, 0)
-        del(os.environ['USEJIRA'])
 
+    @patch.dict(os.environ, {"USEJIRA": "True"})
     def test_repair_placeholder_jira_bug(self):
         runner = CliRunner()
         bug = flexmock(id=1, status="MODIFIED", summary="Placeholder")
@@ -53,11 +52,9 @@ class RepairBugsTestCase(unittest.TestCase):
         flexmock(BugzillaBugTracker).should_receive("login")
         flexmock(BugzillaBugTracker).should_receive("get_bug").with_args(1).and_return(bug)
         flexmock(BugzillaBugTracker).should_receive("update_bug_status").once()
-        os.environ['USEJIRA'] = "True"
         result = runner.invoke(cli, ['-g', 'openshift-4.6', 'repair-bugs', '--close-placeholder', '--id', '1', '--to', 'ON_QA', '-a', '99999'])
         self.assertIn("1 bugs successfully modified", result.output)
         self.assertEqual(result.exit_code, 0)
-        del(os.environ['USEJIRA'])
 
     def test_repair_bugzilla_bug_with_comment(self):
         runner = CliRunner()


### PR DESCRIPTION
Unit tests have been failing due to `USEJIRA` env var being set,
and then failing to be unset. Instead of directly setting and unsetting
os.environ, we use patch decorator in tests requiring the var, which is safer.

I've also consolidated test cases in test_find_bugs_sweep_cli - we used to 
have test cases for only bugzilla, and only jira. Instead now we have each 
test case using bugzilla and jira in one (not all but most relevant of them)

Test
- Run `make test` from project repo