### PR TITLE
Attach cve flaws with jira trackers and bugzilla flaws

### DIFF
--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -320,6 +320,9 @@ class BugTracker:
 
         raise NotImplementedError
 
+    def get_tracker_bugs(self, tracker_bug_ids: List, strict: bool = False):
+        raise NotImplementedError
+
 
 class JIRABugTracker(BugTracker):
     @staticmethod
@@ -482,6 +485,9 @@ class JIRABugTracker(BugTracker):
 
     def advisory_bug_ids(self, advisory_obj):
         return advisory_obj.jira_issues
+
+    def get_tracker_bugs(self, tracker_bug_ids: List, strict: bool = False):
+        return [b for b in self.get_bugs(tracker_bug_ids, permissive=not strict) if b.is_tracker_bug()]
 
     def get_corresponding_flaw_bugs(self, tracker_bugs: List[JIRABug], flaw_bug_tracker: BugTracker = None,
                                     strict: bool = False):
@@ -713,6 +719,11 @@ class BugzillaBugTracker(BugTracker):
 
     def advisory_bug_ids(self, advisory_obj):
         return advisory_obj.errata_bugs
+
+    def get_tracker_bugs(self, tracker_bug_ids: List, strict: bool = False):
+        fields = ["target_release", "blocks", 'whiteboard', 'keywords']
+        return [b for b in self.get_bugs(tracker_bug_ids, permissive=not strict, include_fields=fields) if
+                b.is_tracker_bug()]
 
     def get_corresponding_flaw_bugs(self, tracker_bugs: List[BugzillaBug], flaw_bug_tracker: BugTracker = None,
                                     strict: bool = False):

--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -526,43 +526,6 @@ class JIRABugTracker(BugTracker):
     def get_flaw_bugs(self, bug_ids: List, strict: bool = True):
         return [b for b in self.get_bugs(bug_ids, permissive=not strict) if b.is_flaw_bug()]
 
-    def get_corresponding_flaw_bugs(self, tracker_bugs: List[JIRABug], flaw_bug_tracker: BugTracker = None,
-                                    strict: bool = False):
-        """Get corresponding flaw bug objects for given list of tracker bug objects.
-        Accepts a flaw_bug_tracker object to fetch flaw bugs from, incase it's different from self
-
-        :return: (tracker_flaws, flaw_id_bugs): tracker_flaws is a dict with tracker bug id as key and list of flaw
-        bug id as value, flaw_id_bugs is a dict with flaw bug id as key and flaw bug object as value
-        """
-        bug_tracker = flaw_bug_tracker if flaw_bug_tracker else self
-        flaw_bugs = bug_tracker.get_bugs(list(set(sum([t.corresponding_flaw_bug_ids for t in tracker_bugs], []))))
-        flaw_id_bugs = {}
-        for f in flaw_bugs:
-            if f.is_flaw_bug():
-                flaw_id_bugs[f.id] = f
-            else:
-                logger.warn(f'{bug_tracker.type} Bug {f.id} is associated with a {self.type} tracker bug but is '
-                            f'missing internal flaw bug attributes')
-
-        # Validate that each tracker has a corresponding flaw bug
-        flaw_ids = set(flaw_id_bugs.keys())
-        no_flaws = set()
-        for tracker in tracker_bugs:
-            if not set(tracker.corresponding_flaw_bug_ids).intersection(flaw_ids):
-                no_flaws.add(tracker.id)
-        if no_flaws:
-            msg = f'No flaw bugs could be found for these trackers: {no_flaws}'
-            if strict:
-                raise exceptions.ElliottFatalError(msg)
-            else:
-                logger.warn(msg)
-
-        tracker_flaws: Dict[str, List[int]] = {
-            tracker.id: [b for b in tracker.corresponding_flaw_bug_ids if b in flaw_id_bugs]
-            for tracker in tracker_bugs
-        }
-        return tracker_flaws, flaw_id_bugs
-
 
 class BugzillaBugTracker(BugTracker):
     @staticmethod

--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -301,7 +301,13 @@ class BugTracker:
         if comment_lines:
             self.add_comment(bug.id, '\n'.join(comment_lines), private=True, noop=noop)
 
-    def get_corresponding_flaw_bugs(self, tracker_bugs: List, flaw_bug_tracker=None, strict: bool = False):
+    def get_corresponding_flaw_bugs(self, tracker_bugs: List[Bug], flaw_bug_tracker=None, strict: bool = False):
+        """Get corresponding flaw bug objects for given list of tracker bug objects.
+        Accepts a flaw_bug_tracker object to fetch flaw bugs from incase it's different from self
+
+        :return: dict with tracker bug id as key and list of flaw bug objects as value
+        """
+
         raise NotImplementedError
 
 
@@ -467,7 +473,14 @@ class JIRABugTracker(BugTracker):
     def advisory_bug_ids(self, advisory_obj):
         return advisory_obj.jira_issues
 
-    def get_corresponding_flaw_bugs(self, tracker_bugs: List, flaw_bug_tracker=None, strict: bool = False):
+    def get_corresponding_flaw_bugs(self, tracker_bugs: List[Bug], flaw_bug_tracker: BugTracker = None, strict: bool =
+                                    False) -> (Dict[str, List[int]], Dict[int, Bug]):
+        """Get corresponding flaw bug objects for given list of tracker bug objects.
+        Accepts a flaw_bug_tracker object to fetch flaw bugs from incase it's different from self
+
+        :return: (tracker_flaws, flaw_id_bugs): tracker_flaws is a dict with tracker bug id as key and list of flaw
+        bug id as value, flaw_id_bugs is a dict with flaw bug id as key and flaw bug object as value
+        """
         raise NotImplementedError
 
 
@@ -664,12 +677,13 @@ class BugzillaBugTracker(BugTracker):
     def advisory_bug_ids(self, advisory_obj):
         return advisory_obj.errata_bugs
 
-    def get_corresponding_flaw_bugs(self, tracker_bugs: List, flaw_bug_tracker=None, strict: bool = False):
-        """
-        Get corresponding flaw bugs objects for the
-        given tracker bug objects
-        :return (tracker_flaws, flaw_id_bugs): tracker_flaws is a dict with tracker bug id as key and list of flaw bug id as value,
-                                            flaw_bugs is a dict with flaw bug id as key and flaw bug object as value
+    def get_corresponding_flaw_bugs(self, tracker_bugs: List[Bug], flaw_bug_tracker: BugTracker = None, strict: bool =
+                                    False) -> (Dict[int, List[int]], Dict[int, Bug]):
+        """Get corresponding flaw bug objects for given list of tracker bug objects.
+        Accepts a flaw_bug_tracker object to fetch flaw bugs from incase it's different from self
+
+        :return: (tracker_flaws, flaw_id_bugs): tracker_flaws is a dict with tracker bug id as key and list of flaw
+        bug id as value, flaw_id_bugs is a dict with flaw bug id as key and flaw bug object as value
         """
         fields = ["product", "component", "depends_on", "alias", "severity", "summary"]
         blocking_bugs = self.get_bugs(list(set(sum([t.blocks for t in tracker_bugs], []))), include_fields=fields)

--- a/elliottlib/cli/attach_cve_flaws_cli.py
+++ b/elliottlib/cli/attach_cve_flaws_cli.py
@@ -73,10 +73,8 @@ async def attach_cve_flaws_cli(runtime: Runtime, advisory_id: int, noop: bool, d
 async def attach_cve_flaws(runtime, advisory_id, noop, advisory, bug_tracker, flaw_bug_tracker):
     # get attached bugs from advisory
     runtime.logger.info("Querying bugs for CVE trackers")
-    fields = ["target_release", "blocks", 'whiteboard', 'keywords']
     advisory_bug_ids = bug_tracker.advisory_bug_ids(advisory)
-    attached_tracker_bugs: List[Bug] = [bug for bug in bug_tracker.get_bugs(advisory_bug_ids, include_fields=fields,
-                                                                            permissive=True) if bug.is_tracker_bug()]
+    attached_tracker_bugs: List[Bug] = bug_tracker.get_tracker_bugs(advisory_bug_ids)
     runtime.logger.info(f'Found {len(attached_tracker_bugs)} {bug_tracker.type} tracker bugs attached to the advisory: '
                         f'{sorted(bug.id for bug in attached_tracker_bugs)}')
 

--- a/elliottlib/cli/attach_cve_flaws_cli.py
+++ b/elliottlib/cli/attach_cve_flaws_cli.py
@@ -4,7 +4,7 @@ import sys
 import traceback
 from errata_tool import Erratum
 
-from elliottlib import bzutil, constants
+from elliottlib import constants
 from elliottlib.cli.common import (cli, click_coroutine, find_default_advisory,
                                    use_default_advisory_option)
 from elliottlib.errata_async import AsyncErrataAPI, AsyncErrataUtils

--- a/elliottlib/cli/attach_cve_flaws_cli.py
+++ b/elliottlib/cli/attach_cve_flaws_cli.py
@@ -141,11 +141,11 @@ async def attach_cve_flaws(runtime, advisory_id, noop, advisory, bug_tracker, fl
         await errata_api.close()
 
 
-async def associate_builds_with_cves(errata_api: AsyncErrataAPI, advisory: Erratum, attached_tracker_bugs: List[Bug], tracker_flaws: Dict[int, List[int]], flaw_id_bugs: Dict[int, Bug], dry_run: bool):
+async def associate_builds_with_cves(errata_api: AsyncErrataAPI, advisory: Erratum, attached_tracker_bugs: List[Bug], tracker_flaws, flaw_id_bugs: Dict[int, Bug], dry_run: bool):
     attached_builds = [b for pv in advisory.errata_builds.values() for b in pv]
     cve_components_mapping: Dict[str, Set[str]] = {}
     for tracker in attached_tracker_bugs:
-        component_name = bzutil.get_whiteboard_component(tracker)
+        component_name = tracker.whiteboard_component
         if not component_name:
             raise ValueError(f"Bug {tracker.id} doesn't have a valid component name in its whiteboard field.")
         flaw_ids = tracker_flaws[tracker.id]

--- a/elliottlib/cli/attach_cve_flaws_cli.py
+++ b/elliottlib/cli/attach_cve_flaws_cli.py
@@ -120,6 +120,7 @@ async def attach_cve_flaws(runtime, advisory_id, noop, advisory, bug_tracker, fl
     advisory = get_updated_advisory_rhsa(runtime.logger, cve_boilerplate, advisory, first_fix_flaw_bugs)
     if not noop:
         runtime.logger.info("Updating advisory details %s", advisory_id)
+        # this removes all attached jira bugs :/
         advisory.commit()
 
     flaw_ids = [flaw_bug.id for flaw_bug in first_fix_flaw_bugs]

--- a/elliottlib/cli/attach_cve_flaws_cli.py
+++ b/elliottlib/cli/attach_cve_flaws_cli.py
@@ -140,7 +140,6 @@ def _update(runtime, advisory, first_fix_flaw_bugs, bug_tracker, noop):
     cve_boilerplate = errata_config['boilerplates']['cve']
     advisory, updated = get_updated_advisory_rhsa(runtime.logger, cve_boilerplate, advisory, first_fix_flaw_bugs)
     if not noop and updated:
-        # this removes all attached jira bugs so use carefully
         runtime.logger.info("Updating advisory details %s", advisory_id)
         advisory.commit()
 

--- a/elliottlib/cli/common.py
+++ b/elliottlib/cli/common.py
@@ -107,9 +107,6 @@ def click_coroutine(f):
     """ A wrapper to allow to use asyncio with click.
     https://github.com/pallets/click/issues/85
     """
-    f = asyncio.coroutine(f)
-
     def wrapper(*args, **kwargs):
-        loop = asyncio.get_event_loop()
-        return loop.run_until_complete(f(*args, **kwargs))
+        return asyncio.run(f(*args, **kwargs))
     return update_wrapper(wrapper, f)

--- a/elliottlib/cli/create_cli.py
+++ b/elliottlib/cli/create_cli.py
@@ -1,13 +1,14 @@
 import click
 import datetime
 import elliottlib
+from elliottlib.bzutil import BugzillaBugTracker
 from elliottlib.cli.common import cli
 from elliottlib.cli.add_metadata_cli import add_metadata_cli
 from elliottlib.cli.create_placeholder_cli import create_placeholder_cli
 from elliottlib.exectools import cmd_assert
 from elliottlib.exceptions import ElliottFatalError
 from elliottlib.util import YMD, validate_release_date, \
-    validate_email_address, exit_unauthorized, green_prefix, yellow_print
+    validate_email_address, exit_unauthorized, green_prefix
 pass_runtime = click.make_pass_decorator(elliottlib.Runtime)
 
 LOGGER = elliottlib.logutil.getLogger(__name__)
@@ -97,7 +98,6 @@ advisory.
     runtime.initialize()
 
     et_data = runtime.gitdata.load_data(key='erratatool').data
-    bz_data = runtime.gitdata.load_data(key='bug').data
 
     # User entered a valid value for --date, set the release date
     release_date = datetime.datetime.strptime(date, YMD)
@@ -107,10 +107,10 @@ advisory.
     unique_bugs = set(bugs)
 
     if bugs:
-        bzapi = elliottlib.bzutil.get_bzapi(bz_data)
+        bug_tracker = BugzillaBugTracker(BugzillaBugTracker.get_config(runtime))
         LOGGER.info("Fetching bugs {} from Bugzilla...".format(
             " ".join(map(str, bugs))))
-        bug_objects = bzapi.getbugs(bugs)
+        bug_objects = bug_tracker.get_bugs(bugs)
         # assert bugs are viable for a new advisory.
         _assert_bugs_are_viable(bugs, bug_objects)
 

--- a/elliottlib/cli/create_cli.py
+++ b/elliottlib/cli/create_cli.py
@@ -9,15 +9,10 @@ from elliottlib.exectools import cmd_assert
 from elliottlib.exceptions import ElliottFatalError
 from elliottlib.util import YMD, validate_release_date, \
     validate_email_address, exit_unauthorized, green_prefix
-pass_runtime = click.make_pass_decorator(elliottlib.Runtime)
 
 LOGGER = elliottlib.logutil.getLogger(__name__)
 
 
-#
-# Create Advisory (RPM and image)
-# advisory:create
-#
 @cli.command("create", short_help="Create a new advisory")
 @click.option("--type", '-t', 'errata_type',
               type=click.Choice(['RHBA', 'RHEA']),
@@ -56,7 +51,7 @@ LOGGER = elliottlib.logutil.getLogger(__name__)
               help="Create the advisory (by default only a preview is displayed)")
 @click.option("--bug", "--bugs", "-b", 'bugs', type=int, multiple=True,
               help="Bug IDs for attaching to the advisory on creation. Required for creating a security advisory.")
-@pass_runtime
+@click.pass_obj
 @click.pass_context
 def create_cli(ctx, runtime, errata_type, kind, impetus, date, assigned_to, manager, package_owner, with_placeholder, with_liveid, yes, bugs):
     """Create a new advisory. The kind of advisory must be specified with

--- a/elliottlib/cli/create_placeholder_cli.py
+++ b/elliottlib/cli/create_placeholder_cli.py
@@ -62,6 +62,9 @@ def create_placeholder(kind, advisory_id, bug_tracker, noop):
 
     click.echo(f"Created Bug: {newbug.id} {newbug.weburl}")
 
+    if not advisory_id:
+        return
+
     try:
         advisory = Erratum(errata_id=advisory_id)
     except GSSError:

--- a/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliottlib/cli/find_bugs_sweep_cli.py
@@ -224,7 +224,7 @@ def categorize_bugs_by_type(bugs: List, rpm_advisory_id: Optional[int] = None, m
     if int(major_version) < 4:
         bugs_by_type["rpm"] = set(bugs)
     else:  # for 4.x, sweep rpm cve trackers into rpm advisory
-        rpm_bugs = bzutil.get_valid_rpm_cves(bugs)
+        rpm_bugs = Bug.get_valid_rpm_cves(bugs)
         if rpm_bugs:
             green_prefix("RPM CVEs found: ")
             click.echo(sorted(b.id for b in rpm_bugs))

--- a/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliottlib/cli/verify_attached_bugs_cli.py
@@ -118,7 +118,7 @@ class BugValidator:
     async def verify_attached_flaws(self, advisory_bugs: Dict[int, List[Bug]]):
         futures = []
         for advisory_id, attached_bugs in advisory_bugs.items():
-            attached_trackers = [b for b in attached_bugs if bzutil.is_cve_tracker(b)]
+            attached_trackers = [b for b in attached_bugs if b.is_tracker_bug()]
             attached_flaws = [b for b in attached_bugs if b.is_flaw_bug()]
             futures.append(self._verify_attached_flaws_for(advisory_id, attached_trackers, attached_flaws))
         await asyncio.gather(*futures)
@@ -129,10 +129,7 @@ class BugValidator:
 
     async def _verify_attached_flaws_for(self, advisory_id: int, attached_trackers: Iterable[Bug], attached_flaws: Iterable[Bug]):
         # Retrieve flaw bugs in Bugzilla for attached_tracker_bugs
-        tracker_flaws, flaw_id_bugs = self.bug_tracker.get_corresponding_flaw_bugs(
-            attached_trackers,
-            fields=["depends_on", "alias", "severity", "summary"]
-        )
+        tracker_flaws, flaw_id_bugs = self.bug_tracker.get_corresponding_flaw_bugs(attached_trackers)
 
         # Find first-fix flaws
         first_fix_flaw_ids = set()
@@ -170,7 +167,7 @@ class BugValidator:
         # Check if flaw bugs are associated with specific builds
         cve_components_mapping: Dict[str, Set[str]] = {}
         for tracker in attached_trackers:
-            component_name = bzutil.get_whiteboard_component(tracker)
+            component_name = tracker.whiteboard_component
             if not component_name:
                 raise ValueError(f"Tracker bug {tracker.id} doesn't have a valid component name in its whiteboard field.")
             flaw_ids = tracker_flaws[tracker.id]
@@ -281,7 +278,7 @@ class BugValidator:
     def _verify_bug_status(self, bugs):
         # complain about bugs that are not yet VERIFIED or more.
         for bug in bugs:
-            if bzutil.is_flaw_bug(bug):
+            if bug.is_flaw_bug():
                 continue
             if bug.status in ["VERIFIED", "RELEASE_PENDING"]:
                 continue

--- a/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliottlib/cli/verify_attached_bugs_cli.py
@@ -13,7 +13,7 @@ from elliottlib.errata_async import AsyncErrataAPI, AsyncErrataUtils
 from elliottlib.runtime import Runtime
 from elliottlib.util import (exit_unauthenticated, green_print,
                              minor_version_tuple, red_print)
-from elliottlib.bzutil import BugzillaBugTracker, JIRABugTracker, Bug, get_corresponding_flaw_bugs
+from elliottlib.bzutil import BugzillaBugTracker, JIRABugTracker, Bug
 
 
 @cli.command("verify-attached-bugs", short_help="Verify bugs in a release will not be regressed in the next version")
@@ -129,8 +129,7 @@ class BugValidator:
 
     async def _verify_attached_flaws_for(self, advisory_id: int, attached_trackers: Iterable[Bug], attached_flaws: Iterable[Bug]):
         # Retrieve flaw bugs in Bugzilla for attached_tracker_bugs
-        tracker_flaws, flaw_id_bugs = get_corresponding_flaw_bugs(
-            self.bug_tracker,
+        tracker_flaws, flaw_id_bugs = self.bug_tracker.get_corresponding_flaw_bugs(
             attached_trackers,
             fields=["depends_on", "alias", "severity", "summary"]
         )

--- a/elliottlib/errata.py
+++ b/elliottlib/errata.py
@@ -637,7 +637,7 @@ def add_jira_bugs_with_retry(advisory_id: int, bugids: List[str], noop: bool = F
                 rt = add_jira_issue(advisory_id, chunk_of_bugs[i])
                 if rt.status_code != 201:
                     raise exceptions.ElliottFatalError(f"attach jira bug {chunk_of_bugs[i]} failed with "
-                                                       f"status={rt.status_code}")
+                                                       f"status={rt.status_code}: {rt.json()}")
         logger.info("All jira bugs attached")
 
 

--- a/elliottlib/errata.py
+++ b/elliottlib/errata.py
@@ -15,6 +15,7 @@ import click
 import requests
 from elliottlib import exceptions, constants, brew, logutil
 from elliottlib.util import green_prefix, green_print, exit_unauthenticated, chunk
+from elliottlib import bzutil
 from requests_kerberos import HTTPKerberosAuth
 from spnego.exceptions import GSSError
 from errata_tool import Erratum, ErrataException, ErrataConnector
@@ -566,8 +567,7 @@ def add_bugzilla_bugs_with_retry(advisory_id: int, bugids: List, noop: bool = Fa
     :param batch_size: perform operation in batches of given size
     :return:
     """
-    click.echo(f'Request to attach {len(bugids)} bugs to the advisory {advisory_id}')
-
+    logger.info(f'Request to attach {len(bugids)} bugs to the advisory {advisory_id}')
     try:
         advisory = Erratum(errata_id=advisory_id)
     except GSSError:
@@ -576,7 +576,7 @@ def add_bugzilla_bugs_with_retry(advisory_id: int, bugids: List, noop: bool = Fa
     if not advisory:
         raise exceptions.ElliottFatalError(f"Error: Could not locate advisory {advisory_id}")
 
-    existing_bugs = advisory.errata_bugs
+    existing_bugs = bzutil.BugzillaBugTracker.advisory_bug_ids(advisory)
     new_bugs = set(bugids) - set(existing_bugs)
     logger.info(f'Bugs already attached: {len(existing_bugs)}. New bugs: {len(new_bugs)}')
     if not new_bugs:
@@ -613,7 +613,20 @@ def add_jira_bugs_with_retry(advisory_id: int, bugids: List[str], noop: bool = F
     :param noop: do not modify anything
     :param batch_size: perform operation in batches of given size
     """
-    click.echo(f'Request to attach {len(bugids)} bugs to the advisory {advisory_id}')
+    logger.info(f'Request to attach {len(bugids)} bugs to the advisory {advisory_id}')
+    try:
+        advisory = Erratum(errata_id=advisory_id)
+    except GSSError:
+        exit_unauthenticated()
+
+    if not advisory:
+        raise exceptions.ElliottFatalError(f"Error: Could not locate advisory {advisory_id}")
+
+    existing_bugs = bzutil.JIRABugTracker.advisory_bug_ids(advisory)
+    new_bugs = set(bugids) - set(existing_bugs)
+    logger.info(f'Bugs already attached: {len(existing_bugs)}. New bugs: {len(new_bugs)}')
+    if not new_bugs:
+        return
     for chunk_of_bugs in chunk(bugids, batch_size):
         if noop:
             logger.info('Dry run: Would have attached bugs')

--- a/tests/test_attach_cve_flaws.py
+++ b/tests/test_attach_cve_flaws.py
@@ -36,7 +36,7 @@ class TestAttachCVEFlaws(unittest.TestCase):
         valid_flaw_b = BugzillaBug(flexmock(product=product, component=component, id=2))
         invalid_flaw_c = BugzillaBug(flexmock(product='foo', component=component, id=3))
         invalid_flaw_d = BugzillaBug(flexmock(product=product, component='bar', id=4))
-        flaw_bugs = [valid_flaw_a, valid_flaw_b, invalid_flaw_c, invalid_flaw_d]
+        flaw_bugs = [valid_flaw_a, valid_flaw_b]
 
         tracker_bugs = [
             BugzillaBug(flexmock(blocks=[valid_flaw_a.id, valid_flaw_b.id], id=10)),
@@ -83,9 +83,9 @@ class TestAttachCVEFlaws(unittest.TestCase):
 
     def test_get_corresponding_flaw_bugs_bz_strict(self):
         tracker_bugs = [
-            flexmock(blocks=[1, 2], id=10),
-            flexmock(blocks=[2, 3], id=11),
-            flexmock(blocks=[], id=12)
+            BugzillaBug(flexmock(blocks=[1, 2], id=10)),
+            BugzillaBug(flexmock(blocks=[2, 3], id=11)),
+            BugzillaBug(flexmock(blocks=[], id=12))
         ]
         product = 'Security Response'
         component = 'vulnerability'

--- a/tests/test_attach_cve_flaws.py
+++ b/tests/test_attach_cve_flaws.py
@@ -1,7 +1,7 @@
 import unittest
 from flexmock import flexmock
 from elliottlib import constants, exceptions, bzutil
-from elliottlib.bzutil import Bug, BugzillaBug, JIRABug, BugzillaBugTracker
+from elliottlib.bzutil import Bug, BugzillaBug, JIRABug, BugzillaBugTracker, JIRABugTracker
 
 
 class TestAttachCVEFlaws(unittest.TestCase):
@@ -30,39 +30,58 @@ class TestAttachCVEFlaws(unittest.TestCase):
         self.assertEqual(expected, actual)
 
     def test_get_corresponding_flaw_bugs_bz(self):
-        tracker_bugs = [
-            flexmock(blocks=[1, 2], id=10),
-            flexmock(blocks=[2, 3, 4], id=11),
-        ]
         product = 'Security Response'
         component = 'vulnerability'
-        bug_a = flexmock(product=product, component=component, id=1)
-        flexmock(bug_a).should_receive("is_flaw_bug").and_return(True)
-        bug_b = flexmock(product=product, component=component, id=2)
-        flexmock(bug_b).should_receive("is_flaw_bug").and_return(True)
-        bug_c = flexmock(product='foo', component=component, id=3)
-        flexmock(bug_c).should_receive("is_flaw_bug").and_return(False)
-        bug_d = flexmock(product=product, component='bar', id=4)
-        flexmock(bug_d).should_receive("is_flaw_bug").and_return(False)
-        flaw_bugs = [
-            bug_a,
-            bug_b,
-            bug_c,
-            bug_d
+        valid_flaw_a = BugzillaBug(flexmock(product=product, component=component, id=1))
+        valid_flaw_b = BugzillaBug(flexmock(product=product, component=component, id=2))
+        invalid_flaw_c = BugzillaBug(flexmock(product='foo', component=component, id=3))
+        invalid_flaw_d = BugzillaBug(flexmock(product=product, component='bar', id=4))
+        flaw_bugs = [valid_flaw_a, valid_flaw_b, invalid_flaw_c, invalid_flaw_d]
+
+        tracker_bugs = [
+            BugzillaBug(flexmock(blocks=[valid_flaw_a.id, valid_flaw_b.id], id=10)),
+            BugzillaBug(flexmock(blocks=[valid_flaw_b.id, invalid_flaw_c.id, invalid_flaw_d.id], id=11)),
         ]
 
         flexmock(BugzillaBugTracker).should_receive("login").and_return(None)
         flexmock(BugzillaBugTracker).should_receive("get_bugs").and_return(flaw_bugs)
         bug_tracker = BugzillaBugTracker({})
 
-        expected = 2
-        actual = len(bug_tracker.get_corresponding_flaw_bugs(tracker_bugs)[1])
+        expected = (
+            {10: [valid_flaw_a.id, valid_flaw_b.id], 11: [valid_flaw_b.id]},
+            {valid_flaw_a.id: valid_flaw_a, valid_flaw_b.id: valid_flaw_b}
+        )
+        actual = bug_tracker.get_corresponding_flaw_bugs(tracker_bugs)
         self.assertEqual(expected, actual)
 
     def test_get_corresponding_flaw_bugs_jira(self):
-        pass
+        product = 'Security Response'
+        component = 'vulnerability'
+        valid_flaw = BugzillaBug(flexmock(product=product, component=component, id=9999))
+        invalid_flaw = BugzillaBug(flexmock(product=product, component='foo', id=9998))
+        flaw_bugs = [valid_flaw, invalid_flaw]
 
-    def test_validate_tracker_has_flaw(self):
+        tracker_bugs = [
+            JIRABug(flexmock(key='OCPBUGS-1', fields=flexmock(labels=[f"flaw:bz#{valid_flaw.id}",
+                                                                      f"flaw:bz#{invalid_flaw.id}"]))),
+            JIRABug(flexmock(key='OCPBUGS-2', fields=flexmock(labels=[f"flaw:bz#{invalid_flaw.id}"]))),
+            JIRABug(flexmock(key='OCPBUGS-3', fields=flexmock(labels=[f"flaw:bz#{valid_flaw.id}"])))
+        ]
+
+        flexmock(BugzillaBugTracker).should_receive("login").and_return(None)
+        flexmock(JIRABugTracker).should_receive("login").and_return(None)
+        flexmock(BugzillaBugTracker).should_receive("get_bugs").and_return(flaw_bugs)
+        bug_tracker = JIRABugTracker({})
+        flaw_bug_tracker = BugzillaBugTracker({})
+
+        expected = (
+            {'OCPBUGS-1': [valid_flaw.id], 'OCPBUGS-2': [], 'OCPBUGS-3': [valid_flaw.id]},
+            {valid_flaw.id: valid_flaw}
+        )
+        actual = bug_tracker.get_corresponding_flaw_bugs(tracker_bugs, flaw_bug_tracker)
+        self.assertEqual(expected, actual)
+
+    def test_get_corresponding_flaw_bugs_bz_strict(self):
         tracker_bugs = [
             flexmock(blocks=[1, 2], id=10),
             flexmock(blocks=[2, 3], id=11),
@@ -70,12 +89,9 @@ class TestAttachCVEFlaws(unittest.TestCase):
         ]
         product = 'Security Response'
         component = 'vulnerability'
-        bug_a = flexmock(product=product, component='wrong_component', id=1)
-        flexmock(bug_a).should_receive("is_flaw_bug").and_return(False)
-        bug_b = flexmock(product='wrong_product', component=component, id=2)
-        flexmock(bug_b).should_receive("is_flaw_bug").and_return(False)
-        bug_c = flexmock(product=product, component=component, id=3)
-        flexmock(bug_c).should_receive("is_flaw_bug").and_return(True)
+        bug_a = BugzillaBug(flexmock(product=product, component='wrong_component', id=1))
+        bug_b = BugzillaBug(flexmock(product='wrong_product', component=component, id=2))
+        bug_c = BugzillaBug(flexmock(product=product, component=component, id=3))
         flaw_bugs = [bug_a, bug_b, bug_c]
 
         flexmock(BugzillaBugTracker).should_receive("login").and_return(None)
@@ -103,192 +119,134 @@ class TestAttachCVEFlaws(unittest.TestCase):
         actual = bzutil.is_first_fix_any(bzapi, bug, tr)
         self.assertEqual(expected, actual)
 
-    def test_is_first_fix_any_no_trackers(self):
+    def test_is_first_fix_any_no_valid_trackers(self):
         tr = '4.8.0'
         tracker_bug_ids = [1, 2]
-        bug_a = flexmock(id=1, product=constants.BUGZILLA_PRODUCT_OCP, keywords=['foo'], whiteboard='', target_release=[tr])
-        flexmock(bug_a).should_receive("is_tracker_bug").and_return(False)
+        bug_a = BugzillaBug(flexmock(
+            id=1,
+            product=constants.BUGZILLA_PRODUCT_OCP,
+            keywords=['foo'])
+        )
         tracker_bug_objs = [bug_a]
-        flaw_bug = flexmock(id=6, depends_on=tracker_bug_ids)
-        bzapi = flexmock()
-        fields = ['keywords', 'target_release', 'status', 'resolution', 'whiteboard']
-        (bzapi
-            .should_receive("build_query")
-            .with_args(
-                product=constants.BUGZILLA_PRODUCT_OCP,
-                bug_id=tracker_bug_ids,
-                include_fields=fields))
-        (bzapi
-            .should_receive("query")
-            .and_return(tracker_bug_objs))
-        (bzapi
-            .should_receive("get_bugs")
-            .and_return([]))
+        flaw_bug = BugzillaBug(flexmock(id=6, depends_on=tracker_bug_ids))
+
+        flexmock(BugzillaBugTracker).should_receive("login")
+        bug_tracker = BugzillaBugTracker({})
+        bug_tracker.should_receive("get_bugs").with_args(tracker_bug_ids).and_return(tracker_bug_objs)
 
         expected = True
-        actual = bzutil.is_first_fix_any(bzapi, flaw_bug, tr)
+        actual = bzutil.is_first_fix_any(bug_tracker, flaw_bug, tr)
         self.assertEqual(expected, actual)
 
-    def test_is_first_fix_any_missing_component(self):
+    def test_is_first_fix_any_missing_whiteboard_component(self):
         tr = '4.8.0'
-        bug_a = flexmock(id=1, product=constants.BUGZILLA_PRODUCT_OCP, keywords=constants.TRACKER_BUG_KEYWORDS, whiteboard='', target_release=[tr])
-        flexmock(bug_a).should_receive("is_tracker_bug").and_return(True)
+        tracker_bug_ids = [1, 2]
+        bug_a = BugzillaBug(flexmock(
+            id=1,
+            product=constants.BUGZILLA_PRODUCT_OCP,
+            keywords=constants.TRACKER_BUG_KEYWORDS,
+            whiteboard='', target_release=[tr]
+        ))
         tracker_bug_objs = [bug_a]
-        tracker_bugs_ids = [1, 2]
-        flaw_bug = flexmock(id=5, product=constants.BUGZILLA_PRODUCT_OCP, depends_on=tracker_bugs_ids)
+        flaw_bug = BugzillaBug(flexmock(id=6, depends_on=tracker_bug_ids))
 
-        bzapi = flexmock()
-        fields = ['keywords', 'target_release', 'status', 'resolution', 'whiteboard']
-        (bzapi
-            .should_receive("build_query")
-            .with_args(
-                product=constants.BUGZILLA_PRODUCT_OCP,
-                bug_id=tracker_bugs_ids,
-                include_fields=fields))
-        (bzapi
-            .should_receive("query")
-            .and_return(tracker_bug_objs))
-        (bzapi
-            .should_receive("get_bugs")
-            .and_return(tracker_bug_objs))
+        flexmock(BugzillaBugTracker).should_receive("login")
+        bug_tracker = BugzillaBugTracker({})
+        bug_tracker.should_receive("get_bugs").with_args(tracker_bug_ids).and_return(tracker_bug_objs)
 
         expected = False
-        actual = bzutil.is_first_fix_any(bzapi, flaw_bug, tr)
+        actual = bzutil.is_first_fix_any(bug_tracker, flaw_bug, tr)
         self.assertEqual(expected, actual)
 
-    def test_is_first_fix_any_same_major(self):
-        bug_a = flexmock(
+    def test_is_first_fix_any_is_first_fix_group(self):
+        tr = '4.8.0'
+        bug_a = BugzillaBug(flexmock(
             id=1,
             keywords=constants.TRACKER_BUG_KEYWORDS,
             product=constants.BUGZILLA_PRODUCT_OCP,
             whiteboard='component:runc',
             target_release=['3.11.z'],
-            status='RELEASE_PENDING')
-        flexmock(bug_a).should_receive("is_tracker_bug").and_return(True)
-        bug_b = flexmock(
+            status='RELEASE_PENDING'))
+        bug_b = BugzillaBug(flexmock(
             id=2,
             keywords=constants.TRACKER_BUG_KEYWORDS,
             product=constants.BUGZILLA_PRODUCT_OCP,
             whiteboard='component:runc',
-            target_release=['4.8.0'],
-            status='ON_QA')
-        flexmock(bug_b).should_receive("is_tracker_bug").and_return(True)
-        tracker_bug_objs = [
-            # bug that should be ignored
-            bug_a,
-            bug_b
-        ]
+            target_release=[tr],
+            status='ON_QA'))
+        tracker_bug_objs = [bug_a, bug_b]
         tracker_bug_ids = [t.id for t in tracker_bug_objs]
-        flaw_bug = flexmock(id=3, depends_on=tracker_bug_ids)
-        tr = '4.8.0'
+        flaw_bug = BugzillaBug(flexmock(id=3, depends_on=tracker_bug_ids))
 
-        bzapi = flexmock()
-        fields = ['keywords', 'target_release', 'status', 'resolution', 'whiteboard']
-        (bzapi
-            .should_receive("build_query")
-            .with_args(
-                product=constants.BUGZILLA_PRODUCT_OCP,
-                bug_id=tracker_bug_ids,
-                include_fields=fields))
-        (bzapi
-            .should_receive("query")
-            .and_return(tracker_bug_objs))
-        (bzapi
-            .should_receive("get_bugs")
-            .and_return(tracker_bug_objs))
+        flexmock(BugzillaBugTracker).should_receive("login")
+        bug_tracker = BugzillaBugTracker({})
+        bug_tracker.should_receive("get_bugs").with_args(tracker_bug_ids).and_return(tracker_bug_objs)
 
         expected = True
-        actual = bzutil.is_first_fix_any(bzapi, flaw_bug, tr)
+        actual = bzutil.is_first_fix_any(bug_tracker, flaw_bug, tr)
         self.assertEqual(expected, actual)
 
     def test_is_first_fix_any_already_fixed(self):
-        bug_a = flexmock(
+        tr = '4.8.0'
+        bug_a = BugzillaBug(flexmock(
             id=1,
             keywords=constants.TRACKER_BUG_KEYWORDS,
-            whiteboard='component:runc',
             product=constants.BUGZILLA_PRODUCT_OCP,
+            whiteboard='component:runc',
             target_release=['4.7.z'],
-            status='RELEASE_PENDING')
-        flexmock(bug_a).should_receive("is_tracker_bug").and_return(True)
-        bug_b = flexmock(
+            status='RELEASE_PENDING'))
+        bug_b = BugzillaBug(flexmock(
             id=2,
             keywords=constants.TRACKER_BUG_KEYWORDS,
-            whiteboard='component:runc',
             product=constants.BUGZILLA_PRODUCT_OCP,
-            target_release=['4.8.0'],
-            status='ON_QA')
-        flexmock(bug_b).should_receive("is_tracker_bug").and_return(True)
+            whiteboard='component:runc',
+            target_release=[tr],
+            status='ON_QA'))
         tracker_bug_objs = [bug_a, bug_b]
         tracker_bug_ids = [t.id for t in tracker_bug_objs]
-        flaw_bug = flexmock(id=3, depends_on=tracker_bug_ids)
-        tr = '4.8.0'
+        flaw_bug = BugzillaBug(flexmock(id=3, depends_on=tracker_bug_ids))
 
-        bzapi = flexmock()
-        fields = ['keywords', 'target_release', 'status', 'resolution', 'whiteboard']
-        (bzapi
-            .should_receive("build_query")
-            .with_args(
-                product=constants.BUGZILLA_PRODUCT_OCP,
-                bug_id=tracker_bug_ids,
-                include_fields=fields))
-        (bzapi
-            .should_receive("query")
-            .and_return(tracker_bug_objs))
-        (bzapi
-            .should_receive("get_bugs")
-            .and_return(tracker_bug_objs))
+        flexmock(BugzillaBugTracker).should_receive("login")
+        bug_tracker = BugzillaBugTracker({})
+        bug_tracker.should_receive("get_bugs").with_args(tracker_bug_ids).and_return(tracker_bug_objs)
 
         expected = False
-        actual = bzutil.is_first_fix_any(bzapi, flaw_bug, tr)
+        actual = bzutil.is_first_fix_any(bug_tracker, flaw_bug, tr)
         self.assertEqual(expected, actual)
 
     def test_is_first_fix_any_any(self):
-        bug_a = flexmock(
+        tr = '4.8.0'
+        bug_a = BugzillaBug(flexmock(
             id=1,
             keywords=constants.TRACKER_BUG_KEYWORDS,
             whiteboard='component:runc',
             product=constants.BUGZILLA_PRODUCT_OCP,
             target_release=['4.7.z'],
-            status='RELEASE_PENDING')
-        bug_b = flexmock(
+            status='RELEASE_PENDING'))
+        bug_b = BugzillaBug(flexmock(
             id=2,
             keywords=constants.TRACKER_BUG_KEYWORDS,
             whiteboard='component:runc',
             product=constants.BUGZILLA_PRODUCT_OCP,
-            target_release=['4.8.0'],
-            status='ON_QA')
-        bug_c = flexmock(
+            target_release=[tr],
+            status='ON_QA'))
+        bug_c = BugzillaBug(flexmock(
             id=3,
             keywords=constants.TRACKER_BUG_KEYWORDS,
             whiteboard='component:crio',
             product=constants.BUGZILLA_PRODUCT_OCP,
-            target_release=['4.8.0'],
-            status='ON_QA')
-        flexmock(bug_a).should_receive("is_tracker_bug").and_return(True)
-        flexmock(bug_b).should_receive("is_tracker_bug").and_return(True)
-        flexmock(bug_c).should_receive("is_tracker_bug").and_return(True)
+            target_release=[tr],
+            status='ON_QA'))
         tracker_bug_objs = [bug_a, bug_b, bug_c]
         tracker_bug_ids = [t.id for t in tracker_bug_objs]
-        flaw_bug = flexmock(id=4, depends_on=tracker_bug_ids)
-        tr = '4.8.0'
+        flaw_bug = BugzillaBug(flexmock(id=4, depends_on=tracker_bug_ids))
 
-        bzapi = flexmock()
-        fields = ['keywords', 'target_release', 'status', 'resolution', 'whiteboard']
-        (bzapi
-            .should_receive("build_query")
-            .with_args(
-                product=constants.BUGZILLA_PRODUCT_OCP,
-                bug_id=tracker_bug_ids,
-                include_fields=fields))
-        (bzapi
-            .should_receive("query")
-            .and_return(tracker_bug_objs))
-        (bzapi
-            .should_receive("get_bugs")
-            .and_return(tracker_bug_objs))
+        flexmock(BugzillaBugTracker).should_receive("login")
+        bug_tracker = BugzillaBugTracker({})
+        bug_tracker.should_receive("get_bugs").with_args(tracker_bug_ids).and_return(tracker_bug_objs)
 
         expected = True
-        actual = bzutil.is_first_fix_any(bzapi, flaw_bug, tr)
+        actual = bzutil.is_first_fix_any(bug_tracker, flaw_bug, tr)
         self.assertEqual(expected, actual)
 
 

--- a/tests/test_attach_cve_flaws_cli.py
+++ b/tests/test_attach_cve_flaws_cli.py
@@ -1,7 +1,7 @@
 import unittest
 from asyncio import get_event_loop
 
-from bugzilla.bug import Bug
+from elliottlib.bzutil import BugzillaBug
 from mock import AsyncMock, Mock, patch
 
 from elliottlib.cli import attach_cve_flaws_cli
@@ -60,7 +60,7 @@ class TestAttachCVEFlawsCLI(unittest.TestCase):
         )
 
     @patch("elliottlib.errata_async.AsyncErrataUtils.associate_builds_with_cves", autospec=True)
-    def test_associate_builds_with_cves(self, fake_urils_associate_builds_with_cves: AsyncMock):
+    def test_associate_builds_with_cves_bz(self, fake_urils_associate_builds_with_cves: AsyncMock):
         errata_api = AsyncMock(spec=AsyncErrataAPI)
         advisory = Mock(
             errata_id=12345,
@@ -86,16 +86,16 @@ class TestAttachCVEFlawsCLI(unittest.TestCase):
             5: [102],
         }
         attached_tracker_bugs = [
-            Mock(spec=Bug, id=1, keywords=["Security", "SecurityTracking"], whiteboard="component: a"),
-            Mock(spec=Bug, id=2, keywords=["Security", "SecurityTracking"], whiteboard="component: b"),
-            Mock(spec=Bug, id=3, keywords=["Security", "SecurityTracking"], whiteboard="component: c"),
-            Mock(spec=Bug, id=4, keywords=["Security", "SecurityTracking"], whiteboard="component: d"),
-            Mock(spec=Bug, id=5, keywords=["Security", "SecurityTracking"], whiteboard="component: e"),
+            BugzillaBug(Mock(id=1, keywords=["Security", "SecurityTracking"], whiteboard="component: a")),
+            BugzillaBug(Mock(id=2, keywords=["Security", "SecurityTracking"], whiteboard="component: b")),
+            BugzillaBug(Mock(id=3, keywords=["Security", "SecurityTracking"], whiteboard="component: c")),
+            BugzillaBug(Mock(id=4, keywords=["Security", "SecurityTracking"], whiteboard="component: d")),
+            BugzillaBug(Mock(id=5, keywords=["Security", "SecurityTracking"], whiteboard="component: e")),
         ]
         flaw_id_bugs = {
-            101: Mock(spec=Bug, id=101, keywords=["Security"], alias=["CVE-2099-1"]),
-            102: Mock(spec=Bug, id=102, keywords=["Security"], alias=["CVE-2099-2"]),
-            103: Mock(spec=Bug, id=103, keywords=["Security"], alias=["CVE-2099-3"]),
+            101: BugzillaBug(Mock(id=101, keywords=["Security"], alias=["CVE-2099-1"])),
+            102: BugzillaBug(Mock(id=102, keywords=["Security"], alias=["CVE-2099-2"])),
+            103: BugzillaBug(Mock(id=103, keywords=["Security"], alias=["CVE-2099-3"])),
         }
         actual = get_event_loop().run_until_complete(attach_cve_flaws_cli.associate_builds_with_cves(errata_api, advisory, attached_tracker_bugs, tracker_flaws, flaw_id_bugs, dry_run=False))
         fake_urils_associate_builds_with_cves.assert_awaited_once_with(errata_api, 12345, ['a-1.0.0-1.el8', 'b-1.0.0-1.el8', 'c-1.0.0-1.el8', 'd-1.0.0-1.el8', 'a-1.0.0-1.el7', 'e-1.0.0-1.el7', 'f-1.0.0-1.el7'], {'CVE-2099-1': {'a', 'd', 'b'}, 'CVE-2099-3': {'a', 'd', 'b', 'c'}, 'CVE-2099-2': {'c', 'e'}}, dry_run=False)


### PR DESCRIPTION
Test jira flaw bug with custom flaw label: https://issues.redhat.com/browse/OCPBUGS-8

Test:
`USEJIRA=true ./elliott -g openshift-4.8 attach-cve-flaws -a 96435 --noop`

Right now jira issues are removed when updating an advisory through errata-tool
https://coreos.slack.com/archives/GDBRP5YJH/p1658947821887479
Fix https://github.com/red-hat-storage/errata-tool/pull/231 
I would want to continue with this PR and address this in a follow up PR