### PR TITLE
attach-cve-flaws should remove CVEs if flaws are dropped

### DIFF
--- a/elliottlib/cli/attach_cve_flaws_cli.py
+++ b/elliottlib/cli/attach_cve_flaws_cli.py
@@ -192,17 +192,10 @@ def get_updated_advisory_rhsa(logger, cve_boilerplate: dict, advisory: Erratum, 
         )
 
     cve_names = [b.alias[0] for b in flaw_bugs]
-    if not advisory.cve_names:
-        cve_str = ' '.join(cve_names)
+    cve_str = ' '.join(cve_names)
+    if advisory.cve_names != cve_str:
         advisory.update(cve_names=cve_str)
         updated = True
-    else:
-        cves_not_in_cve_names = [n for n in cve_names if n not in advisory.cve_names]
-        if cves_not_in_cve_names:
-            s = ' '.join(cves_not_in_cve_names)
-            cve_str = f"{advisory.cve_names} {s}".strip()
-            advisory.update(cve_names=cve_str)
-            updated = True
 
     if updated:
         formatted_cve_list = '\n'.join([

--- a/tests/test_attach_cve_flaws_cli.py
+++ b/tests/test_attach_cve_flaws_cli.py
@@ -50,7 +50,7 @@ class TestAttachCVEFlawsCLI(unittest.TestCase):
             topic=boilerplate['topic'].format(IMPACT=impact)
         )
         advisory.update.assert_any_call(
-            cve_names='something CVE-123 CVE-456'
+            cve_names='CVE-123 CVE-456'
         )
         advisory.update.assert_any_call(
             security_impact=impact


### PR DESCRIPTION
If a flaw bug is dropped from the advisory, it should also be removed from the CVENames field of that advisory.