### PR TITLE
component can have multi item

### DIFF
--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -79,7 +79,7 @@ class Bug:
             if b.is_tracker_bug():
                 component_name = b.whiteboard_component
                 # filter out non-rpm suffixes
-                if component_name and not re.search(r'-(apb|container)', component_name):
+                if component_name and not re.search(r'-(apb|container)(,|$)', component_name):
                     rpm_cves[b] = component_name
         return rpm_cves
 

--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -79,7 +79,7 @@ class Bug:
             if b.is_tracker_bug():
                 component_name = b.whiteboard_component
                 # filter out non-rpm suffixes
-                if component_name and not re.search(r'-(apb|container)$', component_name):
+                if component_name and not re.search(r'-(apb|container)', component_name):
                     rpm_cves[b] = component_name
         return rpm_cves
 


### PR DESCRIPTION
in bug https://bugzilla.redhat.com/show_bug.cgi?id=2105528 component name is `component:elasticsearch-operator-container, log-storage` 
it will treat it as a rpm bug