### PR TITLE
Add jira trackers to get output

### DIFF
--- a/elliottlib/cli/__main__.py
+++ b/elliottlib/cli/__main__.py
@@ -156,6 +156,7 @@ Fields for the short format: Release date, State, Synopsys, URL
     json_data = advisory.get_erratum_data()
 
     json_data['bugs'] = advisory.errata_bugs
+    json_data['jira_issues'] = advisory.jira_issues
     json_data['current_flags'] = advisory.current_flags
     json_data['errata_builds'] = advisory.errata_builds
     json_data['rpmdiffs'] = advisory.externalTests(test_type='rpmdiff')


### PR DESCRIPTION
```console
$  elliott -q -g openshift-4.10 --assembly 4.10.31 get --use-default-advisory extras --json - | jq -r '[.bugs[], .jira_issues[]]'
[
  2091213,
  2102672,
  "OCPBUGS-502",
  "OCPBUGS-503"
]
```