### PR TITLE
Verify-bugs --assembly=stream

### DIFF
--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -894,7 +894,7 @@ def _construct_query_url(config, status, search_filter='default', flag=None):
                         # the api expects "sub_components" for the field "sub_component"
                         # https://github.com/python-bugzilla/python-bugzilla/blob/main/bugzilla/base.py#L321
                         'sub_components',
-                        'external_bugs', 'whiteboard', 'keywords', 'target_release']
+                        'external_bugs', 'whiteboard', 'keywords', 'target_release', 'depends_on']
 
     filter_list = []
     if config.get('filter'):

--- a/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliottlib/cli/find_bugs_sweep_cli.py
@@ -9,7 +9,7 @@ from elliottlib.assembly import assembly_issues_config
 from elliottlib.bzutil import BugTracker, Bug, JIRABug
 from elliottlib import (Runtime, bzutil, constants, errata, logutil)
 from elliottlib.cli import common
-from elliottlib.util import green_prefix, green_print, red_prefix, yellow_print, chunk
+from elliottlib.util import green_prefix, green_print, red_prefix, chunk
 
 
 logger = logutil.getLogger(__name__)
@@ -125,12 +125,13 @@ advisory with the --add option.
     bugs: type_bug_list = []
     for b in [runtime.bug_trackers('jira'), runtime.bug_trackers('bugzilla')]:
         try:
-            bugs.extend(find_bugs_sweep(runtime, advisory_id, default_advisory_type, check_builds, major_version, find_bugs_obj,
-                        report, output, brew_event, noop, count_advisory_attach_flags, b))
+            bugs.extend(find_bugs_sweep(runtime, advisory_id, default_advisory_type, check_builds, major_version,
+                                        find_bugs_obj, output, brew_event, noop, count_advisory_attach_flags, b))
         except Exception as e:
             logger.error(traceback.format_exc())
             logger.error(f'exception with {b.type} bug tracker: {e}')
             exit_code = 1
+
     if not bugs:
         logger.info('No bugs found')
         sys.exit(0)
@@ -145,13 +146,7 @@ advisory with the --add option.
     sys.exit(exit_code)
 
 
-def find_bugs_sweep(runtime: Runtime, advisory_id, default_advisory_type, check_builds, major_version, find_bugs_obj,
-                    report, output, brew_event, noop, count_advisory_attach_flags, bug_tracker):
-    if output == 'text':
-        statuses = sorted(find_bugs_obj.status)
-        tr = bug_tracker.target_release()
-        logger.info(f"Searching {bug_tracker.type} for bugs with status {statuses} and target releases: {tr}\n")
-
+def get_bugs_sweep(runtime: Runtime, find_bugs_obj, brew_event, bug_tracker):
     bugs = find_bugs_obj.search(bug_tracker_obj=bug_tracker, verbose=runtime.debug)
 
     sweep_cutoff_timestamp = get_sweep_cutoff_timestamp(runtime, cli_brew_event=brew_event)
@@ -164,8 +159,7 @@ def find_bugs_sweep(runtime: Runtime, advisory_id, default_advisory_type, check_
             b = bug_tracker.filter_bugs_by_cutoff_event(chunk_of_bugs, find_bugs_obj.status,
                                                         sweep_cutoff_timestamp, verbose=runtime.debug)
             qualified_bugs.extend(b)
-        click.echo(f"{len(qualified_bugs)} of {len(bugs)} bugs are qualified for the cutoff time "
-                   f"{utc_ts}...")
+        click.echo(f"{len(qualified_bugs)} of {len(bugs)} bugs are qualified for the cutoff time {utc_ts}...")
         bugs = qualified_bugs
 
     included_bug_ids, excluded_bug_ids = get_assembly_bug_ids(runtime, bug_tracker_type=bug_tracker.type)
@@ -181,6 +175,18 @@ def find_bugs_sweep(runtime: Runtime, advisory_id, default_advisory_type, check_
         logger.warn(f"The following {bug_tracker.type} bugs will be excluded because they are explicitly "
                     f"defined in the assembly config: {excluded_bug_ids}")
         bugs = [bug for bug in bugs if bug.id not in excluded_bug_ids]
+
+    return bugs
+
+
+def find_bugs_sweep(runtime: Runtime, advisory_id, default_advisory_type, check_builds, major_version, find_bugs_obj,
+                    output, brew_event, noop, count_advisory_attach_flags, bug_tracker):
+    if output == 'text':
+        statuses = sorted(find_bugs_obj.status)
+        tr = bug_tracker.target_release()
+        green_prefix(f"Searching {bug_tracker.type} for bugs with status {statuses} and target releases: {tr}\n")
+
+    bugs = get_bugs_sweep(runtime, find_bugs_obj, brew_event, bug_tracker)
 
     if count_advisory_attach_flags < 1:
         return bugs

--- a/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliottlib/cli/find_bugs_sweep_cli.py
@@ -125,8 +125,8 @@ advisory with the --add option.
     bugs: type_bug_list = []
     for b in [runtime.bug_trackers('jira'), runtime.bug_trackers('bugzilla')]:
         try:
-            bugs.extend(find_bugs_sweep(runtime, advisory_id, default_advisory_type, check_builds, major_version,
-                                        find_bugs_obj, output, brew_event, noop, count_advisory_attach_flags, b))
+            bugs.extend(find_and_attach_bugs(runtime, advisory_id, default_advisory_type, check_builds, major_version,
+                        find_bugs_obj, output, brew_event, noop, count_advisory_attach_flags, b))
         except Exception as e:
             logger.error(traceback.format_exc())
             logger.error(f'exception with {b.type} bug tracker: {e}')
@@ -159,7 +159,7 @@ def get_bugs_sweep(runtime: Runtime, find_bugs_obj, brew_event, bug_tracker):
             b = bug_tracker.filter_bugs_by_cutoff_event(chunk_of_bugs, find_bugs_obj.status,
                                                         sweep_cutoff_timestamp, verbose=runtime.debug)
             qualified_bugs.extend(b)
-        click.echo(f"{len(qualified_bugs)} of {len(bugs)} bugs are qualified for the cutoff time {utc_ts}...")
+        logger.info(f"{len(qualified_bugs)} of {len(bugs)} bugs are qualified for the cutoff time {utc_ts}...")
         bugs = qualified_bugs
 
     included_bug_ids, excluded_bug_ids = get_assembly_bug_ids(runtime, bug_tracker_type=bug_tracker.type)
@@ -179,8 +179,8 @@ def get_bugs_sweep(runtime: Runtime, find_bugs_obj, brew_event, bug_tracker):
     return bugs
 
 
-def find_bugs_sweep(runtime: Runtime, advisory_id, default_advisory_type, check_builds, major_version, find_bugs_obj,
-                    output, brew_event, noop, count_advisory_attach_flags, bug_tracker):
+def find_and_attach_bugs(runtime: Runtime, advisory_id, default_advisory_type, check_builds, major_version,
+                         find_bugs_obj, output, brew_event, noop, count_advisory_attach_flags, bug_tracker):
     if output == 'text':
         statuses = sorted(find_bugs_obj.status)
         tr = bug_tracker.target_release()

--- a/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliottlib/cli/verify_attached_bugs_cli.py
@@ -63,7 +63,8 @@ async def verify_attached_bugs(runtime: Runtime, verify_bug_status: bool, adviso
 
 
 @cli.command("verify-bugs", short_help="Same as verify-attached-bugs, but for bugs that are not (yet) attached to advisories")
-@click.option("--with-sweep", is_flag=True, help="Run find-bugs:sweep and verify bugs that qualify")
+@click.option("--stream", is_flag=True, help="Find bugs for stream assembly (similar to find-bugs:sweep) and verify "
+                                             "bugs that qualify")
 @click.option("--verify-bug-status", is_flag=True, help="Check that bugs of advisories are all VERIFIED or more", type=bool, default=False)
 @click.option("--no-verify-blocking-bugs", is_flag=True, help="Don't check if there are open bugs for the next minor version blocking bugs for this minor version", type=bool, default=False)
 @click.option('--output', '-o',
@@ -74,16 +75,16 @@ async def verify_attached_bugs(runtime: Runtime, verify_bug_status: bool, adviso
 @click.argument("bug_ids", nargs=-1, required=False)
 @pass_runtime
 @click_coroutine
-async def verify_bugs_cli(runtime, with_sweep, verify_bug_status, output, bug_ids, no_verify_blocking_bugs: bool):
-    if with_sweep and bug_ids:
+async def verify_bugs_cli(runtime, stream, verify_bug_status, output, bug_ids, no_verify_blocking_bugs: bool):
+    if stream and bug_ids:
         raise click.BadParameter("Cannot use both --with-sweep and [BUG_IDS]")
     runtime.initialize()
-    await verify_bugs(runtime, with_sweep, verify_bug_status, output, bug_ids, no_verify_blocking_bugs)
+    await verify_bugs(runtime, stream, verify_bug_status, output, bug_ids, no_verify_blocking_bugs)
 
 
-async def verify_bugs(runtime, with_sweep, verify_bug_status, output, bug_ids, no_verify_blocking_bugs):
+async def verify_bugs(runtime, stream, verify_bug_status, output, bug_ids, no_verify_blocking_bugs):
     validator = BugValidator(runtime, output)
-    if with_sweep:
+    if stream:
         find_bugs_obj = FindBugsSweep()
         ocp_bugs = []
         for b in [runtime.bug_trackers('jira'), runtime.bug_trackers('bugzilla')]:

--- a/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliottlib/cli/verify_attached_bugs_cli.py
@@ -6,13 +6,16 @@ from spnego.exceptions import GSSError
 from errata_tool import Erratum
 
 
-from elliottlib import bzutil, constants, util, errata
+from elliottlib import bzutil, constants, logutil
 from elliottlib.cli.common import cli, click_coroutine, pass_runtime
 from elliottlib.errata_async import AsyncErrataAPI, AsyncErrataUtils
 from elliottlib.runtime import Runtime
 from elliottlib.util import (exit_unauthenticated, green_print,
                              minor_version_tuple, red_print)
-from elliottlib.bzutil import BugzillaBugTracker, JIRABugTracker, Bug, BugTracker
+from elliottlib.bzutil import Bug, BugTracker
+from elliottlib.cli.find_bugs_sweep_cli import get_bugs_sweep, FindBugsSweep
+
+logger = logutil.getLogger(__name__)
 
 
 @cli.command("verify-attached-bugs", short_help="Verify bugs in a release will not be regressed in the next version")
@@ -60,6 +63,7 @@ async def verify_attached_bugs(runtime: Runtime, verify_bug_status: bool, adviso
 
 
 @cli.command("verify-bugs", short_help="Same as verify-attached-bugs, but for bugs that are not (yet) attached to advisories")
+@click.option("--with-sweep", is_flag=True, help="Run find-bugs:sweep and verify bugs that qualify")
 @click.option("--verify-bug-status", is_flag=True, help="Check that bugs of advisories are all VERIFIED or more", type=bool, default=False)
 @click.option("--no-verify-blocking-bugs", is_flag=True, help="Don't check if there are open bugs for the next minor version blocking bugs for this minor version", type=bool, default=False)
 @click.option('--output', '-o',
@@ -70,29 +74,41 @@ async def verify_attached_bugs(runtime: Runtime, verify_bug_status: bool, adviso
 @click.argument("bug_ids", nargs=-1, required=False)
 @pass_runtime
 @click_coroutine
-async def verify_bugs_cli(runtime, verify_bug_status, output, bug_ids, no_verify_blocking_bugs: bool):
+async def verify_bugs_cli(runtime, with_sweep, verify_bug_status, output, bug_ids, no_verify_blocking_bugs: bool):
+    if with_sweep and bug_ids:
+        raise click.BadParameter("Cannot use both --with-sweep and [BUG_IDS]")
     runtime.initialize()
-    await verify_bugs(runtime, verify_bug_status, output, bug_ids, no_verify_blocking_bugs)
+    await verify_bugs(runtime, with_sweep, verify_bug_status, output, bug_ids, no_verify_blocking_bugs)
 
 
-async def verify_bugs(runtime, verify_bug_status, output, bug_ids, no_verify_blocking_bugs: bool):
+async def verify_bugs(runtime, with_sweep, verify_bug_status, output, bug_ids, no_verify_blocking_bugs):
     validator = BugValidator(runtime, output)
-    jira_ids, bz_ids = bzutil.get_jira_bz_bug_ids(bug_ids)
-    bugs = []
-    if jira_ids:
-        bug_tracker = runtime.bug_trackers('jira')
-        bugs.extend(bug_tracker.get_bugs(jira_ids))
-    if bz_ids:
-        bug_tracker = runtime.bug_trackers('bugzilla')
-        bugs.extend(bug_tracker.get_bugs(bz_ids))
-    non_ocp_bugs = {b for b in bugs if not b.is_ocp_bug()}
-    if non_ocp_bugs:
-        runtime.logger.info(f"Ignoring non-ocp bugs: {[b.id for b in non_ocp_bugs]}")
+    if with_sweep:
+        find_bugs_obj = FindBugsSweep()
+        ocp_bugs = []
+        for b in [runtime.bug_trackers('jira'), runtime.bug_trackers('bugzilla')]:
+            logger.info(f"Running sweep for {b.type} bugs")
+            bugs = get_bugs_sweep(runtime, find_bugs_obj, None, b)
+            logger.info(f"Found {len(bugs)} {b.type} bugs: {[b.id for b in bugs]}")
+            ocp_bugs.extend(bugs)
+    else:
+        jira_ids, bz_ids = bzutil.get_jira_bz_bug_ids(bug_ids)
+        bugs = []
+        if jira_ids:
+            bug_tracker = runtime.bug_trackers('jira')
+            bugs.extend(bug_tracker.get_bugs(jira_ids))
+        if bz_ids:
+            bug_tracker = runtime.bug_trackers('bugzilla')
+            bugs.extend(bug_tracker.get_bugs(bz_ids))
 
-    # bug.is_ocp_bug() filters by product/project, so we don't get flaw bugs or bugs of other products
-    non_flaw_bugs = {b for b in bugs if b.is_ocp_bug()}
+        # bug.is_ocp_bug() filters by product/project, so we don't get flaw bugs or bugs of other products
+        non_ocp_bugs = {b for b in bugs if not b.is_ocp_bug()}
+        if non_ocp_bugs:
+            logger.info(f"Ignoring non-ocp bugs: {[b.id for b in non_ocp_bugs]}")
+        ocp_bugs = {b for b in bugs if b.is_ocp_bug()}
+
     try:
-        validator.validate(non_flaw_bugs, verify_bug_status, no_verify_blocking_bugs)
+        validator.validate(ocp_bugs, verify_bug_status, no_verify_blocking_bugs)
     finally:
         await validator.close()
 
@@ -291,8 +307,8 @@ class BugValidator:
         for bug in blockers:
             if bug.is_ocp_bug() and any(is_next_target(target) for target in bug.target_release):
                 blocking_bugs[bug.id] = bug
-        print(f"Blocking bugs for next target release ({next_version[0]}.{next_version[1]}): "
-              f"{list(blocking_bugs.keys())}")
+        logger.info(f"Blocking bugs for next target release ({next_version[0]}.{next_version[1]}): "
+                    f"{list(blocking_bugs.keys())}")
 
         k = {bug: [blocking_bugs[b] for b in bug.depends_on if b in blocking_bugs] for bug in bugs}
         return k
@@ -312,9 +328,12 @@ class BugValidator:
                                   f"`{blocker.status}` bug <{blocker.weburl}|{blocker.id}>"
                     self._complain(message)
                 if blocker.status in ['CLOSED', 'Closed'] and \
-                    blocker.resolution not in ['CURRENTRELEASE', 'NEXTRELEASE', 'ERRATA', 'DUPLICATE', 'NOTABUG',
-                                               'WONTFIX', 'Done', "Won't Do", 'Errata', 'Duplicate', 'Not a Bug',
-                                               'Done-Errata']:
+                    blocker.resolution not in ['CURRENTRELEASE', 'NEXTRELEASE', 'ERRATA', 'DUPLICATE', 'NOTABUG', 'WONTFIX',
+                                               'Done', 'Fixed', 'Done-Errata'
+                                               'Current Release', 'Errata', 'Next Release',
+                                               "Won't Do", "Won't Fix",
+                                               'Duplicate', 'Duplicate Issue',
+                                               'Not a Bug']:
                     if self.output == 'text':
                         message = f"Regression possible: {bug.status} bug {bug.id} is a backport of bug " \
                             f"{blocker.id} which was CLOSED {blocker.resolution}"

--- a/tests/test_verify_attached_bugs_cli.py
+++ b/tests/test_verify_attached_bugs_cli.py
@@ -92,7 +92,7 @@ class VerifyAttachedBugs(unittest.TestCase):
             .with_args({"OCPBUGS-3", "OCPBUGS-4"})\
             .and_return(depend_on_bugs)
 
-        result = runner.invoke(cli, ['-g', 'openshift-4.6', 'verify-bugs', '--with-sweep'])
+        result = runner.invoke(cli, ['-g', 'openshift-4.6', 'verify-bugs', '--stream'])
         # if result.exit_code != 0:
         #     exc_type, exc_value, exc_traceback = result.exc_info
         #     t = "\n".join(traceback.format_exception(exc_type, exc_value, exc_traceback))


### PR DESCRIPTION
Right now we rely on parsing the output of 
find-bugs:sweep to pass it on to verify-bugs
in our [check-bugs job](https://github.com/openshift/aos-cd-jobs/blob/master/pyartcd/pyartcd/pipelines/check_bugs.py).
Now with jira and bugzilla having different output - 
it makes more sense to make this into a native 
functionality.

```
elliott --group=openshift-4.10 --assembly=stream verify-bugs
```

Test run
https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/hack/job/sidsharm-aos-cd-jobs/job/build%252Fcheck-bugs/8/console