### PR TITLE
Fix another wrong function call to asyncio

### DIFF
--- a/elliottlib/cli/attach_cve_flaws_cli.py
+++ b/elliottlib/cli/attach_cve_flaws_cli.py
@@ -63,8 +63,8 @@ async def attach_cve_flaws_cli(runtime: Runtime, advisory_id: int, noop: bool, d
     tasks = []
     for bug_tracker in runtime.bug_trackers.values():
         flaw_bug_tracker = runtime.bug_trackers['bugzilla'] if bug_tracker.type == 'jira' else None
-        tasks.append(asyncio.create_task(get_flaws(runtime, advisory, bug_tracker,
-                                                   flaw_bug_tracker, noop)))
+        tasks.append(asyncio.get_event_loop().create_task(get_flaws(runtime, advisory, bug_tracker,
+                                                          flaw_bug_tracker, noop)))
     try:
         lists_of_flaw_bugs = await asyncio.gather(*tasks)
         flaw_bugs = list(set(sum(lists_of_flaw_bugs, [])))


### PR DESCRIPTION
```
Python 3.6.15

>>> import asyncio

>>> async def hello():
...   print("Hello")

>>> asyncio.create_task(hello())
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'asyncio' has no attribute 'create_task'

>>> asyncio.get_event_loop().create_task(hello())
<Task pending coro=<hello() running at <stdin>:1>>

```