### PR TITLE
Ignore component:assisted-installer-container bugs

### DIFF
--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -922,6 +922,10 @@ def _construct_query_url(config, status, search_filter='default', flag=None):
     for f in filter_list:
         query_url.addFilter('component', 'notequals', f)
 
+    # CVEs for this image get filed into component that we need to look at. As this is about a
+    # deprecated system and fixing config is not an option, hard code this exclusion:
+    query_url.addFilter('status_whiteboard', 'notsubstring', 'component:assisted-installer-container')
+
     for s in status:
         query_url.addBugStatus(s)
 


### PR DESCRIPTION
Component and subcomponent info does not match reality. We should not sweep assisted-installer bugs into OCP advisories. As there are only two more bugs that potentially will be swept, hard code a hack in the deprecated class.

Before:
```
$ elliott -g openshift-4.11 find-bugs:sweep --dry-run
...
2022-11-24 17:36:45,659 INFO Tracker Bugs found: 2
2022-11-24 17:36:45,659 INFO (2067863, 'ose-multus-admission-controller-container')
2022-11-24 17:36:45,659 INFO (2068230, 'assisted-installer-container')
```

After, 2068230 is not found.