### PR TITLE
Improve handling of CVE associations

### DIFF
--- a/elliottlib/cli/attach_cve_flaws_cli.py
+++ b/elliottlib/cli/attach_cve_flaws_cli.py
@@ -123,17 +123,14 @@ async def get_flaws(runtime, advisory, bug_tracker, flaw_bug_tracker, noop):
     runtime.logger.info('Associating CVEs with builds')
     errata_config = runtime.get_errata_config()
     errata_api = AsyncErrataAPI(errata_config.get("server", constants.errata_url))
-    association_errors = []
     try:
         await errata_api.login()
         await associate_builds_with_cves(errata_api, advisory, attached_tracker_bugs, tracker_flaws, flaw_id_bugs, noop)
     except ValueError as e:
         runtime.logger.warn(f"Error associating builds with cves: {e}")
-        association_errors.append(e)
+        raise ValueError(f'Error associating builds with CVEs: {e}')
     finally:
         await errata_api.close()
-    if association_errors:
-        raise ValueError(f'Error associating builds with CVEs: {association_errors}')
     return first_fix_flaw_bugs
 
 

--- a/elliottlib/cli/attach_cve_flaws_cli.py
+++ b/elliottlib/cli/attach_cve_flaws_cli.py
@@ -123,13 +123,17 @@ async def get_flaws(runtime, advisory, bug_tracker, flaw_bug_tracker, noop):
     runtime.logger.info('Associating CVEs with builds')
     errata_config = runtime.get_errata_config()
     errata_api = AsyncErrataAPI(errata_config.get("server", constants.errata_url))
+    association_errors = []
     try:
         await errata_api.login()
         await associate_builds_with_cves(errata_api, advisory, attached_tracker_bugs, tracker_flaws, flaw_id_bugs, noop)
     except ValueError as e:
         runtime.logger.warn(f"Error associating builds with cves: {e}")
+        association_errors.append(e)
     finally:
         await errata_api.close()
+    if association_errors:
+        raise ValueError(f'Error associating builds with CVEs: {association_errors}')
     return first_fix_flaw_bugs
 
 

--- a/elliottlib/constants.py
+++ b/elliottlib/constants.py
@@ -21,6 +21,9 @@ BUG_SEVERITY_NUMBER_MAP = {
     "urgent": 4,
 }
 
+# These components need special treatment when associating security tracking bugs with builds:
+SPECIAL_CVE_COMPONENTS = ['openshift-golang-builder-container']
+
 BUG_LOOKUP_CHUNK_SIZE = 100
 BUG_ATTACH_CHUNK_SIZE = 100
 

--- a/elliottlib/errata_async.py
+++ b/elliottlib/errata_async.py
@@ -8,6 +8,7 @@ import aiohttp
 import gssapi
 
 from elliottlib.rpm_utils import parse_nvr
+from elliottlib import constants
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -109,7 +110,7 @@ class AsyncErrataUtils:
         :return: a dict that key is CVE name, value is another dict with package name as key and 0 as value
         """
         brew_components = {parse_nvr(nvr)["name"] for nvr in attached_builds}
-        missing_brew_brew_components = {c for components in expected_cve_components.values() for c in components if c != 'openshift-golang-builder-container'} - brew_components
+        missing_brew_brew_components = {c for components in expected_cve_components.values() for c in components if c not in constants.SPECIAL_CVE_COMPONENTS} - brew_components
         if missing_brew_brew_components:
             raise ValueError(f"Missing builds for brew component(s): {missing_brew_brew_components}")
         cve_packages_exclusions = {

--- a/elliottlib/errata_async.py
+++ b/elliottlib/errata_async.py
@@ -109,7 +109,7 @@ class AsyncErrataUtils:
         :return: a dict that key is CVE name, value is another dict with package name as key and 0 as value
         """
         brew_components = {parse_nvr(nvr)["name"] for nvr in attached_builds}
-        missing_brew_brew_components = {c for components in expected_cve_components.values() for c in components} - brew_components
+        missing_brew_brew_components = {c for components in expected_cve_components.values() for c in components if c != 'openshift-golang-builder-container'} - brew_components
         if missing_brew_brew_components:
             raise ValueError(f"Missing builds for brew component(s): {missing_brew_brew_components}")
         cve_packages_exclusions = {

--- a/tests/test_errata_async.py
+++ b/tests/test_errata_async.py
@@ -158,11 +158,13 @@ class TestAsyncErrataUtils(TestCase):
         cve_components = {
             "CVE-2099-1": {"a", "b"},
             "CVE-2099-2": {"c"},
+            "CVE-2099-3": {"openshift-golang-builder-container"},
         }
         attached_builds = ["a-1.0.0-1.el8", "a-1.0.0-1.el7", "b-1.0.0-1.el8", "c-1.0.0-1.el8", "d-1.0.0-1.el8"]
         expected = {
             "CVE-2099-1": {"c": 0, "d": 0},
             "CVE-2099-2": {"a": 0, "b": 0, "d": 0},
+            "CVE-2099-3": {'a': 0, 'a': 0, 'b': 0, 'c': 0, 'd': 0},
         }
         actual = AsyncErrataUtils.compute_cve_package_exclusions(attached_builds, cve_components)
         self.assertEqual(actual, expected)


### PR DESCRIPTION
This commit is an incomplete step towards ART-4552. `elliott
attach-cve-flaws` will now:
- error when mapping of builds to CVEs could not be made
- leave golang bumps to match the whole advisory

In case this runs into an error because the tracker is attached to the
wrong advisory, the tracker needs to be moved manually, and the process
repeated.