### PR TITLE
verify-attached-bugs: add option to skip blocking bug check

### DIFF
--- a/.devcontainer/dev.Dockerfile
+++ b/.devcontainer/dev.Dockerfile
@@ -16,7 +16,7 @@ RUN dnf install -y \
     python38 python3-certifi \
     koji brewkoji \
     # development dependencies
-    gcc krb5-devel \
+    gcc gcc-c++ krb5-devel \
     python3-devel python3-pip python3-wheel python3-autopep8 \
     # other tools
     bash-completion vim tmux procps-ng psmisc wget curl net-tools iproute socat \
@@ -26,7 +26,7 @@ RUN dnf install -y \
   && ln -sfn /usr/bin/python3 /usr/bin/python
 
 
-ARG OC_VERSION=latest-4.12
+ARG OC_VERSION=latest
 RUN wget -O /tmp/openshift-client-linux-"$OC_VERSION".tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview/"$OC_VERSION"/openshift-client-linux.tar.gz \
   && tar -C /usr/local/bin -xzf  /tmp/openshift-client-linux-"$OC_VERSION".tar.gz oc kubectl \
   && rm /tmp/openshift-client-linux-"$OC_VERSION".tar.gz

--- a/.devcontainer/dev.Dockerfile
+++ b/.devcontainer/dev.Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:34
+FROM registry.fedoraproject.org/fedora:36
 LABEL name="elliott-dev" \
   description="Elliott development container image" \
   maintainer="OpenShift Automated Release Tooling (ART) Team <aos-team-art@redhat.com>"
@@ -13,7 +13,7 @@ RUN curl -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt --fail -L \
 RUN dnf install -y \
     # runtime dependencies
     krb5-workstation python-bugzilla-cli git \
-    python36 python3-certifi \
+    python38 python3-certifi \
     koji brewkoji \
     # development dependencies
     gcc krb5-devel \
@@ -26,8 +26,8 @@ RUN dnf install -y \
   && ln -sfn /usr/bin/python3 /usr/bin/python
 
 
-ARG OC_VERSION=latest
-RUN wget -O /tmp/openshift-client-linux-"$OC_VERSION".tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/"$OC_VERSION"/openshift-client-linux.tar.gz \
+ARG OC_VERSION=latest-4.12
+RUN wget -O /tmp/openshift-client-linux-"$OC_VERSION".tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview/"$OC_VERSION"/openshift-client-linux.tar.gz \
   && tar -C /usr/local/bin -xzf  /tmp/openshift-client-linux-"$OC_VERSION".tar.gz oc kubectl \
   && rm /tmp/openshift-client-linux-"$OC_VERSION".tar.gz
 

--- a/elliottlib/__init__.py
+++ b/elliottlib/__init__.py
@@ -2,8 +2,8 @@ import os
 import sys
 from setuptools_scm import get_version
 
-if sys.version_info < (3, 6):
-    sys.exit('Sorry, Python < 3.6 is not supported.')
+if sys.version_info < (3, 8):
+    sys.exit('Sorry, Python < 3.8 is no longer supported.')
 from .runtime import Runtime
 
 

--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -583,7 +583,8 @@ class JIRABugTracker(BugTracker):
     def _search(self, query, verbose=False) -> List[JIRABug]:
         if verbose:
             click.echo(query)
-        return [JIRABug(j) for j in self._client.search_issues(query, maxResults=False)]
+        results = self._client.search_issues(query, maxResults=0)
+        return [JIRABug(j) for j in results]
 
     def blocker_search(self, status, search_filter='default', verbose=False, **kwargs):
         query = self._query(

--- a/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliottlib/cli/verify_attached_bugs_cli.py
@@ -18,10 +18,11 @@ from elliottlib.bzutil import BugzillaBugTracker, JIRABugTracker, Bug, BugTracke
 @cli.command("verify-attached-bugs", short_help="Verify bugs in a release will not be regressed in the next version")
 @click.option("--verify-bug-status", is_flag=True, help="Check that bugs of advisories are all VERIFIED or more", type=bool, default=False)
 @click.option("--verify-flaws", is_flag=True, help="Check that flaw bugs are attached and associated with specific builds", type=bool, default=False)
+@click.option("--no-verify-blocking-bugs", is_flag=True, help="Don't check if there are open bugs for the next minor version blocking bugs for this minor version", type=bool, default=False)
 @click.argument("advisories", nargs=-1, type=click.IntRange(1), required=False)
 @pass_runtime
 @click_coroutine
-async def verify_attached_bugs_cli(runtime: Runtime, verify_bug_status: bool, advisories: Tuple[int, ...], verify_flaws: bool):
+async def verify_attached_bugs_cli(runtime: Runtime, verify_bug_status: bool, advisories: Tuple[int, ...], verify_flaws: bool, no_verify_blocking_bugs: bool):
     """
     Verify the bugs in the advisories (specified as arguments or in group.yml) for a release.
     Requires a runtime to ensure that all bugs in the advisories match the runtime version.
@@ -36,10 +37,10 @@ async def verify_attached_bugs_cli(runtime: Runtime, verify_bug_status: bool, ad
     if not advisories:
         red_print("No advisories specified on command line or in group.yml")
         exit(1)
-    await verify_attached_bugs(runtime, verify_bug_status, advisories, verify_flaws)
+    await verify_attached_bugs(runtime, verify_bug_status, advisories, verify_flaws, no_verify_blocking_bugs)
 
 
-async def verify_attached_bugs(runtime: Runtime, verify_bug_status: bool, advisories: Tuple[int, ...], verify_flaws: bool):
+async def verify_attached_bugs(runtime: Runtime, verify_bug_status: bool, advisories: Tuple[int, ...], verify_flaws: bool, no_verify_blocking_bugs: bool):
     validator = BugValidator(runtime, output="text")
     try:
         await validator.errata_api.login()
@@ -49,7 +50,7 @@ async def verify_attached_bugs(runtime: Runtime, verify_bug_status: bool, adviso
         # bug.is_ocp_bug() filters by product/project, so we don't get flaw bugs or bugs of other products
         non_flaw_bugs = {b for b in bugs if b.is_ocp_bug()}
 
-        validator.validate(non_flaw_bugs, verify_bug_status)
+        validator.validate(non_flaw_bugs, verify_bug_status, no_verify_blocking_bugs)
         if verify_flaws:
             await validator.verify_attached_flaws(advisory_bug_map)
     except GSSError:
@@ -60,6 +61,7 @@ async def verify_attached_bugs(runtime: Runtime, verify_bug_status: bool, adviso
 
 @cli.command("verify-bugs", short_help="Same as verify-attached-bugs, but for bugs that are not (yet) attached to advisories")
 @click.option("--verify-bug-status", is_flag=True, help="Check that bugs of advisories are all VERIFIED or more", type=bool, default=False)
+@click.option("--no-verify-blocking-bugs", is_flag=True, help="Don't check if there are open bugs for the next minor version blocking bugs for this minor version", type=bool, default=False)
 @click.option('--output', '-o',
               required=False,
               type=click.Choice(['text', 'json', 'slack']),
@@ -68,12 +70,12 @@ async def verify_attached_bugs(runtime: Runtime, verify_bug_status: bool, adviso
 @click.argument("bug_ids", nargs=-1, required=False)
 @pass_runtime
 @click_coroutine
-async def verify_bugs_cli(runtime, verify_bug_status, output, bug_ids):
+async def verify_bugs_cli(runtime, verify_bug_status, output, bug_ids, no_verify_blocking_bugs: bool):
     runtime.initialize()
-    await verify_bugs(runtime, verify_bug_status, output, bug_ids)
+    await verify_bugs(runtime, verify_bug_status, output, bug_ids, no_verify_blocking_bugs)
 
 
-async def verify_bugs(runtime, verify_bug_status, output, bug_ids):
+async def verify_bugs(runtime, verify_bug_status, output, bug_ids, no_verify_blocking_bugs: bool):
     validator = BugValidator(runtime, output)
     jira_ids, bz_ids = bzutil.get_jira_bz_bug_ids(bug_ids)
     bugs = []
@@ -90,7 +92,7 @@ async def verify_bugs(runtime, verify_bug_status, output, bug_ids):
     # bug.is_ocp_bug() filters by product/project, so we don't get flaw bugs or bugs of other products
     non_flaw_bugs = {b for b in bugs if b.is_ocp_bug()}
     try:
-        validator.validate(non_flaw_bugs, verify_bug_status)
+        validator.validate(non_flaw_bugs, verify_bug_status, no_verify_blocking_bugs)
     finally:
         await validator.close()
 
@@ -108,10 +110,12 @@ class BugValidator:
     async def close(self):
         await self.errata_api.close()
 
-    def validate(self, non_flaw_bugs: Iterable[Bug], verify_bug_status: bool):
+    def validate(self, non_flaw_bugs: Iterable[Bug], verify_bug_status: bool, no_verify_blocking_bugs: bool):
         non_flaw_bugs = self.filter_bugs_by_release(non_flaw_bugs, complain=True)
-        blocking_bugs_for = self._get_blocking_bugs_for(non_flaw_bugs)
-        self._verify_blocking_bugs(blocking_bugs_for)
+
+        if not no_verify_blocking_bugs:
+            blocking_bugs_for = self._get_blocking_bugs_for(non_flaw_bugs)
+            self._verify_blocking_bugs(blocking_bugs_for)
 
         if verify_bug_status:
             self._verify_bug_status(non_flaw_bugs)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,19 +1,19 @@
-pip~=20.3.3
-setuptools~=41.6.0
+pip>=20.3.3
+setuptools>=41.6.0
 
 -rrequirements.txt
 
 # test reqs
 flexmock
-mock~=4.0.3
+mock>=4.0.3
 
 # tox reqs
-coverage~=5.3
-flake8~=3.8.4
-tox~=3.20.1
+coverage>=5.3
+flake8>=3.8.4
+tox>=3.20.1
 
 # makefile reqs
-virtualenv~=20.2.2
-pytest~=6.2.1
-mypy~=0.812
+virtualenv>=20.2.2
+pytest>=6.2.1
+mypy>=0.812
 pylint

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
 aiohttp[speedups] >= 3.6
 click >= 8.1.3
 contextvars; python_version < '3.7'
-errata-tool >= 1.28.0
+# errata-tool >= 1.27.1
+# Instead use errata-tool commit with fix
+errata-tool @ git+http://github.com/thegreyd/errata-tool.git@bad2cb9c3321a1179f018cd9ddcf1d51d634290b
 future
 koji >= 1.18
 semver

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,7 @@
 aiohttp[speedups] >= 3.6
-click == 8.0.4
+click >= 8.1.3
 contextvars; python_version < '3.7'
-# errata-tool >= 1.27.1
-# Instead use errata-tool commit with fix
-errata-tool @ git+http://github.com/thegreyd/errata-tool.git@bad2cb9c3321a1179f018cd9ddcf1d51d634290b
+errata-tool >= 1.28.0
 future
 koji >= 1.18
 semver
@@ -14,7 +12,6 @@ pyyaml
 requests
 requests_kerberos >= 0.13
 ruamel.yaml
-typing ; python_version <= '3.4'
 tenacity
-jira
+jira ~= 3.2.0  # Pin 3.2.0 until https://github.com/pycontribs/jira/issues/1486 is resolved.
 setuptools-scm


### PR DESCRIPTION
Blocking bug check is not needed if the next minor version is GA'd.
Adding an option `--no-verify-blocking-bugs` to skip blocking check. This option will be used by
pyartcd.

Also bumps some dependencies and updates dev container Dockerfile for
python 3.8.