### PR TITLE
Skip rhcos images in verify-payload

### DIFF
--- a/elliottlib/cli/__main__.py
+++ b/elliottlib/cli/__main__.py
@@ -207,6 +207,7 @@ written out to summary_results.json.
 
     """
     runtime.initialize()
+    rhcos_images = {c['name'] for c in rhcos.get_container_configs(runtime)}
     all_advisory_nvrs = elliottlib.errata.get_advisory_nvrs(advisory)
 
     click.echo("Found {} builds".format(len(all_advisory_nvrs)))
@@ -248,7 +249,6 @@ written out to summary_results.json.
         # The machine-os-content image doesn't follow the standard
         # pattern. We need to skip that image when we find it, it is
         # not attached to advisories.
-        rhcos_images = [c['name'] for c in rhcos.get_container_configs(runtime)]
         if image_name in rhcos_images:
             yellow_prefix(f"Skipping rhcos image {image_name}: ")
             click.echo("Not required for checks")

--- a/elliottlib/cli/__main__.py
+++ b/elliottlib/cli/__main__.py
@@ -203,7 +203,7 @@ written out to summary_results.json.
      advisory 41567
 
  \b
-    $ elliott verify-payload quay.io/openshift-release-dev/ocp-release:4.1.0-rc.6 41567
+    $ elliott -g openshift-1 verify-payload quay.io/openshift-release-dev/ocp-release:4.1.0-rc.6 41567
 
     """
     runtime.initialize()

--- a/elliottlib/rhcos.py
+++ b/elliottlib/rhcos.py
@@ -1,7 +1,25 @@
 import json
 from tenacity import retry, stop_after_attempt, wait_fixed
 from urllib import request
+from elliottlib.model import ListModel
 from elliottlib import util, exectools, constants
+
+# Historically the only RHCOS container was 'machine-os-content'; see
+# https://github.com/openshift/machine-config-operator/blob/master/docs/OSUpgrades.md
+# But in the future this will change, see
+# https://github.com/coreos/enhancements/blob/main/os/coreos-layering.md
+default_primary_container = dict(
+    name="machine-os-content",
+    build_metadata_key="oscontainer",
+    primary=True)
+
+
+def get_container_configs(runtime):
+    """
+    look up the group.yml configuration for RHCOS container(s) for this group, or create if missing.
+    @return ListModel with Model entries like ^^ default_primary_container
+    """
+    return runtime.group_config.rhcos.payload_tags or ListModel([default_primary_container])
 
 
 def release_url(version, arch="x86_64", private=False):


### PR DESCRIPTION
We want to skip rhel-coreos and rhel-coreos-extensions images
in verify-payload so it doesn't fail.

https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fprepare-release/551/consoleFull

Test:
`elliott --group=openshift-4.12 --assembly rc.0 verify-payload registry.ci.openshift.org/ocp-arm64/release-arm64:4.12.0-0.nightly-arm64-2022-11-10-033917 104601`