### PR TITLE
Halt if rpm CVEs don't have corresponding build

### DIFF
--- a/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliottlib/cli/find_bugs_sweep_cli.py
@@ -248,6 +248,7 @@ def categorize_bugs_by_type(bugs: List, rpm_advisory_id: Optional[int] = None, m
                                "no corresponding brew builds were found attached to the rpm advisory. "
                                "First attach builds and then rerun to attach the bugs")
                     click.echo(not_found)
+                    raise ValueError(f'No build found for CVE (bug, package) tuples: {not_found}')
             else:
                 click.echo("Skipping attaching RPM CVEs. Use --check-builds flag to validate with builds.")
 


### PR DESCRIPTION
Throw an error when there are CVE tracker bugs that cannot get attached
because the component that they are about is not getting shipped.

Currently an event like this will go unnoticed, as the log is not
scrutinized.

The can be bypassed by either fixing the issue, or by exclkuding the
relevant bugs from the assembly:

`releases.<name>.issues.exclude: [1234]`