### PR TITLE
fix ut warning

### DIFF
--- a/tests/test_assertion.py
+++ b/tests/test_assertion.py
@@ -44,7 +44,7 @@ class TestAssert(unittest.TestCase):
         """
         Verify both positive and negative results for file test
         """
-        file_exists = "/etc/motd"
+        file_exists = "/etc/hosts"
         file_missing = "/tmp/doesnotexist"
         not_file = "/usr"
 

--- a/tests/test_pushd.py
+++ b/tests/test_pushd.py
@@ -60,6 +60,7 @@ class DirTestCase(unittest.TestCase):
             pool.apply_async(lambda: self.test_getcwd(concurrent=True))
             for _ in range(thread_count)
         ]
+        pool.close()
         for result in results:
             result.get()
 

--- a/tests/test_verify_attached_bugs_cli.py
+++ b/tests/test_verify_attached_bugs_cli.py
@@ -12,15 +12,6 @@ from flexmock import flexmock
 import asyncio
 
 
-def async_test(f):
-    def wrapper(*args, **kwargs):
-        coro = asyncio.coroutine(f)
-        future = coro(*args, **kwargs)
-        loop = asyncio.get_event_loop()
-        loop.run_until_complete(future)
-    return wrapper
-
-
 class VerifyAttachedBugs(unittest.TestCase):
     def test_validator_target_release(self):
         runtime = Runtime()
@@ -96,12 +87,9 @@ class VerifyAttachedBugs(unittest.TestCase):
         }
 
         advisory_id = 123
-        flexmock(BugValidator).should_receive("get_attached_bugs")\
-            .with_args([advisory_id])\
-            .and_return({123: {bugs[0], bugs[1]}})
-        flexmock(BugValidator).should_receive("_get_blocking_bugs_for") \
-            .with_args(bugs) \
-            .and_return(blocking_bugs_map)
+        flexmock(BugValidator).should_receive("get_attached_bugs").with_args([advisory_id])\
+            .and_return({123: {bugs[0], bugs[1]}}).ordered()
+        flexmock(BugValidator).should_receive("_get_blocking_bugs_for").and_return(blocking_bugs_map).ordered()
         flexmock(BugValidator).should_receive("verify_bugs_advisory_type")
 
         result = runner.invoke(cli, ['-g', 'openshift-4.6', 'verify-attached-bugs', str(advisory_id)])


### PR DESCRIPTION
the previous ut has the following warning
```...............................................BZ 9 is ignored because its status was MODIFIED at the moment of sweep cutoff (2021-06-30 12:30:00), however its status changed back to ['ASSIGNED'] afterwards
...................No flaw bugs could be found for these trackers: {'OCPBUGS-2'}
...changed 123 from status1 to status2
.123 is already on status1
.changed 123 from status1 to status2
..changed 123 from status1 to status2
.123 is already on status1
.changed 123 from status1 to status2
................../mnt/workspace/jenkins/working/art-tools_elliott_PR-439/.tox/py38/lib64/python3.8/site-packages/aiohttp/connector.py:767: DeprecationWarning: The object should be created within an async function
  super().__init__(
/mnt/workspace/jenkins/working/art-tools_elliott_PR-439/.tox/py38/lib64/python3.8/site-packages/aiohttp/connector.py:778: DeprecationWarning: The object should be created within an async function
  resolver = DefaultResolver(loop=self._loop)
........./mnt/workspace/jenkins/working/art-tools_elliott_PR-439/elliottlib/errata_async.py:42: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
  resp.raise_for_status()
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
........................................../usr/lib64/python3.8/multiprocessing/pool.py:265: ResourceWarning: unclosed running multiprocessing pool <multiprocessing.pool.ThreadPool state=RUN pool_size=10>
  _warn(f"unclosed running multiprocessing pool {self!r}",
ResourceWarning: Enable tracemalloc to get the object allocation traceback
................/mnt/workspace/jenkins/working/art-tools_elliott_PR-439/elliottlib/errata_async.py:19: DeprecationWarning: The object should be created within an async function
  self._session = aiohttp.ClientSession(connector=aiohttp.TCPConnector(limit=32, force_close=True))
/mnt/workspace/jenkins/working/art-tools_elliott_PR-439/.tox/py38/lib64/python3.8/site-packages/aiohttp/cookiejar.py:67: DeprecationWarning: The object should be created within an async function
  super().__init__(loop=loop)
/mnt/workspace/jenkins/working/art-tools_elliott_PR-439/.tox/py38/lib64/python3.8/site-packages/aiohttp/client.py:342: ResourceWarning: Unclosed client session <aiohttp.client.ClientSession object at 0x7fcb0557a370>
  _warnings.warn(
ResourceWarning: Enable tracemalloc to get the object allocation traceback
Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x7fcb0557a370>
......
```
after fix it should looks like
```...............................................BZ 9 is ignored because its status was MODIFIED at the moment of sweep cutoff (2021-06-30 12:30:00), however its status changed back to ['ASSIGNED'] afterwards
...................No flaw bugs could be found for these trackers: {'OCPBUGS-2'}
...changed 123 from status1 to status2
.123 is already on status1
.changed 123 from status1 to status2
..changed 123 from status1 to status2
.123 is already on status1
.changed 123 from status1 to status2
..........................................................................................
----------------------------------------------------------------------
```