### PR TITLE
Fix wrong function call on asyncio

### DIFF
--- a/elliottlib/cli/common.py
+++ b/elliottlib/cli/common.py
@@ -108,5 +108,5 @@ def click_coroutine(f):
     https://github.com/pallets/click/issues/85
     """
     def wrapper(*args, **kwargs):
-        return asyncio.run(f(*args, **kwargs))
+        return asyncio.get_event_loop().run_until_complete(f(*args, **kwargs))
     return update_wrapper(wrapper, f)


### PR DESCRIPTION
```
Python 3.6.15

>>> import asyncio

>>> async def hello():
...   print("Hello")

>>> asyncio.run(hello())
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'asyncio' has no attribute 'run'

>>> asyncio.get_event_loop().run_until_complete(hello())
Hello
```