### PR TITLE
Do not trigger on Proposed Blockers

### DIFF
--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -577,7 +577,7 @@ class JIRABugTracker(BugTracker):
             status=status,
             with_target_release=True,
             search_filter=search_filter,
-            custom_query='and "Release Blocker" = "Approved" and "Release Blocker" = "Proposed"'
+            custom_query='and "Release Blocker" = "Approved"'
         )
         return self._search(query, verbose=verbose, **kwargs)
 


### PR DESCRIPTION
Following the
[announcement](https://groups.google.com/a/redhat.com/g/aos-devel/c/0j22YV-18no)  that bugs of high enough priority/severity, Release Blocker gets set to Proposed automatically. We should stop alerting on this.