### PR TITLE
verify-attached-operators print nvr for better readability

### DIFF
--- a/elliottlib/cli/verify_attached_operators_cli.py
+++ b/elliottlib/cli/verify_attached_operators_cli.py
@@ -163,16 +163,19 @@ def _missing_references(runtime, references, available):
         if digest in available:
             continue
         ref = image_pullspec.rsplit('/', 1)[1]  # cut off the registry/namespace, just need the name:shasum
+        res = ref
         try:
             nvr = _nvr_for_operand_pullspec(runtime, ref)
             build = brew.get_brew_build(nvr=nvr)
             if [ad for ad in build.all_errata if ad["status"] != "DROPPED_NO_SHIP"]:
                 continue
+            else:
+                res = nvr
         except BrewBuildException:
             # Fall through to missing.add
             pass
-        missing.add(ref)
-        red_print(f"{metadata} has a reference to {ref} not present in the advisories nor shipped images.")
+        missing.add(res)
+        red_print(f"{metadata} has a reference to {res} not present in the advisories nor shipped images.")
     return missing
 
 


### PR DESCRIPTION
in verify-attached-operators cli the output looks like
```
Some references were missing:
  ose-ghostunnel@sha256:09eaea8f5269770839ed13958fe4ff7ee7e4aecf5f41e1c8bee4fcb2047c2961
  ose-metering-hive@sha256:98101bf62a4afdb89985158fce21c347fbf844e0c73538121e009ef3a1bad4b9
  ose-metering-reporting-operator@sha256:2d908913e3309d18b7ea63184c77d491c98ec84c57d5fa37a1a014719bd3c43a
  ose-descheduler@sha256:c0fe8830f8fdcbe8e6d69b90f106d11086c67248fa484a013d410266327a4aed
Ensure all manifest references are shipped or shipping.
```
change the shasum to nvr for better readability