### PR TITLE
Make use_jira default true

### DIFF
--- a/elliottlib/cli/attach_bugs_cli.py
+++ b/elliottlib/cli/attach_bugs_cli.py
@@ -66,10 +66,10 @@ For attaching use --advisory, --use-default-advisory <TYPE>
     if default_advisory_type is not None:
         advisory = find_default_advisory(runtime, default_advisory_type)
 
-    if runtime.use_jira or runtime.only_jira:
-        bug_tracker = runtime.bug_trackers['jira']
+    if runtime.use_jira:
+        bug_tracker = runtime.bug_trackers('jira')
     else:
-        bug_tracker = runtime.bug_trackers['bugzilla']
+        bug_tracker = runtime.bug_trackers('bugzilla')
     bug_ids = bug_tracker.id_convert(bug_ids)
     attach_bugs(runtime, advisory, bug_ids, report, output, noop, bug_tracker)
 

--- a/elliottlib/cli/attach_cve_flaws_cli.py
+++ b/elliottlib/cli/attach_cve_flaws_cli.py
@@ -57,28 +57,21 @@ async def attach_cve_flaws_cli(runtime: Runtime, advisory_id: int, noop: bool, d
     else:
         advisories = [advisory_id]
 
-    # Flaw bugs associated with jira tracker bugs
-    # exist in bugzilla. so to work with jira trackers
-    # we need both bugzilla and jira instances initialized
-    if runtime.only_jira:
-        runtime.use_jira = True
-
     exit_code = 0
+    flaw_bug_tracker = runtime.bug_trackers('bugzilla')
     for advisory_id in advisories:
         runtime.logger.info("Getting advisory %s", advisory_id)
         advisory = Erratum(errata_id=advisory_id)
 
         tasks = []
-        for bug_tracker in runtime.bug_trackers.values():
-            flaw_bug_tracker = runtime.bug_trackers['bugzilla']
+        for bug_tracker in [runtime.bug_trackers('jira'), runtime.bug_trackers('bugzilla')]:
             tasks.append(asyncio.get_event_loop().create_task(get_flaws(runtime, advisory, bug_tracker,
                                                               flaw_bug_tracker, noop)))
         try:
             lists_of_flaw_bugs = await asyncio.gather(*tasks)
             flaw_bugs = list(set(sum(lists_of_flaw_bugs, [])))
             if flaw_bugs:
-                bug_tracker = runtime.bug_trackers['bugzilla']
-                _update_advisory(runtime, advisory, flaw_bugs, bug_tracker, noop)
+                _update_advisory(runtime, advisory, flaw_bugs, flaw_bug_tracker, noop)
         except Exception as e:
             runtime.logger.error(traceback.format_exc())
             runtime.logger.error(f'Exception: {e}')

--- a/elliottlib/cli/create_placeholder_cli.py
+++ b/elliottlib/cli/create_placeholder_cli.py
@@ -46,11 +46,7 @@ def create_placeholder_cli(runtime, kind, advisory_id, default_advisory_type, no
     if not kind:
         raise click.BadParameter("--kind must be specified when not using --use-default-advisory")
 
-    # Creating bug in bugzilla has been disabled
-    # we should use jira only
-    runtime.only_jira = True
-    bug_trackers = runtime.bug_trackers
-    create_placeholder(kind, advisory_id, bug_trackers['jira'], noop)
+    create_placeholder(kind, advisory_id, runtime.bug_trackers('jira'), noop)
 
 
 def create_placeholder(kind, advisory_id, bug_tracker, noop):

--- a/elliottlib/cli/create_textonly_cli.py
+++ b/elliottlib/cli/create_textonly_cli.py
@@ -65,16 +65,15 @@ def create_textonly_cli(runtime, errata_type, date, assigned_to, manager, packag
     """
 
     runtime.initialize()
-    bug_trackers = runtime.bug_trackers
     # we want to create only one advisory regardless of multiple bug trackers being used
     # we give priority to jira in case both are in use
-    if runtime.use_jira or runtime.only_jira:
+    if runtime.use_jira:
         create_textonly(runtime, errata_type, date, assigned_to, manager, package_owner, topic, synopsis,
-                        description, solution, bugtitle, bugdescription, yes, bug_trackers['jira'])
+                        description, solution, bugtitle, bugdescription, yes, runtime.bug_trackers('jira'))
 
     else:
         create_textonly(runtime, errata_type, date, assigned_to, manager, package_owner, topic, synopsis,
-                        description, solution, bugtitle, bugdescription, yes, bug_trackers['bugzilla'])
+                        description, solution, bugtitle, bugdescription, yes, runtime.bug_trackers('bugzilla'))
 
 
 def create_textonly(runtime, errata_type, date, assigned_to, manager, package_owner, topic, synopsis, description,

--- a/elliottlib/cli/find_bugs_blocker_cli.py
+++ b/elliottlib/cli/find_bugs_blocker_cli.py
@@ -60,7 +60,7 @@ Use --exclude_status to filter out from default status list.
     find_bugs_obj.include_status(include_status)
     find_bugs_obj.exclude_status(exclude_status)
     exit_code = 0
-    for b in runtime.bug_trackers.values():
+    for b in [runtime.bug_trackers('jira'), runtime.bug_trackers('bugzilla')]:
         try:
             find_bugs_blocker(runtime, output, find_bugs_obj, b)
         except Exception as e:

--- a/elliottlib/cli/find_bugs_qe_cli.py
+++ b/elliottlib/cli/find_bugs_qe_cli.py
@@ -34,7 +34,7 @@ def find_bugs_qe_cli(runtime: Runtime, noop):
     runtime.initialize()
     find_bugs_obj = FindBugsQE()
     exit_code = 0
-    for b in runtime.bug_trackers.values():
+    for b in [runtime.bug_trackers('jira'), runtime.bug_trackers('bugzilla')]:
         try:
             find_bugs_qe(runtime, find_bugs_obj, noop, b)
         except Exception as e:

--- a/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliottlib/cli/find_bugs_sweep_cli.py
@@ -121,7 +121,7 @@ advisory with the --add option.
     find_bugs_obj.exclude_status(exclude_status)
 
     exit_code = 0
-    for b in runtime.bug_trackers.values():
+    for b in [runtime.bug_trackers('jira'), runtime.bug_trackers('bugzilla')]:
         try:
             find_bugs_sweep(runtime, advisory_id, default_advisory_type, check_builds, major_version, find_bugs_obj,
                             report, output, brew_event, noop, count_advisory_attach_flags, b)
@@ -172,6 +172,9 @@ def find_bugs_sweep(runtime: Runtime, advisory_id, default_advisory_type, check_
     if output == 'text':
         green_prefix(f"Found {len(bugs)} bugs: ")
         click.echo(", ".join(sorted(str(b.id) for b in bugs)))
+
+    if not bugs:
+        return
 
     if report:
         print_report(bugs, output)

--- a/elliottlib/cli/remove_bugs_cli.py
+++ b/elliottlib/cli/remove_bugs_cli.py
@@ -59,7 +59,7 @@ def remove_bugs_cli(runtime, advisory_id, default_advisory_type, bug_ids, remove
         for b in [runtime.bug_trackers('jira'), runtime.bug_trackers('bugzilla')]:
             remove_bugs(advisory_id, bug_ids, remove_all, b, noop)
     else:
-        if runtime.use_jira or runtime.only_jira:
+        if runtime.use_jira:
             bug_tracker = runtime.bug_trackers('jira')
         else:
             bug_tracker = runtime.bug_trackers('bugzilla')

--- a/elliottlib/cli/remove_bugs_cli.py
+++ b/elliottlib/cli/remove_bugs_cli.py
@@ -55,12 +55,13 @@ def remove_bugs_cli(runtime, advisory_id, default_advisory_type, bug_ids, remove
     if default_advisory_type is not None:
         advisory_id = find_default_advisory(runtime, default_advisory_type)
 
-    if runtime.use_jira or runtime.only_jira:
-        bug_tracker = runtime.bug_trackers['jira']
-    else:
-        bug_tracker = runtime.bug_trackers['bugzilla']
-    bug_ids = bug_tracker.id_convert(bug_ids)
-    remove_bugs(advisory_id, bug_ids, remove_all, bug_tracker, noop)
+    if not remove_all and runtime.use_jira:
+        runtime.use_jira = False
+        runtime.only_jira = True
+
+    for b in runtime.bug_trackers.values():
+        bug_ids = b.id_convert(bug_ids)
+        remove_bugs(advisory_id, bug_ids, remove_all, b, noop)
 
 
 def remove_bugs(advisory_id, bug_ids, remove_all, bug_tracker, noop):

--- a/elliottlib/cli/remove_bugs_cli.py
+++ b/elliottlib/cli/remove_bugs_cli.py
@@ -55,16 +55,19 @@ def remove_bugs_cli(runtime, advisory_id, default_advisory_type, bug_ids, remove
     if default_advisory_type is not None:
         advisory_id = find_default_advisory(runtime, default_advisory_type)
 
-    if not remove_all and runtime.use_jira:
-        runtime.use_jira = False
-        runtime.only_jira = True
-
-    for b in runtime.bug_trackers.values():
-        bug_ids = b.id_convert(bug_ids)
-        remove_bugs(advisory_id, bug_ids, remove_all, b, noop)
+    if remove_all:
+        for b in [runtime.bug_trackers('jira'), runtime.bug_trackers('bugzilla')]:
+            remove_bugs(advisory_id, bug_ids, remove_all, b, noop)
+    else:
+        if runtime.use_jira or runtime.only_jira:
+            bug_tracker = runtime.bug_trackers('jira')
+        else:
+            bug_tracker = runtime.bug_trackers('bugzilla')
+        remove_bugs(advisory_id, bug_ids, remove_all, bug_tracker, noop)
 
 
 def remove_bugs(advisory_id, bug_ids, remove_all, bug_tracker, noop):
+    bug_ids = bug_tracker.id_convert(bug_ids)
     try:
         advisory = errata.Advisory(errata_id=advisory_id)
     except GSSError:
@@ -79,13 +82,13 @@ def remove_bugs(advisory_id, bug_ids, remove_all, bug_tracker, noop):
             bug_ids = [b for b in bug_ids if b in attached_bug_ids]
         else:
             bug_ids = attached_bug_ids
-        green_prefix(f"Found {len(bug_ids)} bugs attached to advisory: ")
+        green_prefix(f"Found {len(bug_ids)} {bug_tracker.type} bugs attached to advisory: ")
         click.echo(f"{bug_ids}")
 
         if not bug_ids:
             return
 
-        green_prefix(f"Removing bugs from advisory {advisory_id}..")
+        green_prefix(f"Removing {bug_tracker.type} bugs from advisory {advisory_id}..")
         bug_tracker.remove_bugs(advisory, bug_ids, noop)
     except ErrataException as ex:
         raise ElliottFatalError(getattr(ex, 'message', repr(ex)))

--- a/elliottlib/cli/repair_bugs_cli.py
+++ b/elliottlib/cli/repair_bugs_cli.py
@@ -99,13 +99,17 @@ providing an advisory with the -a/--advisory option.
         raise click.BadParameter("No input provided: Must use one of --id, --advisory, or --use-default-advisory")
 
     runtime.initialize()
-    if not auto and runtime.use_jira:
-        runtime.use_jira = False
-        runtime.only_jira = True
-
-    for b in runtime.bug_trackers.values():
+    if auto:
+        for b in [runtime.bug_trackers('jira'), runtime.bug_trackers('bugzilla')]:
+            repair_bugs(runtime, advisory, auto, id, original_state, new_state, comment, close_placeholder, noop,
+                        default_advisory_type, b)
+    else:
+        if runtime.use_jira:
+            bug_tracker = runtime.bug_trackers('jira')
+        else:
+            bug_tracker = runtime.bug_trackers('bugzilla')
         repair_bugs(runtime, advisory, auto, id, original_state, new_state, comment, close_placeholder, noop,
-                    default_advisory_type, b)
+                    default_advisory_type, bug_tracker)
 
 
 def repair_bugs(runtime, advisory, auto, id, original_state, new_state, comment, close_placeholder, noop,

--- a/elliottlib/runtime.py
+++ b/elliottlib/runtime.py
@@ -282,15 +282,15 @@ class Runtime(object):
     def rpm_metas(self):
         return list(self.rpm_map.values())
 
-    @property
-    def bug_trackers(self):
-        if self._bug_trackers:
-            return self._bug_trackers
-        if not self.only_jira:
-            self._bug_trackers['bugzilla'] = BugzillaBugTracker(BugzillaBugTracker.get_config(self))
-        if self.use_jira or self.only_jira:
-            self._bug_trackers['jira'] = JIRABugTracker(JIRABugTracker.get_config(self))
-        return self._bug_trackers
+    def bug_trackers(self, bug_tracker_type):
+        if bug_tracker_type in self._bug_trackers:
+            return self._bug_trackers[bug_tracker_type]
+        if bug_tracker_type == 'bugzilla':
+            bug_tracker_cls = BugzillaBugTracker
+        elif bug_tracker_type == 'jira':
+            bug_tracker_cls = JIRABugTracker
+        self._bug_trackers[bug_tracker_type] = bug_tracker_cls(bug_tracker_cls.get_config(self))
+        return self._bug_trackers[bug_tracker_type]
 
     @property
     def remove_tmp_working_dir(self):

--- a/elliottlib/runtime.py
+++ b/elliottlib/runtime.py
@@ -51,8 +51,14 @@ class Runtime(object):
         self.verbose = False
         self.quiet = False
         self.data_path = None
-        self.use_jira = os.environ.get('USEJIRA')
-        self.only_jira = os.environ.get('ONLYJIRA')
+        self.use_jira = True
+        if str(os.environ.get('USEJIRA')).lower() in ["false", "0"]:
+            self.use_jira = False
+        if str(os.environ.get('ONLYJIRA')).lower() in ["false", "0"]:
+            self.only_jira = False
+        else:
+            self.only_jira = bool(os.environ.get('ONLYJIRA'))
+
         self._bug_trackers = {}
         self.brew_event: Optional[int] = None
         self.assembly: Optional[str] = 'stream'

--- a/elliottlib/runtime.py
+++ b/elliottlib/runtime.py
@@ -54,11 +54,6 @@ class Runtime(object):
         self.use_jira = True
         if str(os.environ.get('USEJIRA')).lower() in ["false", "0"]:
             self.use_jira = False
-        if str(os.environ.get('ONLYJIRA')).lower() in ["false", "0"]:
-            self.only_jira = False
-        else:
-            self.only_jira = bool(os.environ.get('ONLYJIRA'))
-
         self._bug_trackers = {}
         self.brew_event: Optional[int] = None
         self.assembly: Optional[str] = 'stream'

--- a/tests/test_find_bugs_blocker_cli.py
+++ b/tests/test_find_bugs_blocker_cli.py
@@ -1,43 +1,47 @@
 import unittest
-import os
-from mock import patch
+import traceback
 from click.testing import CliRunner
 import elliottlib.cli.find_bugs_blocker_cli
 from elliottlib.cli.common import cli, Runtime
-from elliottlib.bzutil import BugzillaBugTracker
+from elliottlib.bzutil import BugzillaBugTracker, JIRABugTracker
 from flexmock import flexmock
 
 
 class FindBugsBlockerTestCase(unittest.TestCase):
-    @patch.dict(os.environ, {"USEJIRA": "False"})
     def test_find_bugs_blocker(self):
         # mock init
         runner = CliRunner()
         flexmock(Runtime).should_receive("initialize").and_return(None)
         flexmock(BugzillaBugTracker).should_receive("get_config").and_return({'target_release': ['4.6.z']})
         flexmock(BugzillaBugTracker).should_receive("login").and_return(None)
+        flexmock(JIRABugTracker).should_receive("get_config").and_return({'target_release': ['4.6.z']})
+        flexmock(JIRABugTracker).should_receive("login").and_return(None)
 
-        bugs = [
-            flexmock(
-                id='BZ1',
-                created_days_ago=lambda: 33,
-                cf_pm_score='score',
-                component='OLM',
-                status='ON_DEV',
-                summary='summary'
-            )
-        ]
+        bz_bug = flexmock(
+            id=1, created_days_ago=lambda: 33,
+            cf_pm_score='score', component='OLM',
+            status='ON_DEV', summary='summary'
+        )
 
-        flexmock(BugzillaBugTracker).should_receive("blocker_search")\
-            .with_args({'NEW', 'ASSIGNED', 'POST', 'MODIFIED', 'ON_DEV', 'RELEASE_PENDING'}, verbose=False)\
-            .and_return(bugs)
+        jira_bug = flexmock(
+            id='OCPBUGS-1', created_days_ago=lambda: 34,
+            cf_pm_score='score', component='OLM',
+            status='ON_QA', summary='summary'
+        )
 
-        result = runner.invoke(cli, ['-g', 'openshift-4.6', 'find-bugs:blocker', '--exclude-status=ON_QA',
-                                     '--include-status=RELEASE_PENDING'])
+        flexmock(JIRABugTracker).should_receive("blocker_search").and_return([jira_bug])
+        flexmock(BugzillaBugTracker).should_receive("blocker_search").and_return([bz_bug])
+        result = runner.invoke(cli, ['-g', 'openshift-4.6', 'find-bugs:blocker'])
 
-        expected_output = 'BZ1           OLM                       ON_DEV       score   33  days   summary'
+        bz_output = '1             OLM                       ON_DEV       score   33  days   summary'
+        jira_output = 'OCPBUGS-1     OLM                       ON_QA        score   34  days   summary'
+        if result.exit_code != 0:
+            exc_type, exc_value, exc_traceback = result.exc_info
+            t = "\n".join(traceback.format_exception(exc_type, exc_value, exc_traceback))
+            self.fail(t)
         self.assertEqual(result.exit_code, 0)
-        self.assertIn(expected_output, result.output)
+        self.assertIn(bz_output, result.output)
+        self.assertIn(jira_output, result.output)
 
 
 if __name__ == '__main__':

--- a/tests/test_find_bugs_blocker_cli.py
+++ b/tests/test_find_bugs_blocker_cli.py
@@ -1,4 +1,6 @@
 import unittest
+import os
+from mock import patch
 from click.testing import CliRunner
 import elliottlib.cli.find_bugs_blocker_cli
 from elliottlib.cli.common import cli, Runtime
@@ -7,6 +9,7 @@ from flexmock import flexmock
 
 
 class FindBugsBlockerTestCase(unittest.TestCase):
+    @patch.dict(os.environ, {"USEJIRA": "False"})
     def test_find_bugs_blocker(self):
         # mock init
         runner = CliRunner()

--- a/tests/test_find_bugs_qe_cli.py
+++ b/tests/test_find_bugs_qe_cli.py
@@ -9,6 +9,7 @@ from flexmock import flexmock
 
 
 class FindBugsQETestCase(unittest.TestCase):
+    @patch.dict(os.environ, {"USEJIRA": "False"})
     def test_find_bugs_qe_bz(self):
         runner = CliRunner()
         bug = flexmock(id=123, status="MODIFIED")
@@ -30,7 +31,6 @@ class FindBugsQETestCase(unittest.TestCase):
         self.assertIn(search_string1, result.output)
         self.assertEqual(result.exit_code, 0)
 
-    @patch.dict(os.environ, {"USEJIRA": "True"})
     def test_find_bugs_qe_jira(self):
         runner = CliRunner()
         jira_bug = flexmock(id='OCPBUGS-123', status="MODIFIED")

--- a/tests/test_find_bugs_qe_cli.py
+++ b/tests/test_find_bugs_qe_cli.py
@@ -9,29 +9,7 @@ from flexmock import flexmock
 
 
 class FindBugsQETestCase(unittest.TestCase):
-    @patch.dict(os.environ, {"USEJIRA": "False"})
-    def test_find_bugs_qe_bz(self):
-        runner = CliRunner()
-        bug = flexmock(id=123, status="MODIFIED")
-        bugs = [bug]
-        flexmock(Runtime).should_receive("initialize").and_return(None)
-        flexmock(Runtime).should_receive("get_major_minor").and_return(4, 6)
-        flexmock(BugzillaBugTracker).should_receive("get_config").and_return({
-            'target_release': ['4.6.z'], 'server': "bugzilla.redhat.com"
-        })
-        flexmock(BugzillaBugTracker).should_receive("login").and_return(None)
-        flexmock(FindBugsQE).should_receive("search").and_return(bugs)
-        expected_comment = 'This bug is expected to ship in the next 4.6 release.'
-        flexmock(BugzillaBugTracker).should_receive("update_bug_status").with_args(
-            bug, 'ON_QA', comment=expected_comment, noop=True
-        )
-
-        result = runner.invoke(cli, ['-g', 'openshift-4.6', 'find-bugs:qe', '--noop'])
-        search_string1 = 'Found 1 bugs: 123'
-        self.assertIn(search_string1, result.output)
-        self.assertEqual(result.exit_code, 0)
-
-    def test_find_bugs_qe_jira(self):
+    def test_find_bugs_qe(self):
         runner = CliRunner()
         jira_bug = flexmock(id='OCPBUGS-123', status="MODIFIED")
         bz_bug = flexmock(id='BZ-123', status="MODIFIED")

--- a/tests/test_find_bugs_sweep_cli.py
+++ b/tests/test_find_bugs_sweep_cli.py
@@ -147,7 +147,6 @@ class FindBugsSweepTestCase(unittest.TestCase):
             t = "\n".join(traceback.format_exception(exc_type, exc_value, exc_traceback))
             self.fail(t)
 
-    @patch.dict(os.environ, {"USEJIRA": "False"})
     def test_find_bugs_sweep_advisory_type(self):
         runner = CliRunner()
         bugs = [flexmock(id='BZ1')]
@@ -158,6 +157,11 @@ class FindBugsSweepTestCase(unittest.TestCase):
         flexmock(sweep_cli).should_receive("get_assembly_bug_ids").and_return(set(), set())
         flexmock(sweep_cli).should_receive("categorize_bugs_by_type").and_return({"image": set(bugs)})
         flexmock(common).should_receive("find_default_advisory").and_return(123)
+
+        # jira mocks
+        flexmock(JIRABugTracker).should_receive("get_config").and_return({'target_release': ['4.6.z']})
+        flexmock(JIRABugTracker).should_receive("login")
+        flexmock(JIRABugTracker).should_receive("search").and_return([])
 
         # bz mocks
         flexmock(BugzillaBugTracker).should_receive("get_config").and_return({'target_release': ['4.6.z']})
@@ -171,7 +175,6 @@ class FindBugsSweepTestCase(unittest.TestCase):
             t = "\n".join(traceback.format_exception(exc_type, exc_value, exc_traceback))
             self.fail(t)
 
-    @patch.dict(os.environ, {"USEJIRA": "False"})
     def test_find_bugs_sweep_default_advisories(self):
         runner = CliRunner()
         image_bugs = [flexmock(id=1), flexmock(id=2)]
@@ -194,6 +197,11 @@ class FindBugsSweepTestCase(unittest.TestCase):
         flexmock(BugzillaBugTracker).should_receive("login")
         flexmock(BugzillaBugTracker).should_receive("search").and_return(image_bugs + rpm_bugs + extras_bugs)
         flexmock(BugzillaBugTracker).should_receive("attach_bugs").times(3)
+
+        # jira mocks
+        flexmock(JIRABugTracker).should_receive("get_config").and_return({'target_release': ['4.6.z']})
+        flexmock(JIRABugTracker).should_receive("login")
+        flexmock(JIRABugTracker).should_receive("search").and_return([])
 
         result = runner.invoke(cli, ['-g', 'openshift-4.6', 'find-bugs:sweep', '--into-default-advisories'])
         if result.exit_code != 0:

--- a/tests/test_find_bugs_sweep_cli.py
+++ b/tests/test_find_bugs_sweep_cli.py
@@ -34,7 +34,6 @@ class TestFindBugsMode(unittest.TestCase):
 
 
 class FindBugsSweepTestCase(unittest.TestCase):
-    @patch.dict(os.environ, {"USEJIRA": "True"})
     def test_find_bugs_sweep_report(self):
         runner = CliRunner()
         flexmock(Runtime).should_receive("initialize").and_return(None)
@@ -89,7 +88,6 @@ class FindBugsSweepTestCase(unittest.TestCase):
         self.assertIn(search_string1, result.output)
         self.assertIn(search_string2, result.output)
 
-    @patch.dict(os.environ, {"USEJIRA": "True"})
     def test_find_bugs_sweep_brew_event(self):
         runner = CliRunner()
         bugs = [flexmock(id='BZ1', status='ON_QA')]
@@ -119,7 +117,6 @@ class FindBugsSweepTestCase(unittest.TestCase):
             t = "\n".join(traceback.format_exception(exc_type, exc_value, exc_traceback))
             self.fail(t)
 
-    @patch.dict(os.environ, {"USEJIRA": "True"})
     def test_find_bugs_sweep_advisory_jira(self):
         runner = CliRunner()
         bugs = [flexmock(id='BZ1')]
@@ -150,6 +147,7 @@ class FindBugsSweepTestCase(unittest.TestCase):
             t = "\n".join(traceback.format_exception(exc_type, exc_value, exc_traceback))
             self.fail(t)
 
+    @patch.dict(os.environ, {"USEJIRA": "False"})
     def test_find_bugs_sweep_advisory_type(self):
         runner = CliRunner()
         bugs = [flexmock(id='BZ1')]
@@ -173,6 +171,7 @@ class FindBugsSweepTestCase(unittest.TestCase):
             t = "\n".join(traceback.format_exception(exc_type, exc_value, exc_traceback))
             self.fail(t)
 
+    @patch.dict(os.environ, {"USEJIRA": "False"})
     def test_find_bugs_sweep_default_advisories(self):
         runner = CliRunner()
         image_bugs = [flexmock(id=1), flexmock(id=2)]

--- a/tests/test_remove_bugs_cli.py
+++ b/tests/test_remove_bugs_cli.py
@@ -11,6 +11,7 @@ from flexmock import flexmock
 
 
 class RemoveBugsTestCase(unittest.TestCase):
+    @patch.dict(os.environ, {"USEJIRA": "False"})
     def test_remove_bugzilla_bug(self):
         runner = CliRunner()
 
@@ -29,7 +30,6 @@ class RemoveBugsTestCase(unittest.TestCase):
         self.assertIn("Found 2 bugs", result.output)
         self.assertIn("Removing bugs from advisory 99999", result.output)
 
-    @patch.dict(os.environ, {"ONLYJIRA": "True"})
     def test_remove_jira_bug(self):
         runner = CliRunner()
 
@@ -45,6 +45,7 @@ class RemoveBugsTestCase(unittest.TestCase):
         self.assertIn("Removing bugs from advisory 99999", result.output)
         self.assertEqual(result.exit_code, 0)
 
+    @patch.dict(os.environ, {"USEJIRA": "False"})
     def test_remove_all_bugzilla(self):
         runner = CliRunner()
 

--- a/tests/test_remove_bugs_cli.py
+++ b/tests/test_remove_bugs_cli.py
@@ -27,8 +27,8 @@ class RemoveBugsTestCase(unittest.TestCase):
             exc_type, exc_value, exc_traceback = result.exc_info
             t = "\n".join(traceback.format_exception(exc_type, exc_value, exc_traceback))
             self.fail(t)
-        self.assertIn("Found 2 bugs", result.output)
-        self.assertIn("Removing bugs from advisory 99999", result.output)
+        self.assertIn("Found 2 bugzilla bugs", result.output)
+        self.assertIn("Removing bugzilla bugs from advisory 99999", result.output)
 
     def test_remove_jira_bug(self):
         runner = CliRunner()
@@ -41,29 +41,34 @@ class RemoveBugsTestCase(unittest.TestCase):
         flexmock(JIRABugTracker).should_receive("remove_bugs").with_args(advisory, ['OCPBUGS-3', 'OCPBUGS-4'], False)
 
         result = runner.invoke(cli, ['-g', 'openshift-4.6', 'remove-bugs', 'OCPBUGS-3', 'OCPBUGS-4', '-a', '99999'])
-        self.assertIn("Found 2 bugs", result.output)
-        self.assertIn("Removing bugs from advisory 99999", result.output)
+        self.assertIn("Found 2 jira bugs", result.output)
+        self.assertIn("Removing jira bugs from advisory 99999", result.output)
         self.assertEqual(result.exit_code, 0)
 
-    @patch.dict(os.environ, {"USEJIRA": "False"})
-    def test_remove_all_bugzilla(self):
+    def test_remove_all_bugs(self):
         runner = CliRunner()
 
         flexmock(Runtime).should_receive("initialize")
         flexmock(BugzillaBugTracker).should_receive("get_config").and_return({'target_release': ['4.6.z']})
         flexmock(BugzillaBugTracker).should_receive("login")
-        advisory = flexmock(errata_bugs=[1, 2, 3])
+        flexmock(JIRABugTracker).should_receive("get_config").and_return({'target_release': ['4.6.z']})
+        flexmock(JIRABugTracker).should_receive("login")
+        bz_bug_ids = [1, 2, 3]
+        jira_bug_ids = ["OCPBUGS-1", "OCPBUGS-2"]
+        advisory = flexmock(errata_id='99999',errata_bugs=bz_bug_ids, jira_issues=jira_bug_ids)
         flexmock(errata).should_receive("Advisory").and_return(advisory)
-        flexmock(BugzillaBugTracker).should_receive("remove_bugs").with_args(advisory, [1, 2, 3], False)
+        flexmock(BugzillaBugTracker).should_receive("remove_bugs").with_args(advisory, bz_bug_ids, False)
+        flexmock(JIRABugTracker).should_receive("remove_bugs").with_args(advisory, jira_bug_ids, False)
 
-        result = runner.invoke(cli, ['-g', 'openshift-4.6', 'remove-bugs', '--all', '-a', '99999'])
+        result = runner.invoke(cli, ['-g', 'openshift-4.6', 'remove-bugs', '--all', '-a', advisory.errata_id])
         if result.exit_code != 0:
             exc_type, exc_value, exc_traceback = result.exc_info
             t = "\n".join(traceback.format_exception(exc_type, exc_value, exc_traceback))
             self.fail(t)
-        self.assertIn("Found 3 bugs", result.output)
-        self.assertIn("Removing bugs from advisory 99999", result.output)
-
+        self.assertIn(f"Found {len(jira_bug_ids)} jira bugs", result.output)
+        self.assertIn(f"Found {len(bz_bug_ids)} bugzilla bugs", result.output)
+        self.assertIn(f"Removing bugzilla bugs from advisory {advisory.errata_id}", result.output)
+        self.assertIn(f"Removing jira bugs from advisory {advisory.errata_id}", result.output)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_remove_bugs_cli.py
+++ b/tests/test_remove_bugs_cli.py
@@ -55,7 +55,7 @@ class RemoveBugsTestCase(unittest.TestCase):
         flexmock(JIRABugTracker).should_receive("login")
         bz_bug_ids = [1, 2, 3]
         jira_bug_ids = ["OCPBUGS-1", "OCPBUGS-2"]
-        advisory = flexmock(errata_id='99999',errata_bugs=bz_bug_ids, jira_issues=jira_bug_ids)
+        advisory = flexmock(errata_id='99999', errata_bugs=bz_bug_ids, jira_issues=jira_bug_ids)
         flexmock(errata).should_receive("Advisory").and_return(advisory)
         flexmock(BugzillaBugTracker).should_receive("remove_bugs").with_args(advisory, bz_bug_ids, False)
         flexmock(JIRABugTracker).should_receive("remove_bugs").with_args(advisory, jira_bug_ids, False)
@@ -69,6 +69,7 @@ class RemoveBugsTestCase(unittest.TestCase):
         self.assertIn(f"Found {len(bz_bug_ids)} bugzilla bugs", result.output)
         self.assertIn(f"Removing bugzilla bugs from advisory {advisory.errata_id}", result.output)
         self.assertIn(f"Removing jira bugs from advisory {advisory.errata_id}", result.output)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_repair_bugs_cli.py
+++ b/tests/test_repair_bugs_cli.py
@@ -10,6 +10,7 @@ from flexmock import flexmock
 
 
 class RepairBugsTestCase(unittest.TestCase):
+    @patch.dict(os.environ, {"USEJIRA": "False"})
     def test_repair_bugzilla_bug_id(self):
         runner = CliRunner()
         bug = flexmock(id=1, status="MODIFIED", summary="")
@@ -22,7 +23,6 @@ class RepairBugsTestCase(unittest.TestCase):
         self.assertIn("1 bugs successfully modified", result.output)
         self.assertEqual(result.exit_code, 0)
 
-    @patch.dict(os.environ, {"USEJIRA": "True"})
     def test_repair_jira_bug_id(self):
         runner = CliRunner()
         bug = flexmock(id=1, status="MODIFIED", summary="")
@@ -35,7 +35,6 @@ class RepairBugsTestCase(unittest.TestCase):
         self.assertIn("1 bugs successfully modified", result.output)
         self.assertEqual(result.exit_code, 0)
 
-    @patch.dict(os.environ, {"USEJIRA": "True"})
     def test_repair_placeholder_jira_bug(self):
         runner = CliRunner()
         bug = flexmock(id=1, status="MODIFIED", summary="Placeholder")
@@ -48,6 +47,7 @@ class RepairBugsTestCase(unittest.TestCase):
         self.assertIn("1 bugs successfully modified", result.output)
         self.assertEqual(result.exit_code, 0)
 
+    @patch.dict(os.environ, {"USEJIRA": "False"})
     def test_repair_bugzilla_bug_with_comment(self):
         runner = CliRunner()
         bug = flexmock(id=1, status="MODIFIED", summary="")
@@ -61,7 +61,6 @@ class RepairBugsTestCase(unittest.TestCase):
         self.assertIn("1 bugs successfully modified", result.output)
         self.assertEqual(result.exit_code, 0)
 
-    @patch.dict(os.environ, {"USEJIRA": "True"})
     def test_repair_auto(self):
         runner = CliRunner()
         bug = flexmock(id=1, status="MODIFIED", summary="")


### PR DESCRIPTION
Make usejira=True by default, so when we run elliott with no arguments/env vars
we will be using jira and bugzilla both by default in find commands (find-bugs and attach-cve-flaws)

Deprecate `ONLYJIRA` since it's creating confusion due to some commands only being able to run
in both bugzilla and jira mode, so supporting this is not guaranteed.

For commands which accept bug ids (attach-bugs, remove-bugs, repair-bugs, verify-bugs)
- To use Bugzilla ids with them `USEJIRA=0` or `USEJIRA=False`
