### PR TITLE
fix error in attach-cve-flaws function

### DIFF
--- a/elliottlib/cli/attach_cve_flaws_cli.py
+++ b/elliottlib/cli/attach_cve_flaws_cli.py
@@ -87,9 +87,6 @@ async def attach_cve_flaws_cli(runtime: Runtime, advisory_id: int, noop: bool, d
             runtime.logger.error(traceback.format_exc())
             runtime.logger.error(f'Exception: {e}')
             exit_code = 1
-        finally:
-            if errata_api:
-                await errata_api.close()
     sys.exit(exit_code)
 
 

--- a/elliottlib/errata_async.py
+++ b/elliottlib/errata_async.py
@@ -36,7 +36,7 @@ class AsyncErrataAPI:
             kwargs["headers"] = self._headers
         async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(limit=32, force_close=True)) as session:
             async with session.request(method, self._errata_url + path, **kwargs) as resp:
-                await resp.raise_for_status()
+                resp.raise_for_status()
                 result = await (resp.json() if parse_json else resp.read())
         return result
 


### PR DESCRIPTION
the close function has been removed, no need to close it now
