### PR TITLE
Sweep TALM && BMER Bugs

### DIFF
--- a/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliottlib/cli/find_bugs_sweep_cli.py
@@ -264,11 +264,16 @@ def extras_bugs(bugs: type_bug_list) -> type_bug_list:
         "Logging",
         "Service Brokers",
         "Metering Operator",
-        "Node Feature Discovery Operator"
+        "Node Feature Discovery Operator",
+        "Cloud Native Events",
+        "Telco Edge",
     }  # we will probably find more
     extras_subcomponents = {
         ("Networking", "SR-IOV"),
         ("Storage", "Local Storage Operator"),
+        ("Cloud Native Events", "Hardware Event Proxy"),
+        ("Cloud Native Events", "Hardware Event Proxy Operator"),
+        ("Telco Edge", "TALO"),
     }
     extra_bugs = set()
     for bug in bugs:


### PR DESCRIPTION
With the addition of new images on 4.10 (ART-4052, ART-4074, ART-4075, and ART-4076) we also need to sweep their corresponding bugs into advisories.