### PR TITLE
Fix elliott --version

### DIFF
--- a/elliottlib/__init__.py
+++ b/elliottlib/__init__.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from setuptools_scm import get_version
 
@@ -7,4 +8,8 @@ from .runtime import Runtime
 
 
 def version():
-    return get_version()
+    return get_version(
+        root=os.path.abspath(
+            os.path.join(os.path.dirname(__file__), '..')
+        )
+    )


### PR DESCRIPTION
Command was failing when executed from outside Elliott folder. Setting root param for setuptools_scm.get_version() fixed it.