### PR TITLE
Fixes to attach-cve-flaws w/ jira

### DIFF
--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -310,7 +310,7 @@ class JIRABugTracker(BugTracker):
         query = self._query(bugids=bugids, with_target_release=False)
         if verbose:
             click.echo(query)
-        bugs = self._search(query, **kwargs)
+        bugs = self._search(query)
         if not permissive and len(bugs) < len(bugids):
             raise ValueError(f"Not all bugs were not found, {len(bugs)} out of {len(bugids)}")
         return bugs
@@ -389,10 +389,10 @@ class JIRABugTracker(BugTracker):
             query += custom_query
         return query
 
-    def _search(self, query, verbose=False, **kwargs) -> List[JIRABug]:
+    def _search(self, query, verbose=False) -> List[JIRABug]:
         if verbose:
             click.echo(query)
-        return [JIRABug(j) for j in self._client.search_issues(query, maxResults=False, **kwargs)]
+        return [JIRABug(j) for j in self._client.search_issues(query, maxResults=False)]
 
     def blocker_search(self, status, search_filter='default', verbose=False, **kwargs):
         query = self._query(
@@ -403,12 +403,12 @@ class JIRABugTracker(BugTracker):
         )
         return self._search(query, verbose=verbose, **kwargs)
 
-    def search(self, status, search_filter='default', verbose=False, **kwargs):
+    def search(self, status, search_filter='default', verbose=False):
         query = self._query(
             status=status,
             search_filter=search_filter
         )
-        return self._search(query, verbose=verbose, **kwargs)
+        return self._search(query, verbose=verbose)
 
     def attach_bugs(self, advisory_id: int, bugids: List, noop=False, verbose=False):
         return errata.add_jira_bugs_with_retry(advisory_id, bugids, noop=noop)
@@ -445,6 +445,8 @@ class BugzillaBugTracker(BugTracker):
         return BugzillaBug(self._client.getbug(bugid, **kwargs))
 
     def get_bugs(self, bugids, permissive=False, check_tracker=False, **kwargs):
+        if 'verbose' in kwargs:
+            kwargs.pop('verbose')
         return [BugzillaBug(b) for b in self._client.getbugs(bugids, permissive=permissive, **kwargs)]
 
     def client(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 aiohttp[speedups] >= 3.6
 click
 contextvars; python_version < '3.7'
-errata-tool >= 1.22
+errata-tool >= 1.27.1
 future
 koji >= 1.18
 semver

--- a/tests/test_attach_cve_flaws.py
+++ b/tests/test_attach_cve_flaws.py
@@ -1,20 +1,32 @@
 import unittest
 from flexmock import flexmock
 from elliottlib import constants, exceptions, bzutil
-from elliottlib.bzutil import Bug, BugzillaBugTracker
+from elliottlib.bzutil import Bug, BugzillaBug, JIRABug
 
 
 class TestAttachCVEFlaws(unittest.TestCase):
-    def test_is_tracker_bug(self):
-        bug = flexmock(keywords=constants.TRACKER_BUG_KEYWORDS)
+    def test_is_tracker_bug_bz(self):
+        bug = flexmock(id='1', keywords=constants.TRACKER_BUG_KEYWORDS)
         expected = True
-        actual = Bug(bug).is_tracker_bug()
+        actual = BugzillaBug(bug).is_tracker_bug()
         self.assertEqual(expected, actual)
 
-    def test_is_tracker_bug_fail(self):
-        bug = flexmock(keywords=['SomeOtherKeyword'])
+    def test_is_tracker_bug_jira(self):
+        bug = flexmock(key='OCPBUGS1', fields=flexmock(labels=constants.TRACKER_BUG_KEYWORDS + ['somethingelse']))
+        expected = True
+        actual = JIRABug(bug).is_tracker_bug()
+        self.assertEqual(expected, actual)
+
+    def test_is_tracker_bug_fail_bz(self):
+        bug = flexmock(id='1', keywords=['SomeOtherKeyword'])
         expected = False
-        actual = Bug(bug).is_tracker_bug()
+        actual = BugzillaBug(bug).is_tracker_bug()
+        self.assertEqual(expected, actual)
+
+    def test_is_tracker_bug_fail_jira(self):
+        bug = flexmock(key='OCPBUGS1', fields=flexmock(labels=['somethingelse']))
+        expected = False
+        actual = JIRABug(bug).is_tracker_bug()
         self.assertEqual(expected, actual)
 
     def test_get_corresponding_flaw_bugs(self):


### PR DESCRIPTION
Branched off of https://github.com/openshift/elliott/pull/350 (Ignore those changes)

Includes several fixes
- Fix is_flaw_bug and is_tracker_bug methods for jira
- Include tracker_type str attr in bug_tracker for logging
- Abstract out advisory_bug_ids method in bug_tracker (needs upgraded errata-tool package)
- Remove check_tracker param in get_bugs (imo an anti-pattern we should avoid)
- Remove kwargs where not needed in fetch methods (they were breaking search)
- Don't use exit(0) in func runs

Test
- `elliott -g openshift-4.10 --assembly rc.1 attach-cve-flaws --noop --use-default-advisory image`
- With jira 
    - `export JIRA_TOKEN=<token>`
    - `USEJIRA=True` and run ^^ again