### PR TITLE
exclude placeholder bug in bug sweep and fix RHSA check

### DIFF
--- a/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliottlib/cli/find_bugs_sweep_cli.py
@@ -168,7 +168,9 @@ def find_bugs_sweep(runtime: Runtime, advisory_id, default_advisory_type, check_
         yellow_print("The following bugs will be excluded because they are explicitly "
                      f"defined in the assembly config: {excluded_bug_ids}")
         bugs = [bug for bug in bugs if bug.id not in excluded_bug_ids]
-
+    # exclude placeholder bug
+    click.echo("Filtering bugs that is Placeholder bug...")
+    bugs = [bug for bug in bugs if "Placeholder" not in bug.summary]
     if output == 'text':
         green_prefix(f"Found {len(bugs)} bugs: ")
         click.echo(", ".join(sorted(str(b.id) for b in bugs)))

--- a/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliottlib/cli/verify_attached_bugs_cli.py
@@ -241,7 +241,10 @@ class BugValidator:
 
     def filter_bugs_by_product(self, bugs):
         # filter out bugs for different product (presumably security flaw bugs)
-        return [b for b in bugs if b.product == self.product]
+        if self.use_jira:
+            return [b for b in bugs if b.product == self.bz_product or b.product == self.jira_product]
+        else:
+            return [b for b in bugs if b.product == self.bz_product]
 
     def filter_bugs_by_release(self, bugs: Iterable[Bug], complain: bool = False) -> List[Bug]:
         # filter out bugs with an invalid target release

--- a/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliottlib/cli/verify_attached_bugs_cli.py
@@ -272,9 +272,9 @@ class BugValidator:
             bug.id: bug
             for bug in self.bz_tracker.get_bugs(list({b for deps in [b.depends_on for b in bz_bugs if b.depends_on] for b in deps}))
             # b.target release is a list of size 0 or 1
-            if any(minor_version_tuple(target) == next_version for target in bug.target_release 
-                if pattern.match(target) and bug.product == self.bz_product)
-        }
+            if any(minor_version_tuple(target) == next_version for target in bug.target_release
+            if pattern.match(target) and bug.product == self.bz_product)
+            }
         if self.use_jira:
             blocking_jira_bugs = {
                 bug.id: bug

--- a/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliottlib/cli/verify_attached_bugs_cli.py
@@ -272,9 +272,8 @@ class BugValidator:
             bug.id: bug
             for bug in self.bz_tracker.get_bugs(list({b for deps in [b.depends_on for b in bz_bugs if b.depends_on] for b in deps}))
             # b.target release is a list of size 0 or 1
-            if any(minor_version_tuple(target) == next_version for target in bug.target_release
-            if pattern.match(target) and bug.product == self.bz_product)
-            }
+            if any(minor_version_tuple(target) == next_version for target in bug.target_release if pattern.match(target) and bug.product == self.bz_product)
+        }
         if self.use_jira:
             blocking_jira_bugs = {
                 bug.id: bug

--- a/tests/test_find_bugs_sweep_cli.py
+++ b/tests/test_find_bugs_sweep_cli.py
@@ -122,7 +122,7 @@ class FindBugsSweepTestCase(unittest.TestCase):
     @patch.dict(os.environ, {"USEJIRA": "True"})
     def test_find_bugs_sweep_advisory_jira(self):
         runner = CliRunner()
-        bugs = [flexmock(id='BZ1')]
+        bugs = [flexmock(id='BZ1', summary='bug')]
         advisory_id = 123
 
         # common mocks
@@ -152,7 +152,7 @@ class FindBugsSweepTestCase(unittest.TestCase):
 
     def test_find_bugs_sweep_advisory_type(self):
         runner = CliRunner()
-        bugs = [flexmock(id='BZ1')]
+        bugs = [flexmock(id='BZ1', summary='bug')]
 
         # common mocks
         flexmock(Runtime).should_receive("initialize")
@@ -175,9 +175,9 @@ class FindBugsSweepTestCase(unittest.TestCase):
 
     def test_find_bugs_sweep_default_advisories(self):
         runner = CliRunner()
-        image_bugs = [flexmock(id=1), flexmock(id=2)]
-        rpm_bugs = [flexmock(id=3), flexmock(id=4)]
-        extras_bugs = [flexmock(id=5), flexmock(id=6)]
+        image_bugs = [flexmock(id=1, summary='bug'), flexmock(id=2, summary='bug')]
+        rpm_bugs = [flexmock(id=3, summary='bug'), flexmock(id=4, summary='bug')]
+        extras_bugs = [flexmock(id=5, summary='bug'), flexmock(id=6, summary='bug')]
 
         # common mocks
         flexmock(Runtime).should_receive("initialize").and_return(None)

--- a/tests/test_verify_attached_bugs_cli.py
+++ b/tests/test_verify_attached_bugs_cli.py
@@ -11,10 +11,8 @@ import asyncio
 
 def async_test(f):
     def wrapper(*args, **kwargs):
-        coro = asyncio.coroutine(f)
-        future = coro(*args, **kwargs)
         loop = asyncio.get_event_loop()
-        loop.run_until_complete(future)
+        loop.run_until_complete(f(*args, **kwargs))
     return wrapper
 
 

--- a/tests/test_verify_attached_bugs_cli.py
+++ b/tests/test_verify_attached_bugs_cli.py
@@ -1,7 +1,7 @@
 import unittest
 from click.testing import CliRunner
 from elliottlib.cli.common import cli, Runtime
-from elliottlib.cli.verify_attached_bugs_cli import BugValidator, verify_bugs_cli
+from elliottlib.cli.verify_attached_bugs_cli import BugValidator
 from elliottlib.errata_async import AsyncErrataAPI
 from elliottlib import errata
 from elliottlib.bzutil import JIRABugTracker, BugzillaBugTracker
@@ -37,6 +37,9 @@ class VerifyAttachedBugs(unittest.TestCase):
         flexmock(JIRABugTracker).should_receive("get_config").and_return({'project': 'OCPBUGS', 'target_release': [
             '4.6.z']})
         flexmock(JIRABugTracker).should_receive("login")
+        flexmock(BugzillaBugTracker).should_receive("get_config").and_return({'product': 'OCPBUGS', 'target_release': [
+            '4.6.z']})
+        flexmock(BugzillaBugTracker).should_receive("login")
 
         bugs = [
             flexmock(id="OCPBUGS-1", product='OCPBUGS', target_release=['4.6.z'], depends_on=['OCPBUGS-4'],
@@ -65,6 +68,7 @@ class TestGetAttachedBugs(unittest.TestCase):
             'bug-1': flexmock(id='bug-1'),
             'bug-2': flexmock(id='bug-2'),
         }
+
         async def get_ad():
             return {'bugs': {'bugs': []}, 'content': {'content': {'errata_id': '12345'}}}
 


### PR DESCRIPTION
validate two types of bugs together, if not usejira the related bug list would be empty, so when checking ET type it can compute result together
```
elliott --assembly 4.10.28 --group=openshift-4.10 verify-attached-bugs --verify-flaws
2022-08-24 09:46:28,861 INFO Cloning config data from https://github.com/openshift/ocp-build-data.git
2022-08-24 09:46:30,627 INFO Using branch from group.yml: rhaos-4.10-rhel-8
2022-08-24 09:46:30,627 WARNING Constraining brew event to assembly basis for 4.10.28: 46763830
Retrieving bugs for advisory [100251, 100250, 100252, 100249]
Verify blocking bugs for 2112995 Passed
Verify blocking bugs for 2104454 Passed
Verify blocking bugs for 2100369 Passed
Verify blocking bugs for 2110963 Passed
Verify blocking bugs for 2115267 Passed
Verify blocking bugs for 2117369 Passed
Verify blocking bugs for 2114833 Passed
Verify blocking bugs for 2106794 Passed
Verify blocking bugs for 2112815 Passed
Verify blocking bugs for 2102386 Passed
Verify blocking bugs for 2108176 Passed
Verify blocking bugs for 2111335 Passed
Verify blocking bugs for 2117346 Passed
Verify blocking bugs for 2109518 Passed
Verify blocking bugs for 2116545 Passed
Verify blocking bugs for 2101412 Passed
Verify blocking bugs for 2116401 Passed
All bugs were verified. This check doesn't cover CVE flaw bugs.
All CVE flaw bugs were verified.
```