### PR TITLE
Commands can recognize different bugids

### DIFF
--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -31,6 +31,13 @@ def datetime_now():
     return datetime.now(timezone.utc)
 
 
+def get_jira_bz_bug_ids(bug_ids):
+    ids = cli_opts.id_convert_str(bug_ids)
+    jira_ids = {b for b in ids if JIRABug.looks_like_a_jira_bug(b)}
+    bz_ids = {int(b) for b in ids if not JIRABug.looks_like_a_jira_bug(b)}
+    return jira_ids, bz_ids
+
+
 class Bug:
     def __init__(self, bug_obj):
         self.bug = bug_obj

--- a/elliottlib/cli/attach_bugs_cli.py
+++ b/elliottlib/cli/attach_bugs_cli.py
@@ -1,8 +1,7 @@
 import click
 
 from elliottlib import Runtime, logutil
-from elliottlib.bzutil import Bug
-from elliottlib.cli import cli_opts
+from elliottlib.bzutil import Bug, get_jira_bz_bug_ids
 from elliottlib.cli.common import cli, find_default_advisory, use_default_advisory_option
 from elliottlib.cli.find_bugs_sweep_cli import print_report
 
@@ -31,20 +30,14 @@ LOGGER = logutil.getLogger(__name__)
               help="Don't change anything")
 @click.pass_obj
 def attach_bugs_cli(runtime: Runtime, advisory, default_advisory_type, bug_ids, report, output, noop):
-    """Attach OCP Bugs to ADVISORY
+    """Attach Openshift Bugs (JIRA or Bugzilla) to ADVISORY
 Print bug details with --report
-For attaching use --advisory, --use-default-advisory <TYPE>
+For attaching use --advisory or --use-default-advisory <TYPE>
 
     Print bug report (no attach)
 
 \b
-    $ elliott -g openshift-4.10 attach-bugs 8675309 7001337 --report
-
-
-    Print bug report for jira bugs (no attach)
-
-\b
-    $ USEJIRA=true elliott -g openshift-4.10 attach-bugs OCPBUGS-10 OCPBUGS-9 --report
+    $ elliott -g openshift-4.10 attach-bugs OCPBUGS-1 8675309 7001337 --report
 
 
     Attach bugs to the advisory 123456
@@ -66,12 +59,11 @@ For attaching use --advisory, --use-default-advisory <TYPE>
     if default_advisory_type is not None:
         advisory = find_default_advisory(runtime, default_advisory_type)
 
-    if runtime.use_jira:
-        bug_tracker = runtime.bug_trackers('jira')
-    else:
-        bug_tracker = runtime.bug_trackers('bugzilla')
-    bug_ids = bug_tracker.id_convert(bug_ids)
-    attach_bugs(runtime, advisory, bug_ids, report, output, noop, bug_tracker)
+    jira_ids, bz_ids = get_jira_bz_bug_ids(bug_ids)
+    if jira_ids:
+        attach_bugs(runtime, advisory, jira_ids, report, output, noop, runtime.bug_trackers('jira'))
+    if bz_ids:
+        attach_bugs(runtime, advisory, bz_ids, report, output, noop, runtime.bug_trackers('bugzilla'))
 
 
 def attach_bugs(runtime, advisory, bug_ids, report, output, noop, bug_tracker):

--- a/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliottlib/cli/verify_attached_bugs_cli.py
@@ -1,9 +1,7 @@
 import asyncio
 import re
 from typing import Any, Dict, Iterable, List, Set, Tuple
-
 import click
-from bugzilla.bug import Bug
 from spnego.exceptions import GSSError
 
 

--- a/tests/test_remove_bugs_cli.py
+++ b/tests/test_remove_bugs_cli.py
@@ -1,7 +1,4 @@
 import unittest
-import os
-import traceback
-from mock import patch
 from click.testing import CliRunner
 from elliottlib import errata
 from elliottlib.cli.common import cli, Runtime
@@ -11,48 +8,34 @@ from flexmock import flexmock
 
 
 class RemoveBugsTestCase(unittest.TestCase):
-    @patch.dict(os.environ, {"USEJIRA": "False"})
-    def test_remove_bugzilla_bug(self):
+    def test_remove_bugs(self):
         runner = CliRunner()
-
         flexmock(Runtime).should_receive("initialize")
         flexmock(BugzillaBugTracker).should_receive("get_config").and_return({'target_release': ['4.6.z']})
         flexmock(BugzillaBugTracker).should_receive("login")
-        advisory = flexmock(errata_bugs=[1, 2, 3])
-        flexmock(errata).should_receive("Advisory").and_return(advisory)
-        flexmock(BugzillaBugTracker).should_receive("remove_bugs").with_args(advisory, [1, 2], False)
-
-        result = runner.invoke(cli, ['-g', 'openshift-4.6', 'remove-bugs', '1', '2', '-a', '99999'])
-        if result.exit_code != 0:
-            exc_type, exc_value, exc_traceback = result.exc_info
-            t = "\n".join(traceback.format_exception(exc_type, exc_value, exc_traceback))
-            self.fail(t)
-        self.assertIn("Found 2 bugzilla bugs", result.output)
-        self.assertIn("Removing bugzilla bugs from advisory 99999", result.output)
-
-    def test_remove_jira_bug(self):
-        runner = CliRunner()
-
-        flexmock(Runtime).should_receive("initialize")
         flexmock(JIRABugTracker).should_receive("get_config").and_return({'target_release': ['4.6.z']})
         flexmock(JIRABugTracker).should_receive("login")
-        advisory = flexmock(jira_issues=['OCPBUGS-3', 'OCPBUGS-4', 'OCPBUGS-5'])
-        flexmock(errata).should_receive("Advisory").and_return(advisory)
-        flexmock(JIRABugTracker).should_receive("remove_bugs").with_args(advisory, ['OCPBUGS-3', 'OCPBUGS-4'], False)
 
-        result = runner.invoke(cli, ['-g', 'openshift-4.6', 'remove-bugs', 'OCPBUGS-3', 'OCPBUGS-4', '-a', '99999'])
+        advisory = flexmock(errata_id='999', errata_bugs=[1, 2, 3], jira_issues=['OCPBUGS-3', 'OCPBUGS-4', 'OCPBUGS-5'])
+        flexmock(errata).should_receive("Advisory").and_return(advisory)
+        flexmock(JIRABugTracker).should_receive("remove_bugs").with_args(advisory, {'OCPBUGS-3', 'OCPBUGS-4'}, False)
+        flexmock(BugzillaBugTracker).should_receive("remove_bugs").with_args(advisory, {1, 2}, False)
+
+        result = runner.invoke(cli, ['-g', 'openshift-4.6', 'remove-bugs', '1', '2', 'OCPBUGS-3', 'OCPBUGS-4', '-a',
+                                     advisory.errata_id])
         self.assertIn("Found 2 jira bugs", result.output)
-        self.assertIn("Removing jira bugs from advisory 99999", result.output)
-        self.assertEqual(result.exit_code, 0)
+        self.assertIn(f"Removing jira bugs from advisory {advisory.errata_id}", result.output)
+        self.assertIn("Found 2 bugzilla bugs", result.output)
+        self.assertIn(f"Removing bugzilla bugs from advisory {advisory.errata_id}", result.output)
 
     def test_remove_all_bugs(self):
         runner = CliRunner()
-
         flexmock(Runtime).should_receive("initialize")
         flexmock(BugzillaBugTracker).should_receive("get_config").and_return({'target_release': ['4.6.z']})
         flexmock(BugzillaBugTracker).should_receive("login")
         flexmock(JIRABugTracker).should_receive("get_config").and_return({'target_release': ['4.6.z']})
         flexmock(JIRABugTracker).should_receive("login")
+
         bz_bug_ids = [1, 2, 3]
         jira_bug_ids = ["OCPBUGS-1", "OCPBUGS-2"]
         advisory = flexmock(errata_id='99999', errata_bugs=bz_bug_ids, jira_issues=jira_bug_ids)
@@ -61,10 +44,6 @@ class RemoveBugsTestCase(unittest.TestCase):
         flexmock(JIRABugTracker).should_receive("remove_bugs").with_args(advisory, jira_bug_ids, False)
 
         result = runner.invoke(cli, ['-g', 'openshift-4.6', 'remove-bugs', '--all', '-a', advisory.errata_id])
-        if result.exit_code != 0:
-            exc_type, exc_value, exc_traceback = result.exc_info
-            t = "\n".join(traceback.format_exception(exc_type, exc_value, exc_traceback))
-            self.fail(t)
         self.assertIn(f"Found {len(jira_bug_ids)} jira bugs", result.output)
         self.assertIn(f"Found {len(bz_bug_ids)} bugzilla bugs", result.output)
         self.assertIn(f"Removing bugzilla bugs from advisory {advisory.errata_id}", result.output)

--- a/tests/test_repair_bugs_cli.py
+++ b/tests/test_repair_bugs_cli.py
@@ -1,6 +1,5 @@
+import traceback
 import unittest
-import os
-from mock import patch
 from click.testing import CliRunner
 from elliottlib.cli.common import cli, Runtime
 import elliottlib.cli.repair_bugs_cli
@@ -10,44 +9,42 @@ from flexmock import flexmock
 
 
 class RepairBugsTestCase(unittest.TestCase):
-    @patch.dict(os.environ, {"USEJIRA": "False"})
-    def test_repair_bugzilla_bug_id(self):
+    def test_repair_bugs(self):
         runner = CliRunner()
-        bug = flexmock(id=1, status="MODIFIED", summary="")
+        bz_bug = flexmock(id=1, status="MODIFIED", summary="")
+        jira_bug = flexmock(id="OCPBUGS-1", status="MODIFIED", summary="")
         flexmock(Runtime).should_receive("initialize")
         flexmock(BugzillaBugTracker).should_receive("get_config").and_return({'target_release': ['4.6.z']})
         flexmock(BugzillaBugTracker).should_receive("login")
-        flexmock(BugzillaBugTracker).should_receive("get_bug").with_args(1).and_return(bug)
+        flexmock(BugzillaBugTracker).should_receive("get_bug").with_args(1).and_return(bz_bug)
         flexmock(BugzillaBugTracker).should_receive("update_bug_status").once()
-        result = runner.invoke(cli, ['-g', 'openshift-4.6', 'repair-bugs', '--id', '1', '--to', 'ON_QA', '-a', '99999'])
-        self.assertIn("1 bugs successfully modified", result.output)
-        self.assertEqual(result.exit_code, 0)
 
-    def test_repair_jira_bug_id(self):
-        runner = CliRunner()
-        bug = flexmock(id=1, status="MODIFIED", summary="")
-        flexmock(Runtime).should_receive("initialize")
         flexmock(JIRABugTracker).should_receive("get_config").and_return({'target_release': ['4.6.z']})
         flexmock(JIRABugTracker).should_receive("login")
-        flexmock(JIRABugTracker).should_receive("get_bug").with_args("1").and_return(bug)
+        flexmock(JIRABugTracker).should_receive("get_bug").with_args("OCPBUGS-1").and_return(jira_bug)
         flexmock(JIRABugTracker).should_receive("update_bug_status").once()
-        result = runner.invoke(cli, ['-g', 'openshift-4.6', 'repair-bugs', '--id', '1', '--to', 'ON_QA', '-a', '99999'])
-        self.assertIn("1 bugs successfully modified", result.output)
+
+        result = runner.invoke(cli, ['-g', 'openshift-4.6', 'repair-bugs', '--id', '1', '--id', 'OCPBUGS-1', '--to',
+                                     'ON_QA', '-a', '99999'])
         self.assertEqual(result.exit_code, 0)
 
     def test_repair_placeholder_jira_bug(self):
         runner = CliRunner()
-        bug = flexmock(id=1, status="MODIFIED", summary="Placeholder")
+        bug = flexmock(id="OCPBUGS-1", status="MODIFIED", summary="Placeholder")
         flexmock(Runtime).should_receive("initialize")
         flexmock(JIRABugTracker).should_receive("get_config").and_return({'target_release': ['4.6.z']})
         flexmock(JIRABugTracker).should_receive("login")
-        flexmock(JIRABugTracker).should_receive("get_bug").with_args("1").and_return(bug)
+        flexmock(JIRABugTracker).should_receive("get_bug").with_args("OCPBUGS-1").and_return(bug)
         flexmock(JIRABugTracker).should_receive("update_bug_status").once()
-        result = runner.invoke(cli, ['-g', 'openshift-4.6', 'repair-bugs', '--close-placeholder', '--id', '1', '--to', 'ON_QA', '-a', '99999'])
+        result = runner.invoke(cli, ['-g', 'openshift-4.6', 'repair-bugs', '--close-placeholder', '--id', 'OCPBUGS-1',
+                                     '--to', 'ON_QA', '-a', '99999'])
+        if result.exit_code != 0:
+            exc_type, exc_value, exc_traceback = result.exc_info
+            t = "\n".join(traceback.format_exception(exc_type, exc_value, exc_traceback))
+            self.fail(t)
         self.assertIn("1 bugs successfully modified", result.output)
         self.assertEqual(result.exit_code, 0)
 
-    @patch.dict(os.environ, {"USEJIRA": "False"})
     def test_repair_bugzilla_bug_with_comment(self):
         runner = CliRunner()
         bug = flexmock(id=1, status="MODIFIED", summary="")


### PR DESCRIPTION
This change is for elliott commands that accept bug_ids as argument. 
Right now we need usejira=True to tell elliott that we are passing in 
jira ids and usejira=False to tell those are bugzilla ids. With this change
we try to be smart and automatically recognize bug_ids into jira and bz
and run accordingly. If pattern matching on bugids fails we crash.

Note: verify-bugs needs a refactor and will need follow up work before
having this change in.

## Testing
- `make test`
- `elliott -g openshift-4.9 attach-bugs [OCPBUGS-1](https://issues.redhat.com//browse/OCPBUGS-1) 2053222 -a 100250 --noop`
- `elliott -g openshift-4.9 remove-bugs [OCPBUGS-1](https://issues.redhat.com//browse/OCPBUGS-1) 2053222 -a 100250 --noop`

