### PR TITLE
Fix requirments.txt and CI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ click == 8.0.4
 contextvars; python_version < '3.7'
 # errata-tool >= 1.27.1
 # Instead use errata-tool commit with fix
-git+ssh://git@github.com/red-hat-storage/errata-tool.git@a24cf5228be8f32a2f937be183fa1caaeca3cd5b
+errata-tool @ git+http://github.com/red-hat-storage/errata-tool.git@a24cf5228be8f32a2f937be183fa1caaeca3cd5b
 future
 koji >= 1.18
 semver


### PR DESCRIPTION
Fix
```
error in rh-elliott setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; Parse error at "'+ssh://g'": Expected stringEnd

```