### PR TITLE
attach-cve-flaws can accept bug ids to validate

### DIFF
--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -84,7 +84,7 @@ class Bug:
         :param bugs: List[Bug] instance
         """
         invalid_bugs = []
-        target_releases = set()
+        target_releases_bugs_dict = {}
 
         if not bugs:
             raise ValueError("bugs should be a non empty list")
@@ -96,7 +96,10 @@ class Bug:
             if not valid_target_rel:
                 invalid_bugs.append(bug)
             else:
-                target_releases.add(bug.target_release[0])
+                tr = bug.target_release[0]
+                if tr not in target_releases_bugs_dict:
+                    target_releases_bugs_dict[tr] = []
+                target_releases_bugs_dict[tr].append(bug.id)
 
         if invalid_bugs:
             err = 'target_release should be a list with a string matching regex (digit+.digit+.[0|z])'
@@ -104,12 +107,14 @@ class Bug:
                 err += f'\n bug: {b.id}, target_release: {b.target_release} '
             raise ValueError(err)
 
-        if len(target_releases) != 1:
-            err = f'Found different target_release values for bugs: {target_releases}. ' \
-                'There should be only 1 target release for all bugs. Fix the offending bug(s) and try again.'
+        trs = list(target_releases_bugs_dict.keys())
+        if len(trs) != 1:
+            err = f'Found different target_release values for bugs: {trs}. ' \
+                  'There should be only 1 target release for all bugs. Fix the offending bug(s) and try again :' \
+                  f'{target_releases_bugs_dict}'
             raise ValueError(err)
 
-        return target_releases.pop()
+        return trs[0]
 
 
 class BugzillaBug(Bug):

--- a/elliottlib/cli/attach_cve_flaws_cli.py
+++ b/elliottlib/cli/attach_cve_flaws_cli.py
@@ -21,7 +21,8 @@ from elliottlib.bzutil import Bug, get_highest_security_impact, is_first_fix_any
               type=int,
               help='Find tracker bugs in given advisory')
 @click.option('--id', default=None, multiple=True,
-              help='For the given list of bugs, determine which flaw bugs would qualify to be attached (for testing)')
+              help='For the given list of bugs, determine which flaw bugs would qualify to be attached (for testing)'
+                   'This is a noop.')
 @click.option("--noop", "--dry-run",
               required=False,
               default=False, is_flag=True,

--- a/elliottlib/cli/attach_cve_flaws_cli.py
+++ b/elliottlib/cli/attach_cve_flaws_cli.py
@@ -64,19 +64,23 @@ async def attach_cve_flaws_cli(runtime: Runtime, advisory_id: int, id: str, noop
     elif advisory_id:
         advisories = [advisory_id]
 
+    if id:
+        if runtime.only_jira or runtime.use_jira:
+            bug_tracker = runtime.bug_trackers['jira']
+            bug_ids = cli_opts.id_convert_str(id)
+        else:
+            bug_tracker = runtime.bug_trackers['bugzilla']
+            bug_ids = cli_opts.id_convert(id)
+        flaw_bug_tracker = runtime.bug_trackers['bugzilla']
+        await get_flaws(runtime, None, bug_ids,
+                        bug_tracker, flaw_bug_tracker, noop)
+        return
+
     # Flaw bugs associated with jira tracker bugs
     # exist in bugzilla. so to work with jira trackers
     # we need both bugzilla and jira instances initialized
     if runtime.only_jira:
         runtime.use_jira = True
-
-    if id:
-        bug_tracker = runtime.bug_trackers['jira']
-        flaw_bug_tracker = runtime.bug_trackers['bugzilla']
-        bug_ids = cli_opts.id_convert_str(id)
-        await get_flaws(runtime, None, bug_ids,
-                        bug_tracker, flaw_bug_tracker, noop)
-        return
 
     exit_code = 0
     for advisory_id in advisories:

--- a/elliottlib/cli/repair_bugs_cli.py
+++ b/elliottlib/cli/repair_bugs_cli.py
@@ -22,7 +22,7 @@ pass_runtime = click.make_pass_decorator(Runtime)
               help="AUTO mode, check all bugs attached to ADVISORY")
 @click.option("--id", default=None, metavar='BUGID',
               multiple=True, required=False,
-              help="Bugzilla IDs to modify, conflicts with --auto [MULTIPLE]")
+              help="Bug IDs to modify, conflicts with --auto [MULTIPLE]")
 @click.option("--from", "original_state",
               multiple=True,
               default=['MODIFIED'],


### PR DESCRIPTION
This allows us to run attach-cve-flaws before <release day / advisories are created> and discover associated issues beforehand
- `elliott -g=openshift-4.11 --stream=assembly find-bugs:sweep` and then feeding the bug ids to
- `elliott -g=openshift-4.11 --stream=assembly attach-cve-flaws --id "bug_string"`

attach-cve-flaws performs several validations which would be convenient to know to be good before release day
when we perform promotion.

Possibly we can put this flow in check-bugs job to report on issues before release day

Superceded by https://github.com/openshift/elliott/pull/419