### PR TITLE
Migrate from requests_kerberos to requests-gssapi

### DIFF
--- a/elliottlib/brew.py
+++ b/elliottlib/brew.py
@@ -15,7 +15,7 @@ from typing import Dict, Iterable, List, Optional, Tuple, BinaryIO
 # 3rd party
 import koji
 import requests
-from requests_kerberos import HTTPKerberosAuth
+from requests_gssapi import HTTPSPNEGOAuth
 
 # ours
 from elliottlib import constants, exceptions, logutil
@@ -171,11 +171,11 @@ def get_brew_build(nvr, product_version='', session=None):
     if session is not None:
         res = session.get(constants.errata_get_build_url.format(id=nvr),
                           verify=ssl.get_default_verify_paths().openssl_cafile,
-                          auth=HTTPKerberosAuth())
+                          auth=HTTPSPNEGOAuth())
     else:
         res = requests.get(constants.errata_get_build_url.format(id=nvr),
                            verify=ssl.get_default_verify_paths().openssl_cafile,
-                           auth=HTTPKerberosAuth())
+                           auth=HTTPSPNEGOAuth())
     if res.status_code == 200:
         return Build(nvr=nvr, body=res.json(), product_version=product_version)
     else:

--- a/elliottlib/cli/__main__.py
+++ b/elliottlib/cli/__main__.py
@@ -69,7 +69,6 @@ from elliottlib.cli.repair_bugs_cli import repair_bugs_cli
 # 3rd party
 import click
 from errata_tool import ErrataException
-from spnego.exceptions import GSSError
 
 
 # -----------------------------------------------------------------------------
@@ -134,10 +133,7 @@ Fields for the short format: Release date, State, Synopsys, URL
         click.echo(advisory)
         return
 
-    try:
-        advisory = elliottlib.errata.Advisory(errata_id=advisory)
-    except GSSError:
-        exit_unauthenticated()
+    advisory = elliottlib.errata.Advisory(errata_id=advisory)
 
     if details:
         click.echo(advisory)

--- a/elliottlib/cli/add_metadata_cli.py
+++ b/elliottlib/cli/add_metadata_cli.py
@@ -7,9 +7,7 @@ from elliottlib.exceptions import ElliottFatalError
 from elliottlib.util import exit_unauthenticated, exit_unauthorized, ensure_erratatool_auth
 from elliottlib.util import release_from_branch, green_prefix, green_print, red_print
 
-from errata_tool import Erratum, ErrataException
-from spnego.exceptions import GSSError
-import requests
+from errata_tool import Erratum
 import click
 
 LOGGER = logutil.getLogger(__name__)
@@ -45,10 +43,7 @@ Example to add standard metadata to a 3.10 images release
     runtime.initialize()
     release = release_from_branch(runtime.group_config.branch)
 
-    try:
-        advisory = Erratum(errata_id=advisory)
-    except GSSError:
-        exit_unauthenticated()
+    advisory = Erratum(errata_id=advisory)
 
     result = elliottlib.errata.add_comment(
         advisory.errata_id, {'release': release, 'kind': kind, 'impetus': impetus})

--- a/elliottlib/cli/create_placeholder_cli.py
+++ b/elliottlib/cli/create_placeholder_cli.py
@@ -5,7 +5,6 @@ from elliottlib.exceptions import ElliottFatalError
 from elliottlib.util import exit_unauthenticated
 
 from errata_tool import Erratum
-from spnego.exceptions import GSSError
 import click
 
 LOGGER = logutil.getLogger(__name__)
@@ -59,10 +58,7 @@ def create_placeholder(kind, advisory_id, bug_tracker, noop):
     if not advisory_id:
         return
 
-    try:
-        advisory = Erratum(errata_id=advisory_id)
-    except GSSError:
-        exit_unauthenticated()
+    advisory = Erratum(errata_id=advisory_id)
 
     if advisory is False:
         raise ElliottFatalError(f"Error: Could not locate advisory {advisory_id}")

--- a/elliottlib/cli/find_builds_cli.py
+++ b/elliottlib/cli/find_builds_cli.py
@@ -6,8 +6,7 @@ from typing import Dict, List, Set, Union
 import click
 import koji
 import requests
-from errata_tool import Erratum, ErrataException
-from spnego.exceptions import GSSError
+from errata_tool import ErrataException
 
 import elliottlib
 from elliottlib import Runtime, brew, constants, errata, logutil
@@ -223,9 +222,6 @@ PRESENT advisory. Here are some examples:
             cdn_repos = et_data.get('cdn_repos')
             if cdn_repos and not no_cdn_repos and kind == "image":
                 erratum.set_cdn_repos(cdn_repos)
-
-    except GSSError:
-        exit_unauthenticated()
     except ErrataException as e:
         red_print(f'Cannot change advisory {advisory}: {e}')
         exit(1)

--- a/elliottlib/cli/list_cli.py
+++ b/elliottlib/cli/list_cli.py
@@ -1,6 +1,5 @@
 import click
 import elliottlib
-from spnego.exceptions import GSSError
 from elliottlib.util import exit_unauthenticated
 from elliottlib.exceptions import ElliottFatalError
 
@@ -40,7 +39,5 @@ yourself online: https://errata.devel.redhat.com/filter/1965
                        state=erratum.errata_state,
                        synopsis=erratum.synopsis,
                        url=erratum.url()))
-    except GSSError:
-        exit_unauthenticated()
     except elliottlib.exceptions.ErrataToolError as ex:
         raise ElliottFatalError(getattr(ex, 'message', repr(ex)))

--- a/elliottlib/cli/puddle_advisories_cli.py
+++ b/elliottlib/cli/puddle_advisories_cli.py
@@ -1,7 +1,6 @@
 import click
 import sys
 import elliottlib
-from spnego.exceptions import GSSError
 from elliottlib import logutil, Runtime
 from elliottlib.cli.common import cli
 from elliottlib.exceptions import ElliottFatalError
@@ -62,7 +61,5 @@ first comment.
                     sys.stderr.flush()
 
         click.echo(", ".join(use_in_puddle_conf))
-    except GSSError:
-        exit_unauthenticated()
     except elliottlib.exceptions.ErrataToolError as ex:
         raise ElliottFatalError(getattr(ex, 'message', repr(ex)))

--- a/elliottlib/cli/remove_bugs_cli.py
+++ b/elliottlib/cli/remove_bugs_cli.py
@@ -7,7 +7,6 @@ from elliottlib.util import green_prefix
 from elliottlib.bzutil import get_jira_bz_bug_ids, JIRABugTracker, BugzillaBugTracker
 
 from errata_tool import ErrataException
-from spnego.exceptions import GSSError
 
 LOGGER = logutil.getLogger(__name__)
 
@@ -55,10 +54,7 @@ def remove_bugs_cli(runtime, advisory_id, default_advisory_type, bug_ids, remove
     if default_advisory_type is not None:
         advisory_id = find_default_advisory(runtime, default_advisory_type)
 
-    try:
-        advisory = errata.Advisory(errata_id=advisory_id)
-    except GSSError:
-        exit_unauthenticated()
+    advisory = errata.Advisory(errata_id=advisory_id)
     if not advisory:
         raise ElliottFatalError(f"Error: Could not locate advisory {advisory_id}")
     attached_jira_ids = JIRABugTracker.advisory_bug_ids(advisory)

--- a/elliottlib/cli/validate_rhsa.py
+++ b/elliottlib/cli/validate_rhsa.py
@@ -3,7 +3,6 @@ from elliottlib.cli.common import cli
 from elliottlib.util import exit_unauthenticated
 
 from errata_tool import Erratum
-from spnego.exceptions import GSSError
 import click
 import json
 import koji
@@ -24,12 +23,9 @@ def validate_rhsa_cli(runtime, advisory):
     $ elliott validate-rhsa ID
 """
 
-    try:
-        if Erratum(errata_id=advisory).errata_type != 'RHSA':
-            print(f"Advisory {advisory} is not an RHSA. Nothing to check.")
-            exit(0)
-    except GSSError:
-        exit_unauthenticated()
+    if Erratum(errata_id=advisory).errata_type != 'RHSA':
+        print(f"Advisory {advisory} is not an RHSA. Nothing to check.")
+        exit(0)
 
     session = requests.Session()
     url = constants.SFM2_ERRATA_ALERTS_URL.format(id=advisory)

--- a/elliottlib/cli/verify_attached_operators_cli.py
+++ b/elliottlib/cli/verify_attached_operators_cli.py
@@ -1,7 +1,6 @@
 import click
 from io import BytesIO
 import koji
-from spnego.exceptions import GSSError
 import re
 import requests
 import yaml
@@ -66,14 +65,11 @@ def verify_attached_operators_cli(runtime, exclude_shipped, advisories):
 def _get_attached_image_builds(brew_session, advisories):
     # get all attached image builds
     build_nvrs = []
-    try:
-        for advisory in advisories:
-            green_print(f"Retrieving builds from advisory {advisory}")
-            advisory = Erratum(errata_id=advisory)
-            for build_list in advisory.errata_builds.values():  # one per product version
-                build_nvrs.extend(build_list)
-    except GSSError:
-        exit_unauthenticated()
+    for advisory in advisories:
+        green_print(f"Retrieving builds from advisory {advisory}")
+        advisory = Erratum(errata_id=advisory)
+        for build_list in advisory.errata_builds.values():  # one per product version
+            build_nvrs.extend(build_list)
 
     green_print(f"Found {len(build_nvrs)} builds")
     return [build for build in brew.get_build_objects(build_nvrs, brew_session) if _is_image(build)]

--- a/elliottlib/errata.py
+++ b/elliottlib/errata.py
@@ -17,7 +17,6 @@ from elliottlib import exceptions, constants, brew, logutil
 from elliottlib.util import green_prefix, green_print, exit_unauthenticated, chunk
 from elliottlib import bzutil
 from requests_gssapi import HTTPSPNEGOAuth
-from spnego.exceptions import GSSError
 from errata_tool import Erratum, ErrataException, ErrataConnector
 from typing import List
 
@@ -568,10 +567,7 @@ def add_bugzilla_bugs_with_retry(advisory_id: int, bugids: List, noop: bool = Fa
     :return:
     """
     logger.info(f'Request to attach {len(bugids)} bugs to the advisory {advisory_id}')
-    try:
-        advisory = Erratum(errata_id=advisory_id)
-    except GSSError:
-        exit_unauthenticated()
+    advisory = Erratum(errata_id=advisory_id)
 
     if not advisory:
         raise exceptions.ElliottFatalError(f"Error: Could not locate advisory {advisory_id}")
@@ -616,10 +612,7 @@ def add_jira_bugs_with_retry(advisory_id: int, bugids: List[str], noop: bool = F
     :param batch_size: perform operation in batches of given size
     """
     logger.info(f'Request to attach {len(bugids)} bugs to the advisory {advisory_id}')
-    try:
-        advisory = Erratum(errata_id=advisory_id)
-    except GSSError:
-        exit_unauthenticated()
+    advisory = Erratum(errata_id=advisory_id)
 
     if not advisory:
         raise exceptions.ElliottFatalError(f"Error: Could not locate advisory {advisory_id}")
@@ -723,8 +716,6 @@ def get_advisory_nvrs(advisory):
     """
     try:
         builds = get_builds(advisory)
-    except GSSError:
-        exit_unauthenticated()
     except exceptions.ErrataToolError as ex:
         raise exceptions.ElliottFatalError(getattr(ex, 'message', repr(ex)))
 
@@ -751,8 +742,6 @@ def get_all_advisory_nvrs(advisory):
     """
     try:
         builds = get_builds(advisory)
-    except GSSError:
-        exit_unauthenticated()
     except exceptions.ErrataToolError as ex:
         raise exceptions.ElliottFatalError(getattr(ex, 'message', repr(ex)))
 

--- a/elliottlib/errata.py
+++ b/elliottlib/errata.py
@@ -16,7 +16,7 @@ import requests
 from elliottlib import exceptions, constants, brew, logutil
 from elliottlib.util import green_prefix, green_print, exit_unauthenticated, chunk
 from elliottlib import bzutil
-from requests_kerberos import HTTPKerberosAuth
+from requests_gssapi import HTTPSPNEGOAuth
 from spnego.exceptions import GSSError
 from errata_tool import Erratum, ErrataException, ErrataConnector
 from typing import List
@@ -281,7 +281,7 @@ def build_signed(build):
     filter_endpoint = constants.errata_get_build_url.format(id=build)
     res = requests.get(filter_endpoint,
                        verify=ssl.get_default_verify_paths().openssl_cafile,
-                       auth=HTTPKerberosAuth())
+                       auth=HTTPSPNEGOAuth())
     if res.status_code == 200:
         return res.json()['rpms_signed']
     elif res.status_code == 401:
@@ -308,7 +308,7 @@ def get_filtered_list(filter_id=constants.errata_default_filter, limit=5):
     filter_endpoint = constants.errata_filter_list_url.format(id=filter_id)
     res = requests.get(filter_endpoint,
                        verify=ssl.get_default_verify_paths().openssl_cafile,
-                       auth=HTTPKerberosAuth())
+                       auth=HTTPSPNEGOAuth())
     if res.status_code == 200:
         # When asked for an advisory list which does not exist
         # normally you would expect a code like '404' (not
@@ -346,7 +346,7 @@ def add_comment(advisory_id, comment):
     data = {"comment": json.dumps(comment)}
     return requests.post(constants.errata_add_comment_url.format(id=advisory_id),
                          verify=ssl.get_default_verify_paths().openssl_cafile,
-                         auth=HTTPKerberosAuth(),
+                         auth=HTTPSPNEGOAuth(),
                          data=data)
 
 
@@ -388,7 +388,7 @@ def get_comments(advisory_id):
             constants.errata_get_comments_url,
             params=params,
             verify=ssl.get_default_verify_paths().openssl_cafile,
-            auth=HTTPKerberosAuth(),
+            auth=HTTPSPNEGOAuth(),
             json=body)
         if res.ok:
             data = res.json().get('data', [])
@@ -440,7 +440,7 @@ def get_builds(advisory_id, session=None):
         session = requests.session()
     res = session.get(constants.errata_get_builds_url.format(id=advisory_id),
                       verify=ssl.get_default_verify_paths().openssl_cafile,
-                      auth=HTTPKerberosAuth())
+                      auth=HTTPSPNEGOAuth())
     if res.status_code == 200:
         return res.json()
     else:
@@ -472,7 +472,7 @@ def get_brew_builds(errata_id, session=None):
 
     res = session.get(constants.errata_get_builds_url.format(id=errata_id),
                       verify=ssl.get_default_verify_paths().openssl_cafile,
-                      auth=HTTPKerberosAuth())
+                      auth=HTTPSPNEGOAuth())
     brew_list = []
     if res.status_code == 200:
         jlist = res.json()
@@ -512,7 +512,7 @@ def get_brew_build(nvr, product_version='', session=None):
 
     res = session.get(constants.errata_get_build_url.format(id=nvr),
                       verify=ssl.get_default_verify_paths().openssl_cafile,
-                      auth=HTTPKerberosAuth())
+                      auth=HTTPSPNEGOAuth())
 
     if res.status_code == 200:
         return brew.Build(nvr=nvr, body=res.json(), product_version=product_version)
@@ -534,7 +534,7 @@ def get_advisories_for_bug(bug_id, session=None):
         session = requests.session()
     r = session.get(constants.errata_get_advisories_for_bug_url.format(id=int(bug_id)),
                     verify=ssl.get_default_verify_paths().openssl_cafile,
-                    auth=HTTPKerberosAuth())
+                    auth=HTTPSPNEGOAuth())
     r.raise_for_status()
     return r.json()
 
@@ -676,7 +676,7 @@ def get_rpmdiff_runs(advisory_id, status=None, session=None):
         resp = session.get(
             url,
             params=params,
-            auth=HTTPKerberosAuth(),
+            auth=HTTPSPNEGOAuth(),
         )
         resp.raise_for_status()
         data = resp.json()["data"]

--- a/elliottlib/rpmdiff.py
+++ b/elliottlib/rpmdiff.py
@@ -1,7 +1,7 @@
 
 from builtins import object
 import requests
-from requests_kerberos import HTTPKerberosAuth
+from requests_gssapi import HTTPSPNEGOAuth
 
 
 class RPMDiffClient(object):
@@ -16,7 +16,7 @@ class RPMDiffClient(object):
         return resp.json()["token"]
 
     def authenticate(self):
-        token = self.get_token(HTTPKerberosAuth())
+        token = self.get_token(HTTPSPNEGOAuth())
         self.session.headers["Authorization"] = "Token " + token
 
     def get_run(self, run_id):

--- a/elliottlib/util.py
+++ b/elliottlib/util.py
@@ -10,7 +10,6 @@ from elliottlib import brew
 from elliottlib.exceptions import BrewBuildException
 
 from errata_tool import Erratum
-from spnego.exceptions import GSSError
 
 # -----------------------------------------------------------------------------
 # Constants and defaults
@@ -75,10 +74,7 @@ def exit_unauthorized():
 
 def ensure_erratatool_auth():
     """Test (cheaply) that we at least have authentication to erratatool"""
-    try:
-        Erratum(errata_id=1)
-    except GSSError:
-        exit_unauthenticated()
+    Erratum(errata_id=1)
 
 
 def validate_release_date(ctx, param, value):

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ pygit2 == 1.10.1  # https://github.com/libgit2/pygit2/issues/1176
 python-bugzilla >= 3.2
 pyyaml
 requests
-requests_kerberos >= 0.13
 requests-gssapi ~= 1.2.3
 ruamel.yaml
 tenacity

--- a/tests/test_brew.py
+++ b/tests/test_brew.py
@@ -143,8 +143,8 @@ class TestBrew(unittest.TestCase):
             .and_return(flexmock(openssl_cafile="/my/cert.pem")))
 
         (flexmock(errata)
-            .should_receive("HTTPKerberosAuth")
-            .and_return("MyHTTPKerberosAuth"))
+            .should_receive("HTTPSPNEGOAuth")
+            .and_return("MyHTTPSPNEGOAuth"))
 
         response = flexmock(status_code=200)
         response.should_receive("json").and_return(test_structures.rpm_build_attached_json)
@@ -155,7 +155,7 @@ class TestBrew(unittest.TestCase):
         (flexmock(errata.requests.Session)
             .should_receive("get")
             .with_args(constants.errata_get_build_url.format(id=nvr),
-                       auth="MyHTTPKerberosAuth",
+                       auth="MyHTTPSPNEGOAuth",
                        verify="/my/cert.pem")
             .and_return(response))
 
@@ -169,8 +169,8 @@ class TestBrew(unittest.TestCase):
             .and_return(flexmock(openssl_cafile="/my/cert.pem")))
 
         (flexmock(errata)
-            .should_receive("HTTPKerberosAuth")
-            .and_return("MyHTTPKerberosAuth"))
+            .should_receive("HTTPSPNEGOAuth")
+            .and_return("MyHTTPSPNEGOAuth"))
 
         response = flexmock(status_code=200)
         response.should_receive("json").and_return(test_structures.rpm_build_attached_json)
@@ -182,7 +182,7 @@ class TestBrew(unittest.TestCase):
         (session
             .should_receive("get")
             .with_args(constants.errata_get_build_url.format(id=nvr),
-                       auth="MyHTTPKerberosAuth",
+                       auth="MyHTTPSPNEGOAuth",
                        verify="/my/cert.pem")
             .and_return(response))
 
@@ -196,8 +196,8 @@ class TestBrew(unittest.TestCase):
             .and_return(flexmock(openssl_cafile="/my/cert.pem")))
 
         (flexmock(errata)
-            .should_receive("HTTPKerberosAuth")
-            .and_return("MyHTTPKerberosAuth"))
+            .should_receive("HTTPSPNEGOAuth")
+            .and_return("MyHTTPSPNEGOAuth"))
 
         response = flexmock(status_code=404, text="_irrelevant_")
 
@@ -207,7 +207,7 @@ class TestBrew(unittest.TestCase):
         (flexmock(errata.requests.Session)
             .should_receive("get")
             .with_args(constants.errata_get_build_url.format(id=nvr),
-                       auth="MyHTTPKerberosAuth",
+                       auth="MyHTTPSPNEGOAuth",
                        verify="/my/cert.pem")
             .and_return(response))
 


### PR DESCRIPTION
`requests-gssapi` is used by koji and errata_tool packages internally, and it works on macOS.