### PR TITLE
Verify bugs are not attached to multiple advisories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ install:
 	./venv/bin/pip install -r requirements-dev.txt
 
 venv:
-	python3 -m venv venv
+	python3.8 -m venv venv
 	# source venv/bin/activate
 
 lint:

--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -56,11 +56,10 @@ class Bug:
         raise NotImplementedError
 
     @property
-    def all_advisory_ids(self):
+    def whiteboard_component(self):
         raise NotImplementedError
 
-    @property
-    def whiteboard_component(self):
+    def all_advisory_ids(self):
         raise NotImplementedError
 
     def is_tracker_bug(self):
@@ -134,10 +133,6 @@ class BugzillaBug(Bug):
             return None
 
     @property
-    def all_advisory_ids(self):
-        return ErrataBug(self.id).all_advisory_ids
-
-    @property
     def corresponding_flaw_bug_ids(self):
         return self.bug.blocks
 
@@ -156,6 +151,9 @@ class BugzillaBug(Bug):
             component_name = tmp.groups()[0]
             return component_name
         return None
+
+    def all_advisory_ids(self):
+        return ErrataBug(self.id).all_advisory_ids
 
     def is_ocp_bug(self):
         return self.product == constants.BUGZILLA_PRODUCT_OCP
@@ -203,10 +201,6 @@ class JIRABug(Bug):
                 if match:
                     flaw_bug_ids.append(match[1])
         return [int(f) for f in flaw_bug_ids]
-
-    @property
-    def all_advisory_ids(self):
-        return ErrataJira(self.id).all_advisory_ids
 
     @property
     def version(self):
@@ -304,6 +298,9 @@ class JIRABug(Bug):
             if "Low" in self.bug.fields.customfield_12316142.value:
                 return "Low"
         return None
+
+    def all_advisory_ids(self):
+        return ErrataJira(self.id).all_advisory_ids
 
     def creation_time_parsed(self):
         return datetime.strptime(str(self.bug.fields.created), '%Y-%m-%dT%H:%M:%S.%f%z')

--- a/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliottlib/cli/verify_attached_bugs_cli.py
@@ -154,7 +154,7 @@ class BugValidator:
                                    f' {[b.id for b in extra_bugs]}')
 
     def verify_bugs_multiple_advisories(self, non_flaw_bugs: List[Bug]):
-        logger.info(f'Making sure bugs are not attached to multiple advisories..')
+        logger.info('Making sure bugs are not attached to multiple advisories..')
         for bug in non_flaw_bugs:
             all_advisories_id = bug.all_advisory_ids
             if len(all_advisories_id) > 1:

--- a/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliottlib/cli/verify_attached_bugs_cli.py
@@ -154,7 +154,7 @@ class BugValidator:
                                    f' {[b.id for b in extra_bugs]}')
 
     async def verify_bugs_multiple_advisories(self, non_flaw_bugs: List[Bug]):
-        logger.info(f'Checking if bugs ({len(non_flaw_bugs)}) are attached to multiple advisories')
+        logger.info(f'Checking {len(non_flaw_bugs)} bugs, if any bug is attached to multiple advisories')
 
         async def get_all_advisory_ids(bug):
             all_advisories_id = bug.all_advisory_ids()

--- a/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliottlib/cli/verify_attached_bugs_cli.py
@@ -156,7 +156,7 @@ class BugValidator:
     def verify_bugs_multiple_advisories(self, non_flaw_bugs: List[Bug]):
         logger.info('Making sure bugs are not attached to multiple advisories..')
         for bug in non_flaw_bugs:
-            all_advisories_id = bug.all_advisory_ids
+            all_advisories_id = bug.all_advisory_ids()
             if len(all_advisories_id) > 1:
                 self._complain(f'Bug {bug.id} is attached in multiple advisories: {all_advisories_id}')
 

--- a/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliottlib/cli/verify_attached_bugs_cli.py
@@ -5,7 +5,6 @@ import click
 from spnego.exceptions import GSSError
 from errata_tool import Erratum
 
-
 from elliottlib import bzutil, constants, logutil
 from elliottlib.cli.common import cli, click_coroutine, pass_runtime
 from elliottlib.errata_async import AsyncErrataAPI, AsyncErrataUtils
@@ -60,7 +59,13 @@ async def verify_attached_bugs(runtime: Runtime, verify_bug_status: bool, adviso
         non_flaw_bugs = [b for b in bugs if b.is_ocp_bug()]
 
         validator.validate(non_flaw_bugs, verify_bug_status, no_verify_blocking_bugs)
-        validator.verify_bugs_advisory_type(non_flaw_bugs, advisory_id_map, advisory_bug_map)
+
+        # skip advisory type check if advisories are
+        # manually passed in and we don't know their type
+        if '?' not in advisory_id_map.keys():
+            validator.verify_bugs_advisory_type(non_flaw_bugs, advisory_id_map, advisory_bug_map)
+
+        validator.verify_bugs_multiple_advisories(non_flaw_bugs)
         if verify_flaws:
             await validator.verify_attached_flaws(advisory_bug_map)
         if validator.problems:
@@ -134,7 +139,7 @@ class BugValidator:
     def verify_bugs_advisory_type(self, non_flaw_bugs, advisory_id_map, advisory_bug_map):
         bugs_by_type = categorize_bugs_by_type(non_flaw_bugs, advisory_id_map)
         for kind, advisory_id in advisory_id_map.items():
-            if kind in ['metadata', '?']:
+            if kind in ['metadata']:
                 continue
             actual = {b for b in advisory_bug_map[advisory_id] if b.is_ocp_bug()}
             expected = bugs_by_type[kind]
@@ -147,6 +152,13 @@ class BugValidator:
                 if extra_bugs:
                     self._complain(f'Unexpected Bugs found in {kind} advisory ({advisory_id}):'
                                    f' {[b.id for b in extra_bugs]}')
+
+    def verify_bugs_multiple_advisories(self, non_flaw_bugs: List[Bug]):
+        logger.info(f'Making sure bugs are not attached to multiple advisories..')
+        for bug in non_flaw_bugs:
+            all_advisories_id = bug.all_advisory_ids
+            if len(all_advisories_id) > 1:
+                self._complain(f'Bug {bug.id} is attached in multiple advisories: {all_advisories_id}')
 
     async def verify_attached_flaws(self, advisory_bugs: Dict[int, List[Bug]]):
         futures = []


### PR DESCRIPTION
We can have a case where a non flaw bug can be attached to multiple advisories

```
curl -sSL --negotiate --user : https://errata.devel.redhat.com/jira_issues/OCPBUGS-35
71/advisories.json | jq -r '.[].advisory_name'
```

Verify that's not the case. Placeholder bugs are excluded so they are not included in this check,
so you won't see the above bug as a complain, but this should catch any other bugs.

Test
- elliott -g openshift-4.11 verify-attached-bugs 105365 --no-verify-blocking-bugs
