### PR TITLE
ART-3380 Improve Tracker Bug sorting

### DIFF
--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -66,33 +66,6 @@ class Bug:
     def is_ocp_bug(self):
         raise NotImplementedError
 
-    def is_rpm_tracker(self):
-        if not self.is_tracker_bug():
-            return False
-        component_name = self.whiteboard_component
-        if not component_name:
-            return False
-        # if component name does not have image suffixes, then assume it is a rpm
-        return not re.search(r'-(apb|container)(,|$)', component_name)
-
-    @staticmethod
-    def get_valid_tracker_bugs(bugs: List[Bug]) -> Dict[Bug, str]:
-        """ Get valid cve tracker bugs with their component names
-
-        An OCP cve tracker has a whiteboard value "component:<component_name>"
-
-        :param bugs: list of bug objects
-        :returns: A dict of bug id as key and (bug object, component name) as value
-        """
-
-        tracker_bugs = {}
-        for b in bugs:
-            if b.is_tracker_bug():
-                component_name = b.whiteboard_component
-                if component_name:
-                    tracker_bugs[b.id] = (b, component_name)
-        return tracker_bugs
-
     @staticmethod
     def get_target_release(bugs: List[Bug]) -> str:
         """

--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -277,7 +277,10 @@ class JIRABug(Bug):
         return datetime.strptime(str(self.bug.fields.created), '%Y-%m-%dT%H:%M:%S.%f%z')
 
     def is_ocp_bug(self):
-        return self.bug.fields.project.key == "OCPBUGS" and 'Placeholder' not in self.summary
+        return self.bug.fields.project.key == "OCPBUGS" and not self.is_placeholder_bug()
+
+    def is_placeholder_bug(self):
+        return ('Placeholder' in self.summary) and (self.component == 'Release') and ('Automation' in self.keywords)
 
     def _get_blocks(self):
         blocks = []

--- a/elliottlib/cli/attach_cve_flaws_cli.py
+++ b/elliottlib/cli/attach_cve_flaws_cli.py
@@ -15,6 +15,7 @@ from elliottlib.cli.common import (cli, click_coroutine, find_default_advisory,
 from elliottlib.errata import is_security_advisory
 from elliottlib.errata_async import AsyncErrataAPI, AsyncErrataUtils
 from elliottlib.runtime import Runtime
+from elliottlib.bzutil import Bug, get_highest_security_impact, is_first_fix_any, BugTracker
 
 
 @cli.command('attach-cve-flaws',

--- a/elliottlib/cli/common.py
+++ b/elliottlib/cli/common.py
@@ -93,6 +93,10 @@ def find_default_advisory(runtime, default_advisory_type, quiet=False):
     return default_advisory
 
 
+def get_default_advisories(runtime):
+    return runtime.group_config.get('advisories', {})
+
+
 use_default_advisory_option = click.option(
     '--use-default-advisory', 'default_advisory_type',
     metavar='ADVISORY_TYPE',

--- a/elliottlib/cli/common.py
+++ b/elliottlib/cli/common.py
@@ -93,10 +93,6 @@ def find_default_advisory(runtime, default_advisory_type, quiet=False):
     return default_advisory
 
 
-def get_default_advisories(runtime):
-    return runtime.group_config.get('advisories', {})
-
-
 use_default_advisory_option = click.option(
     '--use-default-advisory', 'default_advisory_type',
     metavar='ADVISORY_TYPE',

--- a/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliottlib/cli/find_bugs_sweep_cli.py
@@ -3,7 +3,7 @@ import click
 import sys
 import traceback
 from datetime import datetime
-from typing import List, Optional
+from typing import List, Dict
 
 from elliottlib.assembly import assembly_issues_config
 from elliottlib.bzutil import BugTracker, Bug, JIRABug
@@ -47,7 +47,7 @@ class FindBugsSweep(FindBugsMode):
               default=None,
               required=False,
               is_flag=True,
-              help='When attaching, add bugs only if corresponding builds are attached to advisory')
+              help='Attach tracker bugs only if corresponding builds are attached to advisory')
 @click.option("--include-status", 'include_status',
               multiple=True,
               default=None,
@@ -86,8 +86,8 @@ def find_bugs_sweep_cli(runtime: Runtime, advisory_id, default_advisory_type, ch
 
  The --group automatically determines the correct target-releases to search
 for bugs claimed to be fixed, but not yet attached to advisories.
---check-builds flag forces bug validation with attached builds to rpm advisory.
-It assumes builds have been attached and only attaches bugs with matching builds.
+Security Tracker Bugs are validated with attached builds to advisories.
+If expected builds are not found then tracker bugs are not attached.
 default statuses: ['MODIFIED', 'ON_QA', 'VERIFIED']
 
 Using --use-default-advisory without a value set for the matching key
@@ -121,12 +121,15 @@ advisory with the --add option.
     find_bugs_obj.include_status(include_status)
     find_bugs_obj.exclude_status(exclude_status)
 
+    if check_builds:
+        logger.warn("--check-builds is ON by default, it will be deprecated in the future")
+
     exit_code = 0
     bugs: type_bug_list = []
     for b in [runtime.bug_trackers('jira'), runtime.bug_trackers('bugzilla')]:
         try:
-            bugs.extend(find_and_attach_bugs(runtime, advisory_id, default_advisory_type, check_builds, major_version,
-                        find_bugs_obj, output, brew_event, noop, count_advisory_attach_flags, b))
+            bugs.extend(find_and_attach_bugs(runtime, advisory_id, default_advisory_type, major_version, find_bugs_obj,
+                        output, brew_event, noop, count_advisory_attach_flags, b))
         except Exception as e:
             logger.error(traceback.format_exc())
             logger.error(f'exception with {b.type} bug tracker: {e}')
@@ -179,7 +182,7 @@ def get_bugs_sweep(runtime: Runtime, find_bugs_obj, brew_event, bug_tracker):
     return bugs
 
 
-def find_and_attach_bugs(runtime: Runtime, advisory_id, default_advisory_type, check_builds, major_version,
+def find_and_attach_bugs(runtime: Runtime, advisory_id, default_advisory_type, major_version,
                          find_bugs_obj, output, brew_event, noop, count_advisory_attach_flags, bug_tracker):
     if output == 'text':
         statuses = sorted(find_bugs_obj.status)
@@ -187,6 +190,12 @@ def find_and_attach_bugs(runtime: Runtime, advisory_id, default_advisory_type, c
         green_prefix(f"Searching {bug_tracker.type} for bugs with status {statuses} and target releases: {tr}\n")
 
     bugs = get_bugs_sweep(runtime, find_bugs_obj, brew_event, bug_tracker)
+
+    advisory_ids = common.get_default_advisories(runtime)
+    bugs_by_type = categorize_bugs_by_type(bugs, advisory_ids,
+                                           major_version=major_version)
+    for kind, kind_bugs in bugs_by_type.items():
+        logger.info(f'{kind} bugs: {[b.id for b in kind_bugs]}')
 
     if count_advisory_attach_flags < 1:
         return bugs
@@ -196,20 +205,16 @@ def find_and_attach_bugs(runtime: Runtime, advisory_id, default_advisory_type, c
         bug_tracker.attach_bugs(advisory_id, [b.id for b in bugs], noop=noop, verbose=runtime.debug)
         return bugs
 
-    rpm_advisory_id = common.find_default_advisory(runtime, 'rpm') if check_builds else None
-    bugs_by_type = categorize_bugs_by_type(bugs, rpm_advisory_id=rpm_advisory_id,
-                                           major_version=major_version,
-                                           check_builds=check_builds)
+    if not advisory_ids:
+        logger.info("No advisories to attach to")
+        return bugs
 
     advisory_types_to_attach = [default_advisory_type] if default_advisory_type else bugs_by_type.keys()
     for advisory_type in sorted(advisory_types_to_attach):
-        bugs = bugs_by_type.get(advisory_type)
-        green_prefix(f'{advisory_type} advisory: {[bug.id for bug in bugs]}')
-        if bugs:
-            adv_id = common.find_default_advisory(runtime, advisory_type)
-            bug_tracker.attach_bugs(adv_id, [b.id for b in bugs], noop=noop, verbose=runtime.debug)
-        else:
-            click.echo("0 bugs found")
+        kind_bugs = bugs_by_type.get(advisory_type)
+        if kind_bugs:
+            advisory_id = advisory_ids[advisory_type]
+            bug_tracker.attach_bugs(advisory_id, [b.id for b in kind_bugs], noop=noop, verbose=runtime.debug)
     return bugs
 
 
@@ -228,8 +233,7 @@ def get_assembly_bug_ids(runtime, bug_tracker_type):
     return included_bug_ids, excluded_bug_ids
 
 
-def categorize_bugs_by_type(bugs: List, rpm_advisory_id: Optional[int] = None, major_version: int = 4, check_builds:
-                            bool = True):
+def categorize_bugs_by_type(bugs: List[Bug], advisory_id_map: Dict[str, int], major_version: int = 4):
     # key is type ("rpm", "image", "extras"), value is a set of bug IDs.
     bugs_by_type = {
         "rpm": set(),
@@ -240,41 +244,53 @@ def categorize_bugs_by_type(bugs: List, rpm_advisory_id: Optional[int] = None, m
     # for 3.x, all bugs should go to the rpm advisory
     if int(major_version) < 4:
         bugs_by_type["rpm"] = set(bugs)
-    else:  # for 4.x, sweep rpm tracker bugs into rpm advisory
-        rpm_bugs = Bug.get_valid_rpm_cves(bugs)
-        if rpm_bugs:
-            green_prefix("RPM Tracker Bugs found: ")
-            click.echo(sorted(b.id for b in rpm_bugs))
-            # if --check-builds flag is set
-            # only attach bugs that have corresponding brew builds attached to rpm advisory
-            if check_builds and rpm_advisory_id:
-                click.echo("Validating bugs with builds attached to the rpm advisory")
-                attached_builds = errata.get_advisory_nvrs(rpm_advisory_id)
-                packages = attached_builds.keys()
-                not_found = []
-                for bug, package_name in rpm_bugs.items():
-                    if package_name not in packages:
-                        not_found.append((bug.id, package_name))
-                    else:
-                        click.echo(f"Build found for #{bug.id}, {package_name}")
-                        bugs_by_type["rpm"].add(bug)
+        return bugs_by_type
 
-                if not_found:
-                    red_prefix("RPM CVE Tracker Error: ")
-                    click.echo("The following (tracker bug, package) were found but not attached, because "
-                               "no corresponding brew builds were found attached to the rpm advisory. "
-                               "First attach builds and then rerun to attach the bugs, or exclude the "
-                               "bug ids in the assembly definition")
-                    click.echo(not_found)
-                    raise ValueError(f'No builds found for CVE (bug, package): {not_found}. Either attach '
-                                     f'builds or exclude the bugs in the assembly definition: {[b for b, p in not_found]}')
-            else:
-                click.echo("Skipping attaching RPM Tracker Bugs. Use --check-builds flag to validate with builds.")
+    # for 4.x, first sort all non_tracker_bugs
+    non_tracker_bugs = [b for b in bugs if not b.is_tracker_bug()]
+    bugs_by_type["extras"] = extras_bugs(non_tracker_bugs)
+    bugs_by_type["image"] = set(non_tracker_bugs) - bugs_by_type["extras"]
 
-        bugs_by_type["extras"] = extras_bugs(bugs)
+    tracker_bugs = [b for b in bugs if b.is_tracker_bug() and b.whiteboard_component]
+    if not tracker_bugs:
+        return bugs_by_type
 
-        # all other bugs should go into "image" advisory
-        bugs_by_type["image"] = set(bugs) - bugs_by_type["extras"] - rpm_bugs.keys()
+    green_prefix(f"Tracker Bugs found ({len(tracker_bugs)}): \n")
+    for b in tracker_bugs:
+        click.echo((b.id, b.whiteboard_component))
+
+    if not advisory_id_map:
+        logger.info("Skipping sorting/attaching Tracker Bugs. Advisories with attached builds must be given to "
+                    "validate trackers.")
+        return bugs_by_type
+
+    found = set()
+    logger.info("Validating tracker bugs with builds in advisories..")
+    for kind in bugs_by_type.keys():
+        if len(found) == len(tracker_bugs):
+            break
+        attached_builds = errata.get_advisory_nvrs(advisory_id_map[kind])
+        packages = attached_builds.keys()
+
+        for bug in tracker_bugs:
+            package_name = bug.whiteboard_component
+            if package_name in packages:
+                found.add(bug)
+                click.echo(f"{kind} build found for #{bug.id}, {package_name} ")
+                bugs_by_type[kind].add(bug)
+
+    not_found = set(tracker_bugs) - found
+    if not_found:
+        not_found_with_component = [(b.id, b.whiteboard_component) for b in not_found]
+        red_prefix("Tracker Bugs Warning: ")
+        click.echo("The following (tracker bug, package) were found BUT not attached,"
+                   " since no corresponding brew build was found attached to any advisory. "
+                   "First attach builds to the correct advisory and rerun to attach the bugs, "
+                   "or exclude the bug ids in the assembly definition")
+        click.echo(not_found_with_component)
+        raise ValueError(f'No builds found for CVE (bug, package): {not_found_with_component}. Either attach '
+                         f'builds or exclude the bugs in the assembly definition')
+
     return bugs_by_type
 
 

--- a/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliottlib/cli/find_bugs_sweep_cli.py
@@ -251,12 +251,12 @@ def categorize_bugs_by_type(bugs: List[Bug], advisory_id_map: Dict[str, int], ma
     bugs_by_type["image"] = set(non_tracker_bugs) - bugs_by_type["extras"]
 
     tracker_bugs = [b for b in bugs if b.is_tracker_bug() and b.whiteboard_component]
+    logger.info(f"Tracker Bugs found: {len(tracker_bugs)}")
     if not tracker_bugs:
         return bugs_by_type
 
-    green_prefix(f"Tracker Bugs found ({len(tracker_bugs)}): \n")
     for b in tracker_bugs:
-        click.echo((b.id, b.whiteboard_component))
+        logger.info((b.id, b.whiteboard_component))
 
     if not advisory_id_map:
         logger.info("Skipping sorting/attaching Tracker Bugs. Advisories with attached builds must be given to "
@@ -275,7 +275,7 @@ def categorize_bugs_by_type(bugs: List[Bug], advisory_id_map: Dict[str, int], ma
             package_name = bug.whiteboard_component
             if package_name in packages:
                 found.add(bug)
-                click.echo(f"{kind} build found for #{bug.id}, {package_name} ")
+                logger.info(f"{kind} build found for #{bug.id}, {package_name} ")
                 bugs_by_type[kind].add(bug)
 
     not_found = set(tracker_bugs) - found

--- a/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliottlib/cli/find_bugs_sweep_cli.py
@@ -191,7 +191,7 @@ def find_and_attach_bugs(runtime: Runtime, advisory_id, default_advisory_type, m
 
     bugs = get_bugs_sweep(runtime, find_bugs_obj, brew_event, bug_tracker)
 
-    advisory_ids = common.get_default_advisories(runtime)
+    advisory_ids = runtime.get_default_advisories()
     bugs_by_type = categorize_bugs_by_type(bugs, advisory_ids,
                                            major_version=major_version)
     for kind, kind_bugs in bugs_by_type.items():
@@ -213,8 +213,7 @@ def find_and_attach_bugs(runtime: Runtime, advisory_id, default_advisory_type, m
     for advisory_type in sorted(advisory_types_to_attach):
         kind_bugs = bugs_by_type.get(advisory_type)
         if kind_bugs:
-            advisory_id = advisory_ids[advisory_type]
-            bug_tracker.attach_bugs(advisory_id, [b.id for b in kind_bugs], noop=noop, verbose=runtime.debug)
+            bug_tracker.attach_bugs(advisory_ids[advisory_type], [b.id for b in kind_bugs], noop=noop, verbose=runtime.debug)
     return bugs
 
 

--- a/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliottlib/cli/verify_attached_bugs_cli.py
@@ -150,10 +150,11 @@ class BugValidator:
                 bugs_not_found = expected - actual
                 extra_bugs = actual - expected
                 if bugs_not_found:
-                    self._complain(f'Bugs not found in {kind} advisory ({advisory_id}):'
+                    self._complain(f'Expected Bugs not found in {kind} advisory ({advisory_id}):'
                                    f' {[b.id for b in bugs_not_found]}')
                 if extra_bugs:
-                    self._complain(f'Extra bugs in {kind} advisory ({advisory_id}): {[b.id for b in extra_bugs]}')
+                    self._complain(f'Unexpected Bugs found in {kind} advisory ({advisory_id}):'
+                                   f' {[b.id for b in extra_bugs]}')
 
     async def verify_attached_flaws(self, advisory_bugs: Dict[int, List[Bug]]):
         futures = []

--- a/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliottlib/cli/verify_attached_bugs_cli.py
@@ -7,7 +7,7 @@ from errata_tool import Erratum
 
 
 from elliottlib import bzutil, constants, logutil
-from elliottlib.cli.common import cli, click_coroutine, pass_runtime, get_default_advisories
+from elliottlib.cli.common import cli, click_coroutine, pass_runtime
 from elliottlib.errata_async import AsyncErrataAPI, AsyncErrataUtils
 from elliottlib.runtime import Runtime
 from elliottlib.util import (exit_unauthenticated, green_print,
@@ -41,7 +41,7 @@ async def verify_attached_bugs_cli(runtime: Runtime, verify_bug_status: bool, ad
                    "correct release advisories, run with --assembly=<release>")
         advisory_id_map = {'?': a for a in advisories}
     else:
-        advisory_id_map = get_default_advisories(runtime)
+        advisory_id_map = runtime.get_default_advisories()
     if not advisory_id_map:
         red_print("No advisories specified on command line or in [group.yml|releases.yml]")
         exit(1)

--- a/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliottlib/cli/verify_attached_bugs_cli.py
@@ -7,13 +7,13 @@ from errata_tool import Erratum
 
 
 from elliottlib import bzutil, constants, logutil
-from elliottlib.cli.common import cli, click_coroutine, pass_runtime
+from elliottlib.cli.common import cli, click_coroutine, pass_runtime, get_default_advisories
 from elliottlib.errata_async import AsyncErrataAPI, AsyncErrataUtils
 from elliottlib.runtime import Runtime
 from elliottlib.util import (exit_unauthenticated, green_print,
                              minor_version_tuple, red_print)
 from elliottlib.bzutil import Bug, BugTracker
-from elliottlib.cli.find_bugs_sweep_cli import get_bugs_sweep, FindBugsSweep
+from elliottlib.cli.find_bugs_sweep_cli import get_bugs_sweep, FindBugsSweep, categorize_bugs_by_type
 
 logger = logutil.getLogger(__name__)
 
@@ -36,26 +36,38 @@ async def verify_attached_bugs_cli(runtime: Runtime, verify_bug_status: bool, ad
     Otherwise, prints the number of bugs in the advisories and exits with success.
     """
     runtime.initialize()
-    advisories = advisories or [a for a in runtime.group_config.get('advisories', {}).values()]
-    if not advisories:
-        red_print("No advisories specified on command line or in group.yml")
+    if advisories:
+        click.echo("WARNING: Cannot verify advisory bug sorting. To verify that bugs are attached to the "
+                   "correct release advisories, run with --assembly=<release>")
+        advisory_id_map = {'?': a for a in advisories}
+    else:
+        advisory_id_map = get_default_advisories(runtime)
+    if not advisory_id_map:
+        red_print("No advisories specified on command line or in [group.yml|releases.yml]")
         exit(1)
-    await verify_attached_bugs(runtime, verify_bug_status, advisories, verify_flaws, no_verify_blocking_bugs)
+    await verify_attached_bugs(runtime, verify_bug_status, advisory_id_map, verify_flaws, no_verify_blocking_bugs)
 
 
-async def verify_attached_bugs(runtime: Runtime, verify_bug_status: bool, advisories: Tuple[int, ...], verify_flaws: bool, no_verify_blocking_bugs: bool):
+async def verify_attached_bugs(runtime: Runtime, verify_bug_status: bool, advisory_id_map: Dict[str, int], verify_flaws:
+                               bool, no_verify_blocking_bugs: bool):
     validator = BugValidator(runtime, output="text")
     try:
         await validator.errata_api.login()
-        advisory_bug_map = validator.get_attached_bugs(advisories)
+        advisory_bug_map = validator.get_attached_bugs(list(advisory_id_map.values()))
         bugs = {b for bugs in advisory_bug_map.values() for b in bugs}
 
-        # bug.is_ocp_bug() filters by product/project, so we don't get flaw bugs or bugs of other products
+        # bug.is_ocp_bug() filters by product/project, so we don't get flaw bugs or bugs of other products or
+        # placeholder
         non_flaw_bugs = {b for b in bugs if b.is_ocp_bug()}
 
         validator.validate(non_flaw_bugs, verify_bug_status, no_verify_blocking_bugs)
+        validator.verify_bugs_advisory_type(non_flaw_bugs, advisory_id_map, advisory_bug_map)
         if verify_flaws:
             await validator.verify_attached_flaws(advisory_bug_map)
+        if validator.problems:
+            if validator.output != 'slack':
+                red_print("Some bug problems were listed above. Please investigate.")
+            exit(1)
     except GSSError:
         exit_unauthenticated()
     finally:
@@ -96,6 +108,10 @@ async def verify_bugs(runtime, verify_bug_status, output, no_verify_blocking_bug
         ocp_bugs.extend(bugs)
     try:
         validator.validate(ocp_bugs, verify_bug_status, no_verify_blocking_bugs)
+        if validator.problems:
+            if validator.output != 'slack':
+                red_print("Some bug problems were listed above. Please investigate.")
+            exit(1)
     finally:
         await validator.close()
 
@@ -123,11 +139,21 @@ class BugValidator:
         if verify_bug_status:
             self._verify_bug_status(non_flaw_bugs)
 
-        if self.problems:
-            if self.output != 'slack':
-                red_print("Some bug problems were listed above. Please investigate.")
-            exit(1)
-        green_print("All bugs were verified. This check doesn't cover CVE flaw bugs.")
+    def verify_bugs_advisory_type(self, non_flaw_bugs, advisory_id_map, advisory_bug_map):
+        bugs_by_type = categorize_bugs_by_type(non_flaw_bugs, advisory_id_map)
+        for kind, advisory_id in advisory_id_map.items():
+            if kind in ['metadata', '?']:
+                continue
+            actual = {b for b in advisory_bug_map[advisory_id] if b.is_ocp_bug()}
+            expected = bugs_by_type[kind]
+            if actual != expected:
+                bugs_not_found = expected - actual
+                extra_bugs = actual - expected
+                if bugs_not_found:
+                    self._complain(f'Bugs not found in {kind} advisory ({advisory_id}):'
+                                   f' {[b.id for b in bugs_not_found]}')
+                if extra_bugs:
+                    self._complain(f'Extra bugs in {kind} advisory ({advisory_id}): {[b.id for b in extra_bugs]}')
 
     async def verify_attached_flaws(self, advisory_bugs: Dict[int, List[Bug]]):
         futures = []
@@ -139,10 +165,6 @@ class BugValidator:
                                      f"attached-flaws: {[b.id for b in attached_flaws]}")
             futures.append(self._verify_attached_flaws_for(advisory_id, attached_trackers, attached_flaws))
         await asyncio.gather(*futures)
-        if self.problems:
-            red_print("Some bug problems were listed above. Please investigate.")
-            exit(1)
-        green_print("All CVE flaw bugs were verified.")
 
     async def _verify_attached_flaws_for(self, advisory_id: int, attached_trackers: Iterable[Bug], attached_flaws: Iterable[Bug]):
         # Retrieve flaw bugs for attached_tracker_bugs
@@ -234,9 +256,9 @@ class BugValidator:
             self._complain(f"On advisory {advisory_id}, bugs for the following CVEs are not attached but listed in "
                            f"advisory's `CVE Names` field: {', '.join(sorted(missing_cves))}")
 
-    def get_attached_bugs(self, advisory_ids: Iterable[str]) -> (Dict[int, Set[Bug]], Dict[int, Set[Bug]]):
+    def get_attached_bugs(self, advisory_ids: Iterable[str]) -> Dict[int, Set[Bug]]:
         """ Get bugs attached to specified advisories
-        :return: 2 dicts (one for jira bugs, one for bz bugs) with advisory id as key and set of bug objects as value
+        :return: a dict with advisory id as key and set of bug objects as value
         """
         green_print(f"Retrieving bugs for advisories: {advisory_ids}")
         advisories = [Erratum(errata_id=advisory_id) for advisory_id in advisory_ids]

--- a/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliottlib/cli/verify_attached_bugs_cli.py
@@ -10,8 +10,7 @@ from elliottlib import bzutil, constants, logutil
 from elliottlib.cli.common import cli, click_coroutine, pass_runtime
 from elliottlib.errata_async import AsyncErrataAPI, AsyncErrataUtils
 from elliottlib.runtime import Runtime
-from elliottlib.util import (exit_unauthenticated, green_print,
-                             minor_version_tuple, red_print)
+from elliottlib.util import (exit_unauthenticated, minor_version_tuple, red_print)
 from elliottlib.bzutil import Bug, BugTracker
 from elliottlib.cli.find_bugs_sweep_cli import get_bugs_sweep, FindBugsSweep, categorize_bugs_by_type
 
@@ -161,9 +160,9 @@ class BugValidator:
         for advisory_id, attached_bugs in advisory_bugs.items():
             attached_trackers = [b for b in attached_bugs if b.is_tracker_bug()]
             attached_flaws = [b for b in attached_bugs if b.is_flaw_bug()]
-            self.runtime.logger.info(f"Verifying advisory {advisory_id}: attached-trackers: "
-                                     f"{[b.id for b in attached_trackers]} "
-                                     f"attached-flaws: {[b.id for b in attached_flaws]}")
+            logger.info(f"Verifying advisory {advisory_id}: attached-trackers: "
+                        f"{[b.id for b in attached_trackers]} "
+                        f"attached-flaws: {[b.id for b in attached_flaws]}")
             futures.append(self._verify_attached_flaws_for(advisory_id, attached_trackers, attached_flaws))
         await asyncio.gather(*futures)
 
@@ -261,7 +260,7 @@ class BugValidator:
         """ Get bugs attached to specified advisories
         :return: a dict with advisory id as key and set of bug objects as value
         """
-        green_print(f"Retrieving bugs for advisories: {advisory_ids}")
+        logger.info(f"Retrieving bugs for advisories: {advisory_ids}")
         advisories = [Erratum(errata_id=advisory_id) for advisory_id in advisory_ids]
 
         attached_bug_map = {advisory_id: set() for advisory_id in advisory_ids}

--- a/elliottlib/errata.py
+++ b/elliottlib/errata.py
@@ -730,8 +730,6 @@ def get_advisory_nvrs(advisory):
     :return: dict, with keys as package names and values as strs in the form: '{version}-{release}'
     """
     try:
-        green_prefix("Fetching advisory builds: ")
-        click.echo("Advisory - {}".format(advisory))
         builds = get_builds(advisory)
     except GSSError:
         exit_unauthenticated()
@@ -740,12 +738,8 @@ def get_advisory_nvrs(advisory):
 
     all_advisory_nvrs = {}
     # Results come back with top level keys which are brew tags
-    green_prefix("Looping over tags: ")
-    click.echo("{} tags to check".format(len(builds)))
     for tag in builds.keys():
         # Each top level has a key 'builds' which is a list of dicts
-        green_prefix("Looping over builds in tag: ")
-        click.echo("{} with {} builds".format(tag, len(builds[tag]['builds'])))
         for build in builds[tag]['builds']:
             # Each dict has a top level key which might be the actual
             # 'nvr' but I don't have enough data to know for sure

--- a/elliottlib/runtime.py
+++ b/elliottlib/runtime.py
@@ -84,6 +84,9 @@ class Runtime(object):
     def get_major_minor(self):
         return self.group_config.vars.MAJOR, self.group_config.vars.MINOR
 
+    def get_default_advisories(self):
+        return self.group_config.get('advisories', {})
+
     def get_group_config(self):
         # group.yml can contain a `vars` section which should be a
         # single level dict containing keys to str.format(**dict) replace

--- a/tests/test_bzutil.py
+++ b/tests/test_bzutil.py
@@ -114,6 +114,33 @@ class TestBugzillaBugTracker(unittest.TestCase):
 
 
 class TestJIRABug(unittest.TestCase):
+    def test_is_placeholder_bug(self):
+        bug1 = flexmock(key='OCPBUGS-1',
+                        fields=flexmock(
+                            summary='Placeholder',
+                            components=[flexmock(name='Release')],
+                            labels=['Automation']))
+        self.assertEqual(JIRABug(bug1).is_placeholder_bug(), True)
+
+        bug2 = flexmock(key='OCPBUGS-2',
+                        fields=flexmock(
+                            summary='Placeholder',
+                            components=[flexmock(name='Foo')],
+                            labels=['Bar']))
+        self.assertEqual(JIRABug(bug2).is_placeholder_bug(), False)
+
+    def test_is_ocp_bug(self):
+        bug1 = flexmock(key='OCPBUGS-1', fields=flexmock(project=flexmock(key='foo')))
+        self.assertEqual(JIRABug(bug1).is_ocp_bug(), False)
+
+        bug2 = flexmock(key='OCPBUGS-1', fields=flexmock(project=flexmock(key='OCPBUGS')))
+        flexmock(JIRABug).should_receive("is_placeholder_bug").and_return(True)
+        self.assertEqual(JIRABug(bug2).is_ocp_bug(), False)
+
+        bug2 = flexmock(key='OCPBUGS-1', fields=flexmock(project=flexmock(key='OCPBUGS')))
+        flexmock(JIRABug).should_receive("is_placeholder_bug").and_return(False)
+        self.assertEqual(JIRABug(bug2).is_ocp_bug(), True)
+
     def test_is_tracker_bug(self):
         bug = flexmock(key='OCPBUGS1', fields=flexmock(labels=constants.TRACKER_BUG_KEYWORDS + ['somethingelse']))
         expected = True

--- a/tests/test_bzutil_jira.py
+++ b/tests/test_bzutil_jira.py
@@ -1,7 +1,6 @@
 import unittest
 from elliottlib.bzutil import JIRABugTracker
 from flexmock import flexmock
-from datetime import datetime
 
 
 class TestJIRABugTracker(unittest.TestCase):

--- a/tests/test_find_bugs_sweep_cli.py
+++ b/tests/test_find_bugs_sweep_cli.py
@@ -1,16 +1,16 @@
 import unittest
-import os
 from flexmock import flexmock
 from mock import patch, MagicMock, Mock
 from datetime import datetime, timezone
 from click.testing import CliRunner
 from elliottlib.cli.find_bugs_sweep_cli import FindBugsMode
 from elliottlib.bzutil import BugzillaBugTracker, JIRABugTracker
-from elliottlib.cli.find_bugs_sweep_cli import extras_bugs, get_assembly_bug_ids
+from elliottlib.cli.find_bugs_sweep_cli import extras_bugs, get_assembly_bug_ids, categorize_bugs_by_type
 from elliottlib.cli.common import cli, Runtime
 import xmlrpc.client
 import elliottlib.cli.find_bugs_sweep_cli as sweep_cli
 import elliottlib.bzutil as bzutil
+from elliottlib import errata
 from elliottlib.cli import common
 import traceback
 
@@ -36,47 +36,39 @@ class TestFindBugsMode(unittest.TestCase):
 class FindBugsSweepTestCase(unittest.TestCase):
     def test_find_bugs_sweep_report(self):
         runner = CliRunner()
+
+        # common mocks
         flexmock(Runtime).should_receive("initialize").and_return(None)
         flexmock(Runtime).should_receive("get_major_minor").and_return(4, 6)
+        flexmock(sweep_cli).should_receive("get_assembly_bug_ids").and_return(set(), set())
+        flexmock(common).should_receive("get_default_advisories").and_return({})
+        flexmock(sweep_cli).should_receive("categorize_bugs_by_type").and_return({})
 
         # jira mocks
-        jirabugs = [
-            flexmock(
-                key='OCPBUGS-1',
-                fields=flexmock(
-                    components=[flexmock(name='OLM')],
-                    status=flexmock(name='ON_QA'),
-                    summary='summary',
-                    created='2021-12-23T19:49:49.328+0000'
-                )
-            )
-        ]
-
+        jira_bug = flexmock(
+            id='OCPBUGS-1',
+            component='OLM',
+            status='ON_QA',
+            summary='summary',
+            created_days_ago=lambda: 7,
+        )
         flexmock(JIRABugTracker).should_receive("get_config").and_return({'target_release': ['4.6.z']})
-        client = flexmock()
-        flexmock(JIRABugTracker).should_receive("login").and_return(client)
-        client.should_receive("search_issues").and_return(jirabugs)
-        flexmock(sweep_cli).should_receive("get_assembly_bug_ids").and_return(set(), set())
-        flexmock(bzutil).should_receive("datetime_now").and_return(datetime(2022, 1, 21, tzinfo=timezone.utc))
+        flexmock(JIRABugTracker).should_receive("login")
+        flexmock(JIRABugTracker).should_receive("search").and_return([jira_bug])
 
         # bz mocks
-        bzbugs = [
-            flexmock(
-                id='BZ1',
-                creation_time=xmlrpc.client.DateTime("20210630T12:29:00"),
-                target_release=['4.6.z'],
-                cf_pm_score='score',
-                component='OLM',
-                status='ON_QA',
-                summary='summary'
-            )
-        ]
+        bz_bug = flexmock(
+            id='BZ1',
+            created_days_ago=lambda: 8,
+            cf_pm_score='score',
+            component='OLM',
+            status='ON_QA',
+            summary='summary'
+        )
 
         flexmock(BugzillaBugTracker).should_receive("get_config").and_return({'target_release': ['4.6.z']})
-        client = flexmock()
-        flexmock(BugzillaBugTracker).should_receive("login").and_return(client)
-        client.should_receive("url_to_query").and_return({})
-        client.should_receive("query").and_return(bzbugs)
+        flexmock(BugzillaBugTracker).should_receive("login")
+        flexmock(BugzillaBugTracker).should_receive("search").and_return([bz_bug])
 
         result = runner.invoke(cli, ['-g', 'openshift-4.6', 'find-bugs:sweep', '--report'])
         if result.exit_code != 0:
@@ -102,6 +94,7 @@ class FindBugsSweepTestCase(unittest.TestCase):
         ts = datetime(2021, 6, 30, 12, 30, 00, 0, tzinfo=timezone.utc).timestamp()
         flexmock(sweep_cli).should_receive("get_sweep_cutoff_timestamp").and_return(ts)
         flexmock(sweep_cli).should_receive("get_assembly_bug_ids").and_return(set(), set())
+        flexmock(common).should_receive("get_default_advisories").and_return({})
 
         # bz mocks
         flexmock(BugzillaBugTracker).should_receive("get_config").and_return({'target_release': ['4.6.z']})
@@ -124,6 +117,7 @@ class FindBugsSweepTestCase(unittest.TestCase):
         flexmock(Runtime).should_receive("initialize")
         flexmock(Runtime).should_receive("get_major_minor").and_return(4, 6)
         flexmock(sweep_cli).should_receive("get_assembly_bug_ids").and_return(set(), set())
+        flexmock(common).should_receive("get_default_advisories").and_return({})
 
         # jira mocks
         flexmock(JIRABugTracker).should_receive("get_config").and_return({'target_release': ['4.6.z']})
@@ -153,8 +147,8 @@ class FindBugsSweepTestCase(unittest.TestCase):
         flexmock(Runtime).should_receive("initialize")
         flexmock(Runtime).should_receive("get_major_minor").and_return(4, 6)
         flexmock(sweep_cli).should_receive("get_assembly_bug_ids").and_return(set(), set())
+        flexmock(common).should_receive("get_default_advisories").and_return({'image': 123})
         flexmock(sweep_cli).should_receive("categorize_bugs_by_type").and_return({"image": set(bugs)})
-        flexmock(common).should_receive("find_default_advisory").and_return(123)
 
         # jira mocks
         flexmock(JIRABugTracker).should_receive("get_config").and_return({'target_release': ['4.6.z']})
@@ -190,7 +184,8 @@ class FindBugsSweepTestCase(unittest.TestCase):
             "rpm": set(rpm_bugs),
             "extras": set(extras_bugs)
         })
-        flexmock(common).should_receive("find_default_advisory").times(6).and_return(123)
+        flexmock(common).should_receive("get_default_advisories").and_return({'image': 123, 'rpm': 123, 'extras': 123,
+                                                                              'metadata': 123})
 
         # bz mocks
         flexmock(BugzillaBugTracker).should_receive("get_config").and_return({'target_release': ['4.6.z']})
@@ -209,6 +204,36 @@ class FindBugsSweepTestCase(unittest.TestCase):
             exc_type, exc_value, exc_traceback = result.exc_info
             t = "\n".join(traceback.format_exception(exc_type, exc_value, exc_traceback))
             self.fail(t)
+
+
+class TestCategorizeBugsByType(unittest.TestCase):
+    def test_categorize_bugs_by_type(self):
+        advisory_id_map = {'image': 1, 'rpm': 2, 'extras': 3}
+        bugs = [
+            flexmock(id='OCPBUGS-1', is_tracker_bug=lambda: True, whiteboard_component='foo'),
+            flexmock(id='OCPBUGS-2', is_tracker_bug=lambda: True, whiteboard_component='bar'),
+            flexmock(id='OCPBUGS-3', is_tracker_bug=lambda: True, whiteboard_component='buzz'),
+            flexmock(id='OCPBUGS-4', is_tracker_bug=lambda: False),
+            flexmock(id='OCPBUGS-5', is_tracker_bug=lambda: False)
+        ]
+        builds_map = {
+            'image': {bugs[2].whiteboard_component: None},
+            'rpm': {bugs[1].whiteboard_component: None},
+            'extras': {bugs[0].whiteboard_component: None}
+        }
+
+        flexmock(sweep_cli).should_receive("extras_bugs").and_return({bugs[3]})
+        for kind in advisory_id_map.keys():
+            flexmock(errata).should_receive("get_advisory_nvrs").with_args(advisory_id_map[kind]).and_return(
+                builds_map[kind])
+        expected = {
+            'rpm': {bugs[1]},
+            'image': {bugs[4], bugs[2]},
+            'extras': {bugs[3], bugs[0]}
+        }
+
+        actual = categorize_bugs_by_type(bugs, advisory_id_map, 4)
+        self.assertEqual(expected, actual)
 
 
 class TestGenAssemblyBugIDs(unittest.TestCase):

--- a/tests/test_find_bugs_sweep_cli.py
+++ b/tests/test_find_bugs_sweep_cli.py
@@ -41,7 +41,7 @@ class FindBugsSweepTestCase(unittest.TestCase):
         flexmock(Runtime).should_receive("initialize").and_return(None)
         flexmock(Runtime).should_receive("get_major_minor").and_return(4, 6)
         flexmock(sweep_cli).should_receive("get_assembly_bug_ids").and_return(set(), set())
-        flexmock(common).should_receive("get_default_advisories").and_return({})
+        flexmock(Runtime).should_receive("get_default_advisories").and_return({})
         flexmock(sweep_cli).should_receive("categorize_bugs_by_type").and_return({})
 
         # jira mocks
@@ -94,7 +94,7 @@ class FindBugsSweepTestCase(unittest.TestCase):
         ts = datetime(2021, 6, 30, 12, 30, 00, 0, tzinfo=timezone.utc).timestamp()
         flexmock(sweep_cli).should_receive("get_sweep_cutoff_timestamp").and_return(ts)
         flexmock(sweep_cli).should_receive("get_assembly_bug_ids").and_return(set(), set())
-        flexmock(common).should_receive("get_default_advisories").and_return({})
+        flexmock(Runtime).should_receive("get_default_advisories").and_return({})
 
         # bz mocks
         flexmock(BugzillaBugTracker).should_receive("get_config").and_return({'target_release': ['4.6.z']})
@@ -117,7 +117,7 @@ class FindBugsSweepTestCase(unittest.TestCase):
         flexmock(Runtime).should_receive("initialize")
         flexmock(Runtime).should_receive("get_major_minor").and_return(4, 6)
         flexmock(sweep_cli).should_receive("get_assembly_bug_ids").and_return(set(), set())
-        flexmock(common).should_receive("get_default_advisories").and_return({})
+        flexmock(Runtime).should_receive("get_default_advisories").and_return({})
 
         # jira mocks
         flexmock(JIRABugTracker).should_receive("get_config").and_return({'target_release': ['4.6.z']})
@@ -147,7 +147,7 @@ class FindBugsSweepTestCase(unittest.TestCase):
         flexmock(Runtime).should_receive("initialize")
         flexmock(Runtime).should_receive("get_major_minor").and_return(4, 6)
         flexmock(sweep_cli).should_receive("get_assembly_bug_ids").and_return(set(), set())
-        flexmock(common).should_receive("get_default_advisories").and_return({'image': 123})
+        flexmock(Runtime).should_receive("get_default_advisories").and_return({'image': 123})
         flexmock(sweep_cli).should_receive("categorize_bugs_by_type").and_return({"image": set(bugs)})
 
         # jira mocks
@@ -184,7 +184,7 @@ class FindBugsSweepTestCase(unittest.TestCase):
             "rpm": set(rpm_bugs),
             "extras": set(extras_bugs)
         })
-        flexmock(common).should_receive("get_default_advisories").and_return({'image': 123, 'rpm': 123, 'extras': 123,
+        flexmock(Runtime).should_receive("get_default_advisories").and_return({'image': 123, 'rpm': 123, 'extras': 123,
                                                                               'metadata': 123})
 
         # bz mocks

--- a/tests/test_verify_attached_bugs_cli.py
+++ b/tests/test_verify_attached_bugs_cli.py
@@ -149,13 +149,13 @@ class VerifyAttachedBugs(unittest.TestCase):
         #     t = "\n".join(traceback.format_exception(exc_type, exc_value, exc_traceback))
         #     self.fail(t)
         self.assertEqual(result.exit_code, 1)
-        self.assertIn("Bugs not found in image advisory (1): ['OCPBUGS-3']",
+        self.assertIn("Expected Bugs not found in image advisory (1): ['OCPBUGS-3']",
                       result.output)
-        self.assertIn("Extra bugs in image advisory (1): ['OCPBUGS-1']",
+        self.assertIn("Unexpected Bugs found in image advisory (1): ['OCPBUGS-1']",
                       result.output)
-        self.assertIn("Bugs not found in extras advisory (3): ['OCPBUGS-1']",
+        self.assertIn("Expected Bugs not found in extras advisory (3): ['OCPBUGS-1']",
                       result.output)
-        self.assertIn("Extra bugs in extras advisory (3): ['OCPBUGS-3']",
+        self.assertIn("Unexpected Bugs found in extras advisory (3): ['OCPBUGS-3']",
                       result.output)
 
 

--- a/tests/test_verify_attached_bugs_cli.py
+++ b/tests/test_verify_attached_bugs_cli.py
@@ -123,7 +123,7 @@ class VerifyAttachedBugs(unittest.TestCase):
         flexmock(BugzillaBugTracker).should_receive("get_config").and_return({'project': 'OCPBUGS', 'target_release': [
             '4.6.z']})
         flexmock(BugzillaBugTracker).should_receive("login")
-        flexmock(verify_attached_bugs_cli).should_receive("get_default_advisories")\
+        flexmock(Runtime).should_receive("get_default_advisories")\
             .and_return({'image': 1, 'rpm': 2, 'extras': 3, 'metadata': 4})
 
         f = asyncio.Future()

--- a/tests/test_verify_attached_bugs_cli.py
+++ b/tests/test_verify_attached_bugs_cli.py
@@ -2,13 +2,14 @@ import unittest
 from click.testing import CliRunner
 from errata_tool import Erratum
 from elliottlib.cli.common import cli, Runtime
-from elliottlib.cli.verify_attached_bugs_cli import BugValidator, verify_bugs_cli
+from elliottlib.cli.verify_attached_bugs_cli import verify_bugs_cli
 import elliottlib.cli.find_bugs_sweep_cli as sweep_cli
+from elliottlib.cli.verify_attached_bugs_cli import BugValidator
+import elliottlib.cli.verify_attached_bugs_cli as verify_attached_bugs_cli
 from elliottlib.errata_async import AsyncErrataAPI
 from elliottlib.bzutil import JIRABugTracker, BugzillaBugTracker
 from flexmock import flexmock
 import asyncio
-import traceback
 
 
 def async_test(f):
@@ -66,7 +67,7 @@ class VerifyAttachedBugs(unittest.TestCase):
         self.assertEqual(result.exit_code, 1)
         self.assertIn('Regression possible: ON_QA bug OCPBUGS-2 is a backport of bug OCPBUGS-3 which has status ON_QA', result.output)
 
-    def test_verify_attached_bugs_cli(self):
+    def test_verify_attached_bugs_cli_fail(self):
         runner = CliRunner()
         advisory = flexmock(errata_id=123, jira_issues=["OCPBUGS-1", "OCPBUGS-2"], errata_bugs=[])
         flexmock(Runtime).should_receive("initialize")
@@ -110,6 +111,51 @@ class VerifyAttachedBugs(unittest.TestCase):
         #     self.fail(t)
         self.assertEqual(result.exit_code, 1)
         self.assertIn('Regression possible: ON_QA bug OCPBUGS-2 is a backport of bug OCPBUGS-3 which has status ON_QA',
+                      result.output)
+
+    def test_verify_attached_bugs_cli_fail_on_type(self):
+        runner = CliRunner()
+        flexmock(Runtime).should_receive("initialize")
+        flexmock(Runtime).should_receive("get_errata_config").and_return({})
+        flexmock(JIRABugTracker).should_receive("get_config").and_return({'project': 'OCPBUGS', 'target_release': [
+            '4.6.z']})
+        flexmock(JIRABugTracker).should_receive("login")
+        flexmock(BugzillaBugTracker).should_receive("get_config").and_return({'project': 'OCPBUGS', 'target_release': [
+            '4.6.z']})
+        flexmock(BugzillaBugTracker).should_receive("login")
+        flexmock(verify_attached_bugs_cli).should_receive("get_default_advisories")\
+            .and_return({'image': 1, 'rpm': 2, 'extras': 3, 'metadata': 4})
+
+        f = asyncio.Future()
+        f.set_result(None)
+        flexmock(AsyncErrataAPI).should_receive("login").and_return(f)
+
+        bugs = [
+            flexmock(id="OCPBUGS-1", is_ocp_bug=lambda: True),
+            flexmock(id="OCPBUGS-2", is_ocp_bug=lambda: True),
+            flexmock(id="OCPBUGS-3", is_ocp_bug=lambda: True)
+        ]
+        flexmock(BugValidator).should_receive("get_attached_bugs").and_return(
+            {1: {bugs[0]}, 2: {bugs[1]}, 3: {bugs[2]}}
+        )
+        flexmock(BugValidator).should_receive("validate").and_return()
+        flexmock(verify_attached_bugs_cli).should_receive("categorize_bugs_by_type").and_return(
+            {'image': {bugs[2]}, 'rpm': {bugs[1]}, 'extras': {bugs[0]}}
+        )
+
+        result = runner.invoke(cli, ['-g', 'openshift-4.6', '--assembly', '4.6.50', 'verify-attached-bugs'])
+        # if result.exit_code != 0:
+        #     exc_type, exc_value, exc_traceback = result.exc_info
+        #     t = "\n".join(traceback.format_exception(exc_type, exc_value, exc_traceback))
+        #     self.fail(t)
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn("Bugs not found in image advisory (1): ['OCPBUGS-3']",
+                      result.output)
+        self.assertIn("Extra bugs in image advisory (1): ['OCPBUGS-1']",
+                      result.output)
+        self.assertIn("Bugs not found in extras advisory (3): ['OCPBUGS-1']",
+                      result.output)
+        self.assertIn("Extra bugs in extras advisory (3): ['OCPBUGS-3']",
                       result.output)
 
 


### PR DESCRIPTION
[https://issues.redhat.com/browse/ART-3380](https://issues.redhat.com/browse/ART-3380)

This affects sweep and verify-attached-bugs, to rely on
bug sorting for cve tracker bugs, based on attached builds.

--check-builds will become default and deprecate, so 
we'll always skip attaching trackers if builds are not found

Test
- `elliott --assembly=4.9.48 --group=openshift-4.9 verify-attached-bugs --verify-flaws` 