### PR TITLE
[RHELWF-7726] increase page size to 1000

### DIFF
--- a/elliottlib/errata_async.py
+++ b/elliottlib/errata_async.py
@@ -62,7 +62,7 @@ class AsyncErrataAPI:
     async def get_cve_package_exclusions(self, advisory_id: int):
         path = "/api/v1/cve_package_exclusion"
         # This is a paginated API, we need to increment page[number] until an empty array is returned.
-        params = {"filter[errata_id]": str(int(advisory_id)), "page[number]": 1, "page[size]": 300}
+        params = {"filter[errata_id]": str(int(advisory_id)), "page[number]": 1, "page[size]": 1000}
         while True:
             result = await self._make_request(aiohttp.hdrs.METH_GET, path, params=params)
             data: List[Dict] = result.get('data', [])

--- a/tests/test_errata_async.py
+++ b/tests/test_errata_async.py
@@ -122,7 +122,7 @@ class TestAsyncErrataAPI(TestCase):
             return items
 
         actual = get_event_loop().run_until_complete(_call())
-        _make_request.assert_awaited_with(ANY, 'GET', '/api/v1/cve_package_exclusion', params={'filter[errata_id]': '1', 'page[number]': 3, 'page[size]': 300})
+        _make_request.assert_awaited_with(ANY, 'GET', '/api/v1/cve_package_exclusion', params={'filter[errata_id]': '1', 'page[number]': 3, 'page[size]': 1000})
         self.assertEqual(actual, [{'id': 1}, {'id': 2}, {'id': 3}, {'id': 4}, {'id': 5}])
 
 


### PR DESCRIPTION
elliott verify-attached-bugs will raise such an error message
```
On advisory 103179, CVE-2022-30322 is associated with Brew components openshift-enterprise-cli-alt-container, ose-insights-operator-container without a tracker bug. You may need to explicitly exclude those Brew components from the CVE mapping or attach the corresponding tracker bugs.
On advisory 103179, CVE-2022-30323 is associated with Brew components kuryr-controller-container, ose-azure-disk-csi-driver-container without a tracker bug. You may need to explicitly exclude those Brew components from the CVE mapping or attach the corresponding tracker bugs.
On advisory 103179, CVE-2022-26945 is associated with Brew components cluster-monitoring-operator-container, ose-network-metrics-daemon-container without a tracker bug. You may need to explicitly exclude those Brew components from the CVE mapping or attach the corresponding tracker bugs.
Some bug problems were listed above. Please investigate.
```
it looks like pagination is not correctly working as expected, the [mapping info](https://errata.devel.redhat.com/api/v1/cve_package_exclusion?filter[errata_id]=103179&page[size]=300&page[number]=2) is on page 2
the issue is pagination on the server is not correctly ordered, ticket to this bug is [RHELWF-7726](https://issues.redhat.com/browse/RHELWF-7726)

this PR increases the page size to the maximum value of 1000 to reduce the odds of this error