### PR TITLE
verify-cvp: OSBS 2 accommodation and regex fix

### DIFF
--- a/elliottlib/cvp.py
+++ b/elliottlib/cvp.py
@@ -222,8 +222,8 @@ class CVPInspector:
                 self._logger.info("Processing build log...")
                 # looking for lines in brew logs like
                 # `2020-07-18 10:52:00,888 - atomic_reactor.plugins.imagebuilder - INFO -  java-11-openjdk      i686   1:11.0.8.10-0.el7_8 rhel-server-rpms-x86_64  215 k`
-                pattern = re.compile(r"atomic_reactor\.plugins\.imagebuilder - INFO -\s+([\w-]+)\s+\w+\s+([\w.:-]+)\s+([\w.-]+)\s+[\d.]+\s+\w")
-                self._build_log_cache[(nvr, arch)] = build_log = [line for line in orig_build_log.splitlines() if "- atomic_reactor.plugins.imagebuilder - INFO -" in line and pattern.search(line)]
+                pattern = re.compile(r"atomic_reactor\.(?:plugins\.imagebuilder|tasks\.binary_container_build) - INFO -\s+(?P<name>[\w.-]+)\s+(?P<arch>\w+)\s+(?P<VRE>[\w.:-]+)\s+(?P<repo>[\w.-]+)\s+(?P<size>\d+\s+\w)")
+                self._build_log_cache[(nvr, arch)] = build_log = [line for line in orig_build_log.splitlines() if line and pattern.search(line)]
             return build_log
 
         for test_name, value in report.items():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,19 +1,17 @@
 aiohttp[speedups] >= 3.6
 click >= 8.1.3
-contextvars; python_version < '3.7'
 # errata-tool >= 1.27.1
 # Instead use errata-tool commit with fix
 errata-tool @ git+http://github.com/thegreyd/errata-tool.git@bad2cb9c3321a1179f018cd9ddcf1d51d634290b
 future
 koji >= 1.18
 semver
-pygit2 == 1.6.*; python_version == '3.6'
-pygit2; python_version > '3.6'
+pygit2
 python-bugzilla >= 3.2
 pyyaml
 requests
 requests_kerberos >= 0.13
 ruamel.yaml
 tenacity
-jira ~= 3.2.0  # Pin 3.2.0 until https://github.com/pycontribs/jira/issues/1486 is resolved.
+jira >= 3.4.1  # https://github.com/pycontribs/jira/issues/1486
 setuptools-scm


### PR DESCRIPTION
- Build logs of ovn-kubernetes-microshift image have lines like
```
2022-09-13 20:43:32,770 - atomic_reactor.plugins.imagebuilder - INFO -  openvswitch2.17                    x86_64  2.17.0-22.el8fdp  rhel-8-server-ose-rpms-embargoed-x86_64   16 M
2022-09-13 20:43:32,770 - atomic_reactor.plugins.imagebuilder - INFO -  python3-openvswitch2.17            x86_64  2.17.0-22.el8fdp  rhel-8-server-ose-rpms-embargoed-x86_64  238 k
```
We need to update the regex to allow package name to include a dot.

- OSBS 2 changed its logger name. Needs to update regex to match logs like
```
2022-09-22 22:22:24,813 - atomic_reactor.tasks.binary_container_build - INFO -  openvswitch2.17                    x86_64  2.17.0-22.el8fdp  rhel-8-server-ose-rpms-embargoed-x86_64   16 M
2022-09-22 22:22:24,813 - atomic_reactor.tasks.binary_container_build - INFO -  python3-openvswitch2.17            x86_64  2.17.0-22.el8fdp  rhel-8-server-ose-rpms-embargoed-x86_64  238 k
```