### PR TITLE
remove-bugs fixes

### DIFF
--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -241,6 +241,9 @@ class BugTracker:
             id_bug_map[bugids[i]] = bug
         return id_bug_map
 
+    def remove_bugs(self, advisory_obj, bugids: List, noop=False):
+        raise NotImplementedError
+
     def attach_bugs(self, advisory_id: int, bugids: List, noop=False, verbose=False):
         raise NotImplementedError
 
@@ -410,6 +413,12 @@ class JIRABugTracker(BugTracker):
         )
         return self._search(query, verbose=verbose)
 
+    def remove_bugs(self, advisory_obj, bugids: List, noop=False):
+        if noop:
+            print(f"Would've removed bugs: {bugids}")
+            return
+        return errata.remove_multi_jira_issues(advisory_obj, bugids)
+
     def attach_bugs(self, advisory_id: int, bugids: List, noop=False, verbose=False):
         return errata.add_jira_bugs_with_retry(advisory_id, bugids, noop=noop)
 
@@ -464,6 +473,12 @@ class BugzillaBugTracker(BugTracker):
         if verbose:
             click.echo(query)
         return [BugzillaBug(b) for b in _perform_query(self._client, query)]
+
+    def remove_bugs(self, advisory_obj, bugids: List, noop=False):
+        if noop:
+            print(f"Would've removed bugs: {bugids}")
+            return
+        return errata.remove_bugzilla_bugs(advisory_obj, bugids)
 
     def attach_bugs(self, advisory_id: int, bugids: List, noop=False, verbose=False):
         return errata.add_bugzilla_bugs_with_retry(advisory_id, bugids, noop=noop)

--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -417,7 +417,8 @@ class JIRABugTracker(BugTracker):
         if noop:
             print(f"Would've removed bugs: {bugids}")
             return
-        return errata.remove_multi_jira_issues(advisory_obj, bugids)
+        advisory_id = advisory_obj.errata_id
+        return errata.remove_multi_jira_issues(advisory_id, bugids)
 
     def attach_bugs(self, advisory_id: int, bugids: List, noop=False, verbose=False):
         return errata.add_jira_bugs_with_retry(advisory_id, bugids, noop=noop)

--- a/elliottlib/cli/attach_bugs_cli.py
+++ b/elliottlib/cli/attach_bugs_cli.py
@@ -68,7 +68,8 @@ For attaching use --advisory, --use-default-advisory <TYPE>
         attach_bugs(runtime, advisory, default_advisory_type, bug_ids, report, output, noop,
                     JIRABugTracker(JIRABugTracker.get_config(runtime)))
 
-    attach_bugs(runtime, advisory, default_advisory_type, bug_ids, report, output, noop,
+    else:
+        attach_bugs(runtime, advisory, default_advisory_type, bug_ids, report, output, noop,
                 BugzillaBugTracker(BugzillaBugTracker.get_config(runtime)))
 
 

--- a/elliottlib/cli/attach_bugs_cli.py
+++ b/elliottlib/cli/attach_bugs_cli.py
@@ -70,7 +70,7 @@ For attaching use --advisory, --use-default-advisory <TYPE>
 
     else:
         attach_bugs(runtime, advisory, default_advisory_type, bug_ids, report, output, noop,
-                BugzillaBugTracker(BugzillaBugTracker.get_config(runtime)))
+                    BugzillaBugTracker(BugzillaBugTracker.get_config(runtime)))
 
 
 def attach_bugs(runtime, advisory, default_advisory_type, bug_ids, report, output, noop, bug_tracker):

--- a/elliottlib/cli/remove_bugs_cli.py
+++ b/elliottlib/cli/remove_bugs_cli.py
@@ -34,13 +34,17 @@ def remove_bugs_cli(runtime, advisory_id, default_advisory_type, bug_ids, remove
     Remove bugs that have been attached an advisory:
 
 \b
-    $ elliott --group openshift-3.7 remove-bugs --id 123456 --advisory 1234123
+    $ elliott --group openshift-4.10 remove-bugs 123456 --advisory 1234123
 
-    Remove two bugs from default rpm advisory. Note that --group is required
-    because default advisory is from ocp-build-data:
+    Remove two bugs from default image advisory
 
 \b
-    $ elliott --group openshift-3.7 remove-bugs --id 123456 --id 3412311 --use-default-advisory rpm
+    $ elliott --group openshift-4.10 --assembly 4.10.19 remove-bugs 123456 3412311 --use-default-advisory image
+
+    Remove all bugs from default image advisory
+
+\b
+    $ elliott --group openshift-4.10 --assembly 4.10.19 remove-bugs --all --use-default-advisory image
 
 """
     if bool(remove_all) == bool(bug_ids):

--- a/elliottlib/cli/remove_bugs_cli.py
+++ b/elliottlib/cli/remove_bugs_cli.py
@@ -74,7 +74,7 @@ def remove_bugs(advisory_id, bug_ids, remove_all, bug_tracker, noop):
     except GSSError:
         exit_unauthenticated()
 
-    if advisory is False:
+    if not advisory:
         raise ElliottFatalError(f"Error: Could not locate advisory {advisory_id}")
 
     try:

--- a/elliottlib/cli/remove_bugs_cli.py
+++ b/elliottlib/cli/remove_bugs_cli.py
@@ -1,45 +1,34 @@
 import click
-import requests
-
-import elliottlib
-from elliottlib import constants, logutil, Runtime, errata
+from elliottlib import logutil, errata
 from elliottlib.cli import cli_opts
 from elliottlib.cli.common import cli, use_default_advisory_option, find_default_advisory
 from elliottlib.exceptions import ElliottFatalError
 from elliottlib.bzutil import BugzillaBugTracker, JIRABugTracker
-from elliottlib.util import exit_unauthenticated, ensure_erratatool_auth
-from elliottlib.util import green_prefix, green_print, parallel_results_with_progress, pbar_header
+from elliottlib.util import exit_unauthenticated
+from elliottlib.util import green_prefix
 
-from errata_tool import Erratum, ErrataException
+from errata_tool import ErrataException
 from spnego.exceptions import GSSError
-
 
 LOGGER = logutil.getLogger(__name__)
 
-pass_runtime = click.make_pass_decorator(Runtime)
 
-
-# -----------------------------------------------------------------------------
-# CLI Commands - Please keep these in alphabetical order
-# -----------------------------------------------------------------------------
-#
-#
-# Remove bugs
-#
 @cli.command("remove-bugs", short_help="Remove provided BUGS from ADVISORY")
-@click.option('--advisory', '-a', 'advisory',
+@click.option('--advisory', '-a', 'advisory_id',
               type=int, metavar='ADVISORY',
               help='Remove found bugs from ADVISORY')
-@click.option("--id", metavar='BUGID', default=[],
-              multiple=True, required=False,
-              help="Bug IDs to remove from advisory.")
+@use_default_advisory_option
+@click.argument('bug_ids', metavar='<BUGID>', nargs=-1, required=False, default=None)
 @click.option("--all", "remove_all",
               required=False,
               default=False, is_flag=True,
-              help="Remove all bugs attached to Advisory")
-@pass_runtime
-@use_default_advisory_option
-def remove_bugs_cli(runtime, advisory, default_advisory_type, id, remove_all):
+              help="Remove all bugs attached to the Advisory")
+@click.option("--noop", "--dry-run",
+              is_flag=True,
+              default=False,
+              help="Don't change anything")
+@click.pass_obj
+def remove_bugs_cli(runtime, advisory_id, default_advisory_type, bug_ids, remove_all, noop):
     """Remove given BUGS from ADVISORY.
 
     Remove bugs that have been attached an advisory:
@@ -53,55 +42,50 @@ def remove_bugs_cli(runtime, advisory, default_advisory_type, id, remove_all):
 \b
     $ elliott --group openshift-3.7 remove-bugs --id 123456 --id 3412311 --use-default-advisory rpm
 
-
 """
-    if remove_all and id:
-        raise click.BadParameter("Combining the automatic and manual bug modification options is not supported")
-    if not remove_all and not id:
-        raise click.BadParameter("If not using --all then one or more --id's must be provided")
-    if bool(advisory) == bool(default_advisory_type):
+    if bool(remove_all) == bool(bug_ids):
+        raise click.BadParameter("Specify either <BUGID> or --all param")
+    if bool(advisory_id) == bool(default_advisory_type):
         raise click.BadParameter("Specify exactly one of --use-default-advisory or advisory arg")
 
     runtime.initialize()
-    if runtime.use_jira:
-        remove_bugs(runtime, advisory, default_advisory_type, [i for i in cli_opts.id_convert_str(id) if not str(i).isdigit()], remove_all,
-                    True, JIRABugTracker(JIRABugTracker.get_config(runtime)))
-    remove_bugs(runtime, advisory, default_advisory_type, [int(i) for i in cli_opts.id_convert_str(id) if str(i).isdigit()], remove_all,
-                False, BugzillaBugTracker(BugzillaBugTracker.get_config(runtime)))
-
-
-def remove_bugs(runtime, advisory, default_advisory_type, id, remove_all, use_jira, bug_tracker):
     if default_advisory_type is not None:
-        advisory = find_default_advisory(runtime, default_advisory_type)
+        advisory_id = find_default_advisory(runtime, default_advisory_type)
 
-    if advisory:
-        try:
-            advs = errata.Advisory(errata_id=advisory)
-        except GSSError:
-            exit_unauthenticated()
+    if runtime.use_jira:
+        bug_ids = cli_opts.id_convert_str(bug_ids)
+        bug_tracker = JIRABugTracker(JIRABugTracker.get_config(runtime))
+        remove_bugs(advisory_id, bug_ids, remove_all,
+                    bug_tracker, noop)
+    else:
+        bug_ids = cli_opts.id_convert(bug_ids)
+        bug_tracker = BugzillaBugTracker(BugzillaBugTracker.get_config(runtime))
+        remove_bugs(advisory_id, bug_ids, remove_all,
+                    bug_tracker, noop)
 
-        if advs is False:
-            raise ElliottFatalError("Error: Could not locate advisory {advs}".format(advs=advisory))
 
-        try:
-            if remove_all:
-                if use_jira:
-                    # TODO: this will soon become advs.jira_issues
-                    bug_ids = [issue.key for issue in errata.get_jira_issue(advisory)]
-                else:
-                    bug_ids = advs.errata_bugs
-            else:
-                bug_ids = [bug_tracker.get_bug(i).id for i in id]
-                print(id)
-            print(bug_ids)
-            green_prefix(f"Found {len(bug_ids)} bugs:")
-            click.echo(f" {', '.join([str(b) for b in bug_ids])}")
-            green_prefix(f"Removing bugs from advisory {advisory}:")
-            if bug_ids:
-                if use_jira:
-                    errata.remove_multi_jira_issues(advisory, bug_ids)
-                else:
-                    advs.removeBugs([bug for bug in bug_ids])
-                    advs.commit()
-        except ErrataException as ex:
-            raise ElliottFatalError(getattr(ex, 'message', repr(ex)))
+def remove_bugs(advisory_id, bug_ids, remove_all, bug_tracker, noop):
+    try:
+        advisory = errata.Advisory(errata_id=advisory_id)
+    except GSSError:
+        exit_unauthenticated()
+
+    if advisory is False:
+        raise ElliottFatalError(f"Error: Could not locate advisory {advisory_id}")
+
+    try:
+        attached_bug_ids = bug_tracker.advisory_bug_ids(advisory)
+        if not remove_all:
+            bug_ids = [b for b in bug_ids if b in attached_bug_ids]
+        else:
+            bug_ids = attached_bug_ids
+        green_prefix(f"Found {len(bug_ids)} bugs attached to advisory: ")
+        click.echo(f"{bug_ids}")
+
+        if not bug_ids:
+            return
+
+        green_prefix(f"Removing bugs from advisory {advisory_id}..")
+        bug_tracker.remove_bugs(advisory, bug_ids, noop)
+    except ErrataException as ex:
+        raise ElliottFatalError(getattr(ex, 'message', repr(ex)))

--- a/elliottlib/errata.py
+++ b/elliottlib/errata.py
@@ -545,7 +545,7 @@ def add_bugzilla_bugs_with_retry(advisory_id: int, bugids: List, noop: bool = Fa
     except GSSError:
         exit_unauthenticated()
 
-    if advisory is False:
+    if not advisory:
         raise exceptions.ElliottFatalError(f"Error: Could not locate advisory {advisory_id}")
 
     existing_bugs = advisory.errata_bugs

--- a/elliottlib/errata.py
+++ b/elliottlib/errata.py
@@ -122,7 +122,6 @@ def remove_multi_jira_issues(advisory_id, jira_list: List):
     Remove multi jira issues from advisory
     Return a list of response code
     """
-    print("im hereere")
     return [remove_jira_issue(advisory_id, jira_id) for jira_id in jira_list]
 
 

--- a/elliottlib/errata.py
+++ b/elliottlib/errata.py
@@ -122,6 +122,7 @@ def remove_multi_jira_issues(advisory_id, jira_list: List):
     Remove multi jira issues from advisory
     Return a list of response code
     """
+    print("im hereere")
     return [remove_jira_issue(advisory_id, jira_id) for jira_id in jira_list]
 
 
@@ -518,6 +519,11 @@ def parse_exception_error_message(e):
     :return: [1685399, 1685398]
     """
     return [int(b.split('#')[1]) for b in re.findall(r'Bug #[0-9]*', str(e))]
+
+
+def remove_bugzilla_bugs(advisory_obj, bugids: List):
+    advisory_obj.removeBugs([bug for bug in bugids])
+    advisory_obj.commit()
 
 
 def add_bugzilla_bugs_with_retry(advisory_id: int, bugids: List, noop: bool = False,


### PR DESCRIPTION
Note: errata api for removing jira bugs is broken. I'll follow up with the team

Summary
- Make sure bug id given is attached to the advisory
- Abstract out out bug remove logic into bug tracker methods
- Change the cli interface (no longer `--id`) to be consistent with attach-bugs

Test
- `make test`
- `elliott -g openshift-4.10 --assembly 4.10.19 remove-bugs --all --use-default-advisory image --noop`
- `elliott -g openshift-4.10 --assembly 4.10.19 remove-bugs 2095114 --use-default-advisory image --noop`
- `USEJIRA=True ./elliott -g openshift-4.10 remove-bugs --advisory 96435 OCPBUGS-1`