### PR TITLE
[ART-4877] Complain when Tracker Bugs don't have Tracker Keywords

### DIFF
--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -60,6 +60,9 @@ class Bug:
     def is_tracker_bug(self):
         return set(constants.TRACKER_BUG_KEYWORDS).issubset(set(self.keywords))
 
+    def is_cve_in_summary(self):
+        return re.search(r'^CVE-(\d+)-(\d+)', self.summary)
+
     def is_flaw_bug(self):
         return self.product == "Security Response" and self.component == "vulnerability"
 

--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -61,7 +61,7 @@ class Bug:
         return set(constants.TRACKER_BUG_KEYWORDS).issubset(set(self.keywords))
 
     def is_cve_in_summary(self):
-        return re.search(r'^CVE-(\d+)-(\d+)', self.summary)
+        return True if re.search(r'^CVE-\d+-\d+', self.summary) else False
 
     def is_flaw_bug(self):
         return self.product == "Security Response" and self.component == "vulnerability"

--- a/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliottlib/cli/find_bugs_sweep_cli.py
@@ -260,8 +260,7 @@ def categorize_bugs_by_type(bugs: List[Bug], advisory_id_map: Dict[str, int], ma
 
     warning_bug = [b.id for b in non_tracker_bugs if b.is_cve_in_summary()]
     if warning_bug:
-        logger.warn(f"Bug {warning_bug} have CVE number in summary but don't have tracker keywords "
-                    "need to check if they are missing CVE labels")
+        logger.warn(f"Bug {warning_bug} has CVE number in summary but does not have tracker keywords")
 
     if not advisory_id_map:
         logger.info("Skipping sorting/attaching Tracker Bugs. Advisories with attached builds must be given to "

--- a/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliottlib/cli/find_bugs_sweep_cli.py
@@ -258,6 +258,11 @@ def categorize_bugs_by_type(bugs: List[Bug], advisory_id_map: Dict[str, int], ma
     for b in tracker_bugs:
         logger.info((b.id, b.whiteboard_component))
 
+    warning_bug = [b.id for b in non_tracker_bugs if b.is_cve_in_summary()]
+    if warning_bug:
+        logger.warn(f"Bug {warning_bug} have CVE number in summary but don't have tracker keywords "
+                     "need to check if they are missing CVE labels")
+
     if not advisory_id_map:
         logger.info("Skipping sorting/attaching Tracker Bugs. Advisories with attached builds must be given to "
                     "validate trackers.")

--- a/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliottlib/cli/find_bugs_sweep_cli.py
@@ -261,7 +261,7 @@ def categorize_bugs_by_type(bugs: List[Bug], advisory_id_map: Dict[str, int], ma
     warning_bug = [b.id for b in non_tracker_bugs if b.is_cve_in_summary()]
     if warning_bug:
         logger.warn(f"Bug {warning_bug} have CVE number in summary but don't have tracker keywords "
-                     "need to check if they are missing CVE labels")
+                    "need to check if they are missing CVE labels")
 
     if not advisory_id_map:
         logger.info("Skipping sorting/attaching Tracker Bugs. Advisories with attached builds must be given to "

--- a/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliottlib/cli/verify_attached_bugs_cli.py
@@ -130,7 +130,7 @@ class BugValidator:
 
     def validate(self, non_flaw_bugs: Iterable[Bug], verify_bug_status: bool, no_verify_blocking_bugs: bool):
         non_flaw_bugs = self.filter_bugs_by_release(non_flaw_bugs, complain=True)
-
+        self._verify_bug_summary(non_flaw_bugs)
         if not no_verify_blocking_bugs:
             blocking_bugs_for = self._get_blocking_bugs_for(non_flaw_bugs)
             self._verify_blocking_bugs(blocking_bugs_for)
@@ -364,6 +364,12 @@ class BugValidator:
             if bug.status in ['CLOSED', 'Closed']:
                 status = f"{bug.status}: {bug.resolution}"
             self._complain(f"Bug {bug.id} has status {status}")
+
+    def _verify_bug_summary(self, bugs):
+        # complain about bugs that should be CVE
+        for bug in bugs:
+            if bug.is_cve_in_summary() and not bug.is_tracker_bug():
+                self._complain(f"Bug {bug.id} have CVE number in summary but don't have tracker keywords")
 
     def _complain(self, problem: str):
         red_print(problem)

--- a/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliottlib/cli/verify_attached_bugs_cli.py
@@ -374,7 +374,7 @@ class BugValidator:
         # complain about bugs that should be CVE
         for bug in bugs:
             if bug.is_cve_in_summary() and not bug.is_tracker_bug():
-                self._complain(f"Bug {bug.id} have CVE number in summary but don't have tracker keywords")
+                self._complain(f"Bug {bug.id} has CVE number in summary but does not have tracker keywords")
 
     def _complain(self, problem: str):
         red_print(problem)

--- a/tests/test_assertion.py
+++ b/tests/test_assertion.py
@@ -44,7 +44,7 @@ class TestAssert(unittest.TestCase):
         """
         Verify both positive and negative results for file test
         """
-        file_exists = "/etc/motd"
+        file_exists = "/etc/hosts"
         file_missing = "/tmp/doesnotexist"
         not_file = "/usr"
 

--- a/tests/test_bzutil.py
+++ b/tests/test_bzutil.py
@@ -16,6 +16,10 @@ class TestBug(unittest.TestCase):
         bug_obj = flexmock(id=2)
         self.assertEqual(Bug(bug_obj).bug.id, bug_obj.id)
 
+    def test_is_cve_in_summary(self):
+        bug_true = flexmock(id=1, summary="CVE-2022-0001")
+        self.assertEqual(BugzillaBug(bug_true).is_cve_in_summary(), True)
+
 
 class TestJIRABugTracker(unittest.TestCase):
     def test_get_config(self):

--- a/tests/test_find_bugs_sweep_cli.py
+++ b/tests/test_find_bugs_sweep_cli.py
@@ -213,8 +213,8 @@ class TestCategorizeBugsByType(unittest.TestCase):
             flexmock(id='OCPBUGS-1', is_tracker_bug=lambda: True, is_cve_in_summary=lambda: True, whiteboard_component='foo'),
             flexmock(id='OCPBUGS-2', is_tracker_bug=lambda: True, is_cve_in_summary=lambda: True, whiteboard_component='bar'),
             flexmock(id='OCPBUGS-3', is_tracker_bug=lambda: True, is_cve_in_summary=lambda: True, whiteboard_component='buzz'),
-            flexmock(id='OCPBUGS-4', is_tracker_bug=lambda: False, is_cve_in_summary=lambda: False),
-            flexmock(id='OCPBUGS-5', is_tracker_bug=lambda: False, is_cve_in_summary=lambda: False)
+            flexmock(id='OCPBUGS-4', is_tracker_bug=lambda: False, is_cve_in_summary=lambda: True),
+            flexmock(id='OCPBUGS-5', is_tracker_bug=lambda: False, is_cve_in_summary=lambda: True)
         ]
         builds_map = {
             'image': {bugs[2].whiteboard_component: None},

--- a/tests/test_find_bugs_sweep_cli.py
+++ b/tests/test_find_bugs_sweep_cli.py
@@ -210,11 +210,11 @@ class TestCategorizeBugsByType(unittest.TestCase):
     def test_categorize_bugs_by_type(self):
         advisory_id_map = {'image': 1, 'rpm': 2, 'extras': 3}
         bugs = [
-            flexmock(id='OCPBUGS-1', is_tracker_bug=lambda: True, whiteboard_component='foo'),
-            flexmock(id='OCPBUGS-2', is_tracker_bug=lambda: True, whiteboard_component='bar'),
-            flexmock(id='OCPBUGS-3', is_tracker_bug=lambda: True, whiteboard_component='buzz'),
-            flexmock(id='OCPBUGS-4', is_tracker_bug=lambda: False),
-            flexmock(id='OCPBUGS-5', is_tracker_bug=lambda: False)
+            flexmock(id='OCPBUGS-1', is_tracker_bug=lambda: True, is_cve_in_summary=lambda: True, whiteboard_component='foo'),
+            flexmock(id='OCPBUGS-2', is_tracker_bug=lambda: True, is_cve_in_summary=lambda: True, whiteboard_component='bar'),
+            flexmock(id='OCPBUGS-3', is_tracker_bug=lambda: True, is_cve_in_summary=lambda: True, whiteboard_component='buzz'),
+            flexmock(id='OCPBUGS-4', is_tracker_bug=lambda: False, is_cve_in_summary=lambda: False),
+            flexmock(id='OCPBUGS-5', is_tracker_bug=lambda: False, is_cve_in_summary=lambda: False)
         ]
         builds_map = {
             'image': {bugs[2].whiteboard_component: None},

--- a/tests/test_verify_attached_bugs_cli.py
+++ b/tests/test_verify_attached_bugs_cli.py
@@ -43,13 +43,15 @@ class VerifyAttachedBugs(unittest.TestCase):
 
         bugs = [
             flexmock(id="OCPBUGS-1", target_release=['4.6.z'], depends_on=['OCPBUGS-4'],
-                     status='ON_QA', is_ocp_bug=lambda: True),
+                     status='ON_QA', is_ocp_bug=lambda: True, is_tracker_bug=lambda: False, is_cve_in_summary=lambda: False),
             flexmock(id="OCPBUGS-2", target_release=['4.6.z'], depends_on=['OCPBUGS-3'],
-                     status='ON_QA', is_ocp_bug=lambda: True)
+                     status='ON_QA', is_ocp_bug=lambda: True, is_tracker_bug=lambda: False, is_cve_in_summary=lambda: False)
         ]
         depend_on_bugs = [
-            flexmock(id="OCPBUGS-3", target_release=['4.7.z'], status='ON_QA', is_ocp_bug=lambda: True),
-            flexmock(id="OCPBUGS-4", target_release=['4.7.z'], status='Release Pending', is_ocp_bug=lambda: True)
+            flexmock(id="OCPBUGS-3", target_release=['4.7.z'], status='ON_QA',
+                     is_ocp_bug=lambda: True, is_tracker_bug=lambda: False, is_cve_in_summary=lambda: False),
+            flexmock(id="OCPBUGS-4", target_release=['4.7.z'], status='Release Pending',
+                     is_ocp_bug=lambda: True, is_tracker_bug=lambda: False, is_cve_in_summary=lambda: False)
         ]
         flexmock(JIRABugTracker).should_receive("search")\
             .and_return(bugs)
@@ -59,7 +61,7 @@ class VerifyAttachedBugs(unittest.TestCase):
             .with_args({"OCPBUGS-3", "OCPBUGS-4"})\
             .and_return(depend_on_bugs)
 
-        result = runner.invoke(cli, ['-g', 'openshift-4.6', '--assembly=stream', 'verify-bugs'])
+        result = runner.invoke(cli, ['-g', 'openshift-4.6', '--assembly=stream', '--debug', 'verify-bugs'])
         # if result.exit_code != 0:
         #     exc_type, exc_value, exc_traceback = result.exc_info
         #     t = "\n".join(traceback.format_exception(exc_type, exc_value, exc_traceback))
@@ -86,13 +88,15 @@ class VerifyAttachedBugs(unittest.TestCase):
 
         bugs = [
             flexmock(id="OCPBUGS-1", target_release=['4.6.z'], depends_on=['OCPBUGS-4'],
-                     status='ON_QA', is_ocp_bug=lambda: True),
+                     status='ON_QA', is_ocp_bug=lambda: True, is_tracker_bug=lambda: False, is_cve_in_summary=lambda: False),
             flexmock(id="OCPBUGS-2", target_release=['4.6.z'], depends_on=['OCPBUGS-3'],
-                     status='ON_QA', is_ocp_bug=lambda: True)
+                     status='ON_QA', is_ocp_bug=lambda: True, is_tracker_bug=lambda: False, is_cve_in_summary=lambda: False)
         ]
         depend_on_bugs = [
-            flexmock(id="OCPBUGS-3", target_release=['4.7.z'], status='ON_QA', is_ocp_bug=lambda: True),
-            flexmock(id="OCPBUGS-4", target_release=['4.7.z'], status='Release Pending', is_ocp_bug=lambda: True)
+            flexmock(id="OCPBUGS-3", target_release=['4.7.z'], status='ON_QA',
+                     is_ocp_bug=lambda: True, is_tracker_bug=lambda: False, is_cve_in_summary=lambda: False),
+            flexmock(id="OCPBUGS-4", target_release=['4.7.z'], status='Release Pending',
+                     is_ocp_bug=lambda: True, is_tracker_bug=lambda: False, is_cve_in_summary=lambda: False)
         ]
 
         flexmock(JIRABugTracker).should_receive("get_bugs")\

--- a/tests/test_verify_attached_bugs_cli.py
+++ b/tests/test_verify_attached_bugs_cli.py
@@ -63,7 +63,7 @@ class VerifyAttachedBugs(unittest.TestCase):
             .with_args(bugs)\
             .and_return(blocking_bugs_map)
 
-        result = runner.invoke(cli, ['-g', 'openshift-4.6', '--assembly=stream', '--debug', 'verify-bugs'])
+        result = runner.invoke(cli, ['-g', 'openshift-4.6', '--assembly=4.6.6', 'verify-bugs'])
         # if result.exit_code != 0:
         #     exc_type, exc_value, exc_traceback = result.exc_info
         #     t = "\n".join(traceback.format_exception(exc_type, exc_value, exc_traceback))


### PR DESCRIPTION
ref: [ART-4877](https://issues.redhat.com//browse/ART-4877)
if a bug was backported to Jira, it might miss CVE-related labels but it has CVE feature in its summary and described in its description, so add a check to raise concern if we find such a mismatch in summary, it can be a filter that effect bug sweep and bug validate
