### PR TITLE
attach-cve-flaws validation with-sweep

### DIFF
--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -893,7 +893,7 @@ def _construct_query_url(config, status, search_filter='default', flag=None):
                         # the api expects "sub_components" for the field "sub_component"
                         # https://github.com/python-bugzilla/python-bugzilla/blob/main/bugzilla/base.py#L321
                         'sub_components',
-                        'external_bugs', 'whiteboard', 'keywords', 'target_release']
+                        'external_bugs', 'whiteboard', 'keywords', 'target_release', 'depends_on']
 
     filter_list = []
     if config.get('filter'):

--- a/elliottlib/cli/attach_cve_flaws_cli.py
+++ b/elliottlib/cli/attach_cve_flaws_cli.py
@@ -5,13 +5,16 @@ import traceback
 import asyncio
 from errata_tool import Erratum
 
-from elliottlib import constants
+from elliottlib import constants, logutil
 from elliottlib.cli.common import (cli, click_coroutine, find_default_advisory,
                                    use_default_advisory_option)
 from elliottlib.errata_async import AsyncErrataAPI, AsyncErrataUtils
 from elliottlib.errata import is_security_advisory
 from elliottlib.runtime import Runtime
-from elliottlib.bzutil import Bug, get_highest_security_impact, is_first_fix_any, JIRABugTracker, BugTracker
+from elliottlib.bzutil import Bug, get_highest_security_impact, is_first_fix_any, BugTracker
+from elliottlib.cli.find_bugs_sweep_cli import get_bugs_sweep, FindBugsSweep
+
+logger = logutil.getLogger(__name__)
 
 
 @cli.command('attach-cve-flaws',
@@ -19,6 +22,8 @@ from elliottlib.bzutil import Bug, get_highest_security_impact, is_first_fix_any
 @click.option('--advisory', '-a', 'advisory_id',
               type=int,
               help='Find tracker bugs in given advisory')
+@click.option("--validate-with-sweep", is_flag=True,
+              help="Run find-bugs:sweep and perform cve validation on bugs (does not attach any bugs)")
 @click.option("--noop", "--dry-run",
               required=False,
               default=False, is_flag=True,
@@ -29,7 +34,8 @@ from elliottlib.bzutil import Bug, get_highest_security_impact, is_first_fix_any
               help='Run for all advisories values defined in [group|releases].yml')
 @click.pass_obj
 @click_coroutine
-async def attach_cve_flaws_cli(runtime: Runtime, advisory_id: int, noop: bool, default_advisory_type: str, into_default_advisories: bool):
+async def attach_cve_flaws_cli(runtime: Runtime, advisory_id: int, validate_with_sweep: bool, noop: bool,
+                               default_advisory_type: str, into_default_advisories: bool):
     """Attach corresponding flaw bugs for trackers in advisory (first-fix only).
 
     Also converts advisory to RHSA, if not already.
@@ -47,15 +53,26 @@ async def attach_cve_flaws_cli(runtime: Runtime, advisory_id: int, noop: bool, d
     1851422, 1866148, 1858981, 1852331, 1861044, 1857081, 1857977, 1848647,
     1849044, 1856529, 1843575, 1840253]
     """
-    if sum(map(bool, [advisory_id, default_advisory_type, into_default_advisories])) != 1:
-        raise click.BadParameter("Use one of --use-default-advisory or --advisory or --into-default-advisories")
+    if sum(map(bool, [advisory_id, validate_with_sweep, default_advisory_type, into_default_advisories])) != 1:
+        raise click.BadParameter("Use one of --use-default-advisory or --advisory or --into-default-advisories or "
+                                 "--with-sweep")
     runtime.initialize()
     if into_default_advisories:
         advisories = runtime.group_config.advisories.values()
     elif default_advisory_type:
         advisories = [find_default_advisory(runtime, default_advisory_type)]
-    else:
+    elif advisory_id:
         advisories = [advisory_id]
+
+    if validate_with_sweep:
+        find_bugs_obj = FindBugsSweep()
+        flaw_bug_tracker = runtime.bug_trackers('bugzilla')
+        for bug_tracker in [runtime.bug_trackers('jira'), runtime.bug_trackers('bugzilla')]:
+            logger.info(f"Running sweep for {bug_tracker.type} bugs")
+            bugs = get_bugs_sweep(runtime, find_bugs_obj, None, bug_tracker)
+            logger.info(f"Found {len(bugs)} {bug_tracker.type} bugs: {[b.id for b in bugs]}")
+            await get_flaws(runtime, None, [b.id for b in bugs], bug_tracker, flaw_bug_tracker, True)
+        return
 
     exit_code = 0
     flaw_bug_tracker = runtime.bug_trackers('bugzilla')
@@ -65,8 +82,13 @@ async def attach_cve_flaws_cli(runtime: Runtime, advisory_id: int, noop: bool, d
 
         tasks = []
         for bug_tracker in [runtime.bug_trackers('jira'), runtime.bug_trackers('bugzilla')]:
-            tasks.append(asyncio.get_event_loop().create_task(get_flaws(runtime, advisory, bug_tracker,
-                                                              flaw_bug_tracker, noop)))
+            # get attached bugs from advisory
+            advisory_bug_ids = bug_tracker.advisory_bug_ids(advisory)
+            if not advisory_bug_ids:
+                runtime.logger.info(f'Found 0 {bug_tracker.type} bugs attached')
+                continue
+            tasks.append(asyncio.get_event_loop().create_task(get_flaws(runtime, advisory, advisory_bug_ids,
+                                                                        bug_tracker, flaw_bug_tracker, noop)))
         try:
             lists_of_flaw_bugs = await asyncio.gather(*tasks)
             flaw_bugs = list(set(sum(lists_of_flaw_bugs, [])))
@@ -79,13 +101,7 @@ async def attach_cve_flaws_cli(runtime: Runtime, advisory_id: int, noop: bool, d
     sys.exit(exit_code)
 
 
-async def get_flaws(runtime, advisory, bug_tracker, flaw_bug_tracker, noop):
-    # get attached bugs from advisory
-    advisory_bug_ids = bug_tracker.advisory_bug_ids(advisory)
-    if not advisory_bug_ids:
-        runtime.logger.info(f'Found 0 {bug_tracker.type} bugs attached')
-        return []
-
+async def get_flaws(runtime, advisory, advisory_bug_ids, bug_tracker, flaw_bug_tracker, noop):
     attached_tracker_bugs: List[Bug] = bug_tracker.get_tracker_bugs(advisory_bug_ids, verbose=runtime.debug)
     runtime.logger.info(f'Found {len(attached_tracker_bugs)} {bug_tracker.type} tracker bugs attached: '
                         f'{sorted([b.id for b in attached_tracker_bugs])}')
@@ -94,6 +110,12 @@ async def get_flaws(runtime, advisory, bug_tracker, flaw_bug_tracker, noop):
 
     # validate and get target_release
     current_target_release = Bug.get_target_release(attached_tracker_bugs)
+    major, minor = runtime.get_major_minor()
+    version = f'{major}.{minor}'
+    if version not in current_target_release:
+        raise ValueError(f'Target release version for given bugs ({current_target_release}) does not match the group '
+                         f'({version}): aborting')
+
     tracker_flaws, flaw_id_bugs = BugTracker.get_corresponding_flaw_bugs(
         attached_tracker_bugs,
         flaw_bug_tracker,
@@ -117,8 +139,8 @@ async def get_flaws(runtime, advisory, bug_tracker, flaw_bug_tracker, noop):
         ]
 
     runtime.logger.info(f'{len(first_fix_flaw_bugs)} out of {len(flaw_id_bugs)} flaw bugs considered "first-fix"')
-    if not first_fix_flaw_bugs:
-        return []
+    if not first_fix_flaw_bugs or not advisory:
+        return first_fix_flaw_bugs
 
     runtime.logger.info('Associating CVEs with builds')
     errata_config = runtime.get_errata_config()

--- a/elliottlib/cli/attach_cve_flaws_cli.py
+++ b/elliottlib/cli/attach_cve_flaws_cli.py
@@ -103,7 +103,7 @@ async def attach_cve_flaws_cli(runtime: Runtime, advisory_id: int, validate_with
 
 async def get_flaws(runtime, advisory, advisory_bug_ids, bug_tracker, flaw_bug_tracker, noop):
     attached_tracker_bugs: List[Bug] = bug_tracker.get_tracker_bugs(advisory_bug_ids, verbose=runtime.debug)
-    runtime.logger.info(f'Found {len(attached_tracker_bugs)} {bug_tracker.type} tracker bugs attached: '
+    runtime.logger.info(f'Found {len(attached_tracker_bugs)} {bug_tracker.type} tracker bugs: '
                         f'{sorted([b.id for b in attached_tracker_bugs])}')
     if not attached_tracker_bugs:
         return []

--- a/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliottlib/cli/find_bugs_sweep_cli.py
@@ -167,7 +167,7 @@ def get_bugs_sweep(runtime: Runtime, find_bugs_obj, brew_event, bug_tracker):
 
 
 def find_bugs_sweep(runtime: Runtime, advisory_id, default_advisory_type, check_builds, major_version, find_bugs_obj,
-                     report, output, brew_event, noop, count_advisory_attach_flags, bug_tracker):
+                    report, output, brew_event, noop, count_advisory_attach_flags, bug_tracker):
     if output == 'text':
         statuses = sorted(find_bugs_obj.status)
         tr = bug_tracker.target_release()

--- a/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliottlib/cli/find_bugs_sweep_cli.py
@@ -132,13 +132,7 @@ advisory with the --add option.
     sys.exit(exit_code)
 
 
-def find_bugs_sweep(runtime: Runtime, advisory_id, default_advisory_type, check_builds, major_version, find_bugs_obj,
-                    report, output, brew_event, noop, count_advisory_attach_flags, bug_tracker):
-    if output == 'text':
-        statuses = sorted(find_bugs_obj.status)
-        tr = bug_tracker.target_release()
-        green_prefix(f"Searching {bug_tracker.type} for bugs with status {statuses} and target releases: {tr}\n")
-
+def get_bugs_sweep(runtime: Runtime, find_bugs_obj, brew_event, bug_tracker):
     bugs = find_bugs_obj.search(bug_tracker_obj=bug_tracker, verbose=runtime.debug)
 
     sweep_cutoff_timestamp = get_sweep_cutoff_timestamp(runtime, cli_brew_event=brew_event)
@@ -168,6 +162,18 @@ def find_bugs_sweep(runtime: Runtime, advisory_id, default_advisory_type, check_
         yellow_print(f"The following {bug_tracker.type} bugs will be excluded because they are explicitly "
                      f"defined in the assembly config: {excluded_bug_ids}")
         bugs = [bug for bug in bugs if bug.id not in excluded_bug_ids]
+
+    return bugs
+
+
+def find_bugs_sweep(runtime: Runtime, advisory_id, default_advisory_type, check_builds, major_version, find_bugs_obj,
+                     report, output, brew_event, noop, count_advisory_attach_flags, bug_tracker):
+    if output == 'text':
+        statuses = sorted(find_bugs_obj.status)
+        tr = bug_tracker.target_release()
+        green_prefix(f"Searching {bug_tracker.type} for bugs with status {statuses} and target releases: {tr}\n")
+
+    bugs = get_bugs_sweep(runtime, find_bugs_obj, brew_event, bug_tracker)
 
     if output == 'text':
         green_prefix(f"Found {len(bugs)} bugs: ")

--- a/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliottlib/cli/verify_attached_bugs_cli.py
@@ -304,7 +304,7 @@ class BugValidator:
             if bug.is_ocp_bug() and any(is_next_target(target) for target in bug.target_release):
                 blocking_bugs[bug.id] = bug
         logger.info(f"Blocking bugs for next target release ({next_version[0]}.{next_version[1]}): "
-              f"{list(blocking_bugs.keys())}")
+                    f"{list(blocking_bugs.keys())}")
 
         k = {bug: [blocking_bugs[b] for b in bug.depends_on if b in blocking_bugs] for bug in bugs}
         return k

--- a/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliottlib/cli/verify_attached_bugs_cli.py
@@ -324,8 +324,12 @@ class BugValidator:
                                   f"`{blocker.status}` bug <{blocker.weburl}|{blocker.id}>"
                     self._complain(message)
                 if blocker.status in ['CLOSED', 'Closed'] and \
-                    blocker.resolution not in ['CURRENTRELEASE', 'NEXTRELEASE', 'ERRATA', 'DUPLICATE', 'NOTABUG',
-                                               'WONTFIX', 'Done', "Won't Do", 'Errata', 'Duplicate', 'Not a Bug']:
+                    blocker.resolution not in ['CURRENTRELEASE', 'NEXTRELEASE', 'ERRATA', 'DUPLICATE', 'NOTABUG', 'WONTFIX',
+                                               'Done', 'Fixed',
+                                               'Current Release', 'Errata', 'Next Release',
+                                               "Won't Do", "Won't Fix",
+                                               'Duplicate', 'Duplicate Issue',
+                                               'Not a Bug']:
                     if self.output == 'text':
                         message = f"Regression possible: {bug.status} bug {bug.id} is a backport of bug " \
                             f"{blocker.id} which was CLOSED {blocker.resolution}"


### PR DESCRIPTION
Forked off of https://github.com/openshift/elliott/pull/418 
This should go after the PR
Follow up to https://github.com/openshift/elliott/pull/391

This performs validation on tracker bugs
- target release
- associated flaw bug

```
$ elliott --group=openshift-4.11 attach-cve-flaws --validate-with-sweep

2022-09-07 17:02:52,556 INFO Cloning config data from https://github.com/openshift/ocp-build-data.git
2022-09-07 17:02:55,520 INFO Using branch from group.yml: rhaos-4.11-rhel-8
2022-09-07 17:02:58,237 INFO Running sweep for jira bugs
2022-09-07 17:02:59,880 INFO Found 14 jira bugs: ['OCPBUGS-982', 'OCPBUGS-892', 'OCPBUGS-851', 'OCPBUGS-828', 'OCPBUGS-826', 'OCPBUGS-795', 'OCPBUGS-782', 'OCPBUGS-749', 'OCPBUGS-744', 'OCPBUGS-577', 'OCPBUGS-541', 'OCPBUGS-528', 'OCPBUGS-500', 'OCPBUGS-185']
2022-09-07 17:03:00,629 INFO Found 0 jira tracker bugs: []
2022-09-07 17:03:00,629 INFO Running sweep for bugzilla bugs
2022-09-07 17:03:05,369 INFO Found 18 bugzilla bugs: [2024946, 2067887, 2100035, 2102335, 2103700, 2104825, 2105594, 2105597, 2108679, 2109193, 2109887, 2110283, 2110958, 2111131, 2111548, 2112928, 2117640, 2118282]
2022-09-07 17:03:06,410 INFO Found 3 bugzilla tracker bugs: [2067887, 2105594, 2105597]
2022-09-07 17:03:07,263 INFO Found 2 bugzilla corresponding flaw bugs: [2045880, 2100495]
2022-09-07 17:03:07,264 INFO Detected z-stream target release, every flaw bug is considered first-fix
2022-09-07 17:03:07,264 INFO 2 out of 2 flaw bugs considered "first-fix"

```