### PR TITLE
fix advisory exception

### DIFF
--- a/elliottlib/errata.py
+++ b/elliottlib/errata.py
@@ -642,6 +642,7 @@ def add_jira_bugs_with_retry(advisory_id: int, bugids: List[str], noop: bool = F
             attached_bugs = re.findall("Issue (.*) The issue is filed already in", str(e))
             if attached_bugs:
                 chunk_of_bugs = [b for b in chunk_of_bugs if b not in [b.upper() for b in attached_bugs]]
+                advisory = Erratum(errata_id=advisory_id)
                 advisory.addJiraIssues(chunk_of_bugs)
                 advisory.commit()
             else:


### PR DESCRIPTION
the first commit's exception didn't close, the exception will be raised in the second commit, like in the following example, the advisory object already raised an exception in the first commit, it will re-raised in the second commit
It can be solved by recreate Erratum object
```
>>> advisory = Erratum(errata_id=105587)
>>> advisory.addJiraIssues(['OCPBUGS-754'])
>>> advisory.commit()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/ximhan/Library/Python/3.9/lib/python/site-packages/errata_tool/erratum.py", line 954, in commit
    self._write()
  File "/Users/ximhan/Library/Python/3.9/lib/python/site-packages/errata_tool/erratum.py", line 913, in _write
    self._processResponse(r)
  File "/Users/ximhan/Library/Python/3.9/lib/python/site-packages/errata_tool/connector.py", line 239, in _processResponse
    raise ErrataException(err_msg)
errata_tool.exception.ErrataException: Erratum 105587: idsfixed: Issue ocpbugs-754 The issue is filed already in RHBA-2022:6372.

>>> advisory.addJiraIssues([])
>>> advisory.commit()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/ximhan/Library/Python/3.9/lib/python/site-packages/errata_tool/erratum.py", line 954, in commit
    self._write()
  File "/Users/ximhan/Library/Python/3.9/lib/python/site-packages/errata_tool/erratum.py", line 913, in _write
    self._processResponse(r)
  File "/Users/ximhan/Library/Python/3.9/lib/python/site-packages/errata_tool/connector.py", line 239, in _processResponse
    raise ErrataException(err_msg)
errata_tool.exception.ErrataException: Erratum 105587: idsfixed: Issue ocpbugs-754 The issue is filed already in RHBA-2022:6372.

>>> advisory = Erratum(errata_id=105587)
>>> advisory.addJiraIssues([])
>>> advisory.commit()
False
```