### PR TITLE
Fix bug when flaw_bug_tracker is None (on attach_cve_flaws)

### DIFF
--- a/elliottlib/cli/attach_cve_flaws_cli.py
+++ b/elliottlib/cli/attach_cve_flaws_cli.py
@@ -98,7 +98,8 @@ async def get_flaws(runtime, advisory, bug_tracker, flaw_bug_tracker, noop):
         flaw_bug_tracker,
         strict=True
     )
-    runtime.logger.info(f'Found {len(flaw_id_bugs)} {flaw_bug_tracker.type} corresponding flaw bugs:'
+    flaw_bug_tracker_type = flaw_bug_tracker.type if hasattr(flaw_bug_tracker, 'type') else ''
+    runtime.logger.info(f'Found {len(flaw_id_bugs)} {flaw_bug_tracker_type} corresponding flaw bugs:'
                         f' {sorted(flaw_id_bugs.keys())}')
 
     # current_target_release is digit.digit.[z|0]


### PR DESCRIPTION
```
Python 3.6.15

>>> flaw_bug_tracker = None

>>> flaw_bug_tracker.type
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'NoneType' object has no attribute 'type'

>>> flaw_bug_tracker.type if hasattr(flaw_bug_tracker, 'type') else ''
''

```