### PR TITLE
Sort CVEs better

### DIFF
--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -1048,7 +1048,7 @@ def sort_cve_bugs(bugs):
     def cve_sort_key(bug):
         impact = constants.security_impact_map[get_highest_security_impact([bug])]
         year, num = bug.alias[0].split("-")[1:]
-        return impact, -int(year), int(num)
+        return impact, -int(year), -int(num)
     return sorted(bugs, key=cve_sort_key, reverse=True)
 
 

--- a/tests/test_bzutil.py
+++ b/tests/test_bzutil.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone
 import logging
 import unittest
+from unittest.mock import Mock
 import xmlrpc.client
 
 from flexmock import flexmock
@@ -451,21 +452,18 @@ class TestBZUtil(unittest.TestCase):
     def test_sort_cve_bugs(self):
         flaw_bugs = [
             flexmock(alias=['CVE-2022-123'], severity='Low'),
-            flexmock(alias=['CVE-2022-456'], severity='urgent'),
+            flexmock(alias=['CVE-2022-9'], severity='urgent'),
+            flexmock(alias=['CVE-2022-10'], severity='urgent'),
             flexmock(alias=['CVE-2021-789'], severity='medium'),
             flexmock(alias=['CVE-2021-100'], severity='medium')
         ]
-        sort_list = bzutil.sort_cve_bugs(flaw_bugs)
-        expected = [
-            flexmock(alias=['CVE-2022-456'], severity='urgent'),
-            flexmock(alias=['CVE-2021-789'], severity='medium'),
-            flexmock(alias=['CVE-2021-100'], severity='medium'),
-            flexmock(alias=['CVE-2022-123'], severity='Low')
-        ]
-        self.assertEqual(expected[0].alias, sort_list[0].alias)
-        self.assertEqual(expected[1].alias, sort_list[1].alias)
-        self.assertEqual(expected[2].alias, sort_list[2].alias)
-        self.assertEqual(expected[3].alias, sort_list[3].alias)
+        sort_list = [b.alias[0] for b in bzutil.sort_cve_bugs(flaw_bugs)]
+
+        self.assertEqual('CVE-2022-9', sort_list[0])
+        self.assertEqual('CVE-2022-10', sort_list[1])
+        self.assertEqual('CVE-2021-100', sort_list[2])
+        self.assertEqual('CVE-2021-789', sort_list[3])
+        self.assertEqual('CVE-2022-123', sort_list[4])
 
     def test_is_first_fix_any_no_valid_trackers(self):
         tr = '4.8.0'


### PR DESCRIPTION
This should follow the spec: Order by Impact, then order by int.