### PR TITLE
Allow change-state to work with different states

### DIFF
--- a/elliottlib/cli/change_state_cli.py
+++ b/elliottlib/cli/change_state_cli.py
@@ -1,21 +1,12 @@
-
-from elliottlib import logutil, Runtime
+from elliottlib import logutil
 from elliottlib.cli.common import cli, use_default_advisory_option, find_default_advisory
-from elliottlib.exceptions import ElliottFatalError
-from elliottlib.util import green_prefix, red_prefix
-
+from elliottlib.util import green_prefix
 from errata_tool import Erratum, ErrataException
 import click
 
 LOGGER = logutil.getLogger(__name__)
 
-pass_runtime = click.make_pass_decorator(Runtime)
 
-
-#
-# Set advisory state
-# change-state
-#
 @cli.command("change-state", short_help="Change ADVISORY state")
 @click.option("--state", '-s', required=True,
               type=click.Choice(['NEW_FILES', 'QE', 'REL_PREP']),
@@ -30,7 +21,7 @@ pass_runtime = click.make_pass_decorator(Runtime)
               is_flag=True,
               default=False,
               help="Do not actually change anything")
-@pass_runtime
+@click.pass_obj
 def change_state_cli(runtime, state, advisory, default_advisories, default_advisory_type, noop):
     """Change the state of an ADVISORY. Additional permissions may be
 required to change an advisory to certain states.
@@ -91,18 +82,6 @@ Bugs.
             if e.errata_state == state:
                 green_prefix(f"No Change ({advisory}): ")
                 click.echo(f"Target state is same as current state: {state}")
-            # we have 5 different states we can only change the state if it's in NEW_FILES or QE
-            # "NEW_FILES",
-            # "QE",
-            # "REL_PREP",
-            # "PUSH_READY",
-            # "IN_PUSH"
-            elif e.errata_state != 'NEW_FILES' and e.errata_state != 'QE':
-                red_prefix(f"Error ({advisory}): ")
-                if default_advisory_type is not None:
-                    click.echo(f"Could not change '{e.errata_state}', group.yml is probably pointing at old one")
-                else:
-                    click.echo(f"Can only change the state if it's in NEW_FILES or QE, current state is {e.errata_state}")
             else:
                 if noop:
                     green_prefix(f"NOOP ({advisory}): ")

--- a/elliottlib/cli/change_state_cli.py
+++ b/elliottlib/cli/change_state_cli.py
@@ -1,10 +1,7 @@
-from elliottlib import logutil
 from elliottlib.cli.common import cli, use_default_advisory_option, find_default_advisory
 from elliottlib.util import green_prefix
 from errata_tool import Erratum, ErrataException
 import click
-
-LOGGER = logutil.getLogger(__name__)
 
 
 @cli.command("change-state", short_help="Change ADVISORY state")
@@ -33,16 +30,9 @@ unless Bugzilla Bugs or JIRA Issues have been attached.
     NOTE: The two advisory options are mutually exclusive and can not
     be used together.
 
-See the find-bugs help for additional information on adding
-Bugs.
-
     Move assembly release advisories to QE
 
     $ elliott -g openshift-4.10 --assembly 4.10.4 change-state -s QE
-
-    Move group release advisories to QE:
-
-    $ elliott -g openshift-4.5 change-state -s QE --default-advisories
 
     Move the advisory 123456 to QE:
 
@@ -52,8 +42,7 @@ Bugs.
 
     $ elliott change-state -s NEW_FILES -a 123456
 
-    Do not actually change state, just check that the command could
-    have ran (for example, when testing out pipelines)
+    Do not actually change state, just check the command could run
 
     $ elliott change-state -s NEW_FILES -a 123456 --noop
 """

--- a/elliottlib/errata.py
+++ b/elliottlib/errata.py
@@ -578,7 +578,9 @@ def add_bugzilla_bugs_with_retry(advisory_id: int, bugids: List, noop: bool = Fa
 
     existing_bugs = bzutil.BugzillaBugTracker.advisory_bug_ids(advisory)
     new_bugs = set(bugids) - set(existing_bugs)
-    logger.info(f'Bugs already attached: {len(existing_bugs)}. New bugs: {len(new_bugs)}')
+    logger.info(f'New bugs (not already attached to advisory): {len(new_bugs)}')
+    logger.debug(f'New bugs: {sorted(new_bugs)}')
+    logger.debug(f'Bugs already attached: {sorted(set(bugids) & set(existing_bugs))}')
     if not new_bugs:
         return
 
@@ -624,7 +626,9 @@ def add_jira_bugs_with_retry(advisory_id: int, bugids: List[str], noop: bool = F
 
     existing_bugs = bzutil.JIRABugTracker.advisory_bug_ids(advisory)
     new_bugs = set(bugids) - set(existing_bugs)
-    logger.info(f'Bugs already attached: {len(existing_bugs)}. New bugs: {len(new_bugs)}')
+    logger.info(f'New bugs (not already attached to advisory): {len(new_bugs)}')
+    logger.debug(f'New bugs: {sorted(new_bugs)}')
+    logger.debug(f'Bugs already attached: {sorted(set(bugids) & set(existing_bugs))}')
     if not new_bugs:
         return
     for chunk_of_bugs in chunk(bugids, batch_size):


### PR DESCRIPTION
change-state should allow to change states from REL_PREP and back
Since release artists are not the only one using elliott
This will allow members of exd, rcm also use elliott