### PR TITLE
ART 4875 Use new jira field "blocked by bugzilla" to check regressions

### DIFF
--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -196,6 +196,17 @@ class JIRABug(Bug):
         return [x.name for x in self.bug.fields.versions]
 
     @property
+    def blocked_by_bz(self):
+        # field "Blocked by Bugzilla Bug"
+        url = self.bug.fields.customfield_12322152
+        if not url:
+            return None
+        bug_id = re.search(r"id=(\d+)", url)
+        if not bug_id:
+            return None
+        return int(bug_id.groups()[0])
+
+    @property
     def target_release(self):
         # field "Target Version"
         return [x.name for x in self.bug.fields.customfield_12319940]
@@ -214,7 +225,11 @@ class JIRABug(Bug):
 
     @property
     def depends_on(self):
-        return self._get_depends()
+        depends_on = self._get_depends()
+        depends_on_bz = self.blocked_by_bz()
+        if depends_on_bz:
+            depends_on.append(depends_on_bz)
+        return depends_on
 
     @property
     def release_blocker(self):
@@ -283,6 +298,7 @@ class JIRABug(Bug):
         return ('Placeholder' in self.summary) and (self.component == 'Release') and ('Automation' in self.keywords)
 
     def _get_blocks(self):
+        # link "blocks"
         blocks = []
         for link in self.bug.fields.issuelinks:
             if link.type.name == "Blocks" and hasattr(link, "outwardIssue"):
@@ -290,6 +306,7 @@ class JIRABug(Bug):
         return blocks
 
     def _get_depends(self):
+        # link "is blocked by"
         depends = []
         for link in self.bug.fields.issuelinks:
             if link.type.name == "Blocks" and hasattr(link, "inwardIssue"):

--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -226,7 +226,7 @@ class JIRABug(Bug):
     @property
     def depends_on(self):
         depends_on = self._get_depends()
-        depends_on_bz = self.blocked_by_bz()
+        depends_on_bz = self.blocked_by_bz
         if depends_on_bz:
             depends_on.append(depends_on_bz)
         return depends_on

--- a/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliottlib/cli/verify_attached_bugs_cli.py
@@ -309,6 +309,7 @@ class BugValidator:
         if bz_ids:
             blockers.extend(self.runtime.bug_trackers('bugzilla')
                             .get_bugs(bz_ids))
+        logger.debug(f"Candidate Blocker bugs found: {[b.id for b in blockers]}")
         blocking_bugs = {}
         for bug in blockers:
             next_target = any(is_next_target(target) for target in bug.target_release)

--- a/tests/test_bzutil.py
+++ b/tests/test_bzutil.py
@@ -115,6 +115,18 @@ class TestBugzillaBugTracker(unittest.TestCase):
 
 
 class TestJIRABug(unittest.TestCase):
+    def test_blocked_by_bz(self):
+        bug_id = 123456
+        bug = flexmock(key='OCPBUGS-1',
+                       fields=flexmock(customfield_12322152=f'bugzilla.com/id={bug_id}'))
+        self.assertEqual(JIRABug(bug).blocked_by_bz, bug_id)
+
+    def test_depends_on(self):
+        bug = flexmock(key='OCPBUGS-1')
+        flexmock(JIRABug).should_receive("_get_depends").and_return(['foo'])
+        flexmock(JIRABug).should_receive("blocked_by_bz").and_return('bar')
+        self.assertEqual(JIRABug(bug).depends_on, ['foo', 'bar'])
+
     def test_is_placeholder_bug(self):
         bug1 = flexmock(key='OCPBUGS-1',
                         fields=flexmock(

--- a/tests/test_verify_attached_bugs_cli.py
+++ b/tests/test_verify_attached_bugs_cli.py
@@ -197,7 +197,7 @@ class TestBugValidator(unittest.TestCase):
 
         bugs = [
             flexmock(id="OCPBUGS-1", target_release=['4.6.z'], depends_on=['OCPBUGS-4']),
-            flexmock(id="OCPBUGS-2", target_release=['4.6.z'], depends_on=['OCPBUGS-3', 1]),
+            flexmock(id="OCPBUGS-2", target_release=['4.6.z'], depends_on=['OCPBUGS-3', 4]),
             flexmock(id=2, target_release=['4.6.z'], depends_on=[1, 3])
         ]
         depend_on_jira_bugs = [
@@ -206,7 +206,8 @@ class TestBugValidator(unittest.TestCase):
         ]
         depend_on_bz_bugs = [
             flexmock(id=1, target_release=['4.7.z'], component='foo', is_ocp_bug=lambda: True),
-            flexmock(id=3, target_release=['4.7.z'], component='not_managed_by_art', is_ocp_bug=lambda: True)
+            flexmock(id=3, target_release=['4.7.z'], component='not_managed_by_art', is_ocp_bug=lambda: True),
+            flexmock(id=4, target_release=['4.7.z'], component='foo', is_ocp_bug=lambda: True),
         ]
 
         flexmock(JIRABugTracker).should_receive("get_bugs") \
@@ -221,7 +222,7 @@ class TestBugValidator(unittest.TestCase):
         actual = validator._get_blocking_bugs_for(bugs)
         expected = {
             bugs[0]: [depend_on_jira_bugs[1]],
-            bugs[1]: [depend_on_bz_bugs[0]],
+            bugs[1]: [depend_on_bz_bugs[2]],
             bugs[2]: [depend_on_bz_bugs[0]]
         }
         self.assertEqual(actual, expected)


### PR DESCRIPTION
https://issues.redhat.com/browse/ART-4875

Test
- Test 4.6 Bug with jira and bz blocker https://issues.redhat.com/browse/OCPBUGS-8
- `./elliott --debug --assembly=stream --group=openshift-4.6 verify-bugs`
- Look for `DEBUG Candidate Blocker bugs found: ['OCPBUGS-1', 1826920, ...]`