### PR TITLE
Make client session a BugValidator instance attribute

### DIFF
--- a/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliottlib/cli/find_bugs_sweep_cli.py
@@ -123,7 +123,7 @@ advisory with the --add option.
     find_bugs_obj.exclude_status(exclude_status)
 
     if check_builds:
-        logger.warn("--check-builds is ON by default, it will be deprecated in the future")
+        logger.warning("--check-builds is ON by default, it will be deprecated in the future")
 
     bugs: type_bug_list = []
     errors = []
@@ -174,12 +174,12 @@ def get_bugs_sweep(runtime: Runtime, find_bugs_obj, brew_event, bug_tracker):
         raise ValueError(f"The following {bug_tracker.type} bugs are defined in both 'include' and 'exclude': "
                          f"{included_bug_ids & excluded_bug_ids}")
     if included_bug_ids:
-        logger.warn(f"The following {bug_tracker.type} bugs will be additionally included because they are "
+        logger.warning(f"The following {bug_tracker.type} bugs will be additionally included because they are "
                     f"explicitly defined in the assembly config: {included_bug_ids}")
         included_bugs = bug_tracker.get_bugs(included_bug_ids)
         bugs.extend(included_bugs)
     if excluded_bug_ids:
-        logger.warn(f"The following {bug_tracker.type} bugs will be excluded because they are explicitly "
+        logger.warning(f"The following {bug_tracker.type} bugs will be excluded because they are explicitly "
                     f"defined in the assembly config: {excluded_bug_ids}")
         bugs = [bug for bug in bugs if bug.id not in excluded_bug_ids]
 
@@ -264,7 +264,7 @@ def categorize_bugs_by_type(bugs: List[Bug], advisory_id_map: Dict[str, int], ma
 
     warning_bug = [b.id for b in non_tracker_bugs if b.is_cve_in_summary()]
     if warning_bug:
-        logger.warn(f"Bug {warning_bug} has CVE number in summary but does not have tracker keywords")
+        logger.warning(f"Bug {warning_bug} has CVE number in summary but does not have tracker keywords")
 
     if not advisory_id_map:
         logger.info("Skipping sorting/attaching Tracker Bugs. Advisories with attached builds must be given to "

--- a/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliottlib/cli/find_bugs_sweep_cli.py
@@ -175,12 +175,12 @@ def get_bugs_sweep(runtime: Runtime, find_bugs_obj, brew_event, bug_tracker):
                          f"{included_bug_ids & excluded_bug_ids}")
     if included_bug_ids:
         logger.warning(f"The following {bug_tracker.type} bugs will be additionally included because they are "
-                    f"explicitly defined in the assembly config: {included_bug_ids}")
+                       f"explicitly defined in the assembly config: {included_bug_ids}")
         included_bugs = bug_tracker.get_bugs(included_bug_ids)
         bugs.extend(included_bugs)
     if excluded_bug_ids:
         logger.warning(f"The following {bug_tracker.type} bugs will be excluded because they are explicitly "
-                    f"defined in the assembly config: {excluded_bug_ids}")
+                       f"defined in the assembly config: {excluded_bug_ids}")
         bugs = [bug for bug in bugs if bug.id not in excluded_bug_ids]
 
     return bugs

--- a/elliottlib/errata_async.py
+++ b/elliottlib/errata_async.py
@@ -16,6 +16,7 @@ _LOGGER = logging.getLogger(__name__)
 class AsyncErrataAPI:
     def __init__(self, url: str):
         self._errata_url = urlparse(url).geturl()
+        self._session = aiohttp.ClientSession(connector=aiohttp.TCPConnector(limit=32, force_close=True))
         self._gssapi_client_ctx = None
         self._headers = {
             "Content-Type": "application/json",
@@ -31,13 +32,15 @@ class AsyncErrataAPI:
         self._gssapi_client_ctx = client_ctx
         self._headers["Authorization"] = 'Negotiate ' + base64.b64encode(out_token).decode()
 
+    async def close(self):
+        await self._session.close()
+
     async def _make_request(self, method: str, path: str, parse_json: bool = True, **kwargs) -> Union[Dict, bytes]:
         if "headers" not in kwargs:
             kwargs["headers"] = self._headers
-        async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(limit=32, force_close=True)) as session:
-            async with session.request(method, self._errata_url + path, **kwargs) as resp:
-                resp.raise_for_status()
-                result = await (resp.json() if parse_json else resp.read())
+        async with self._session.request(method, self._errata_url + path, **kwargs) as resp:
+            resp.raise_for_status()
+            result = await (resp.json() if parse_json else resp.read())
         return result
 
     async def get_advisory(self, advisory: Union[int, str]) -> Dict:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,6 +6,7 @@ setuptools>=41.6.0
 # test reqs
 flexmock
 mock>=4.0.3
+asynctest>=0.13.0
 
 # tox reqs
 coverage>=5.3

--- a/tests/test_errata_async.py
+++ b/tests/test_errata_async.py
@@ -20,7 +20,7 @@ class TestAsyncErrataAPI(IsolatedAsyncioTestCase):
         request = session_mock.return_value.request
         fake_response = request.return_value.__aenter__.return_value
         fake_response.json.return_value = {"result": "fake"}
-        fake_response.raise_for_status = Mock(return_value = None)
+        fake_response.raise_for_status = Mock(return_value=None)
         api = AsyncErrataAPI("https://errata.example.com")
         actual = await api._make_request("HEAD", "/api/path")
         self.assertEqual(actual, {"result": "fake"})

--- a/tests/test_errata_async.py
+++ b/tests/test_errata_async.py
@@ -1,113 +1,114 @@
 import base64
-from asyncio import get_event_loop
-from unittest import TestCase
-from mock import ANY, AsyncMock, MagicMock, Mock, patch
+from unittest import IsolatedAsyncioTestCase
+from mock import ANY, AsyncMock, Mock, patch
 from elliottlib.errata_async import AsyncErrataAPI, AsyncErrataUtils
 
 
-class TestAsyncErrataAPI(TestCase):
+class TestAsyncErrataAPI(IsolatedAsyncioTestCase):
     @patch("aiohttp.ClientSession", autospec=True)
     @patch("gssapi.SecurityContext", autospec=True)
-    def test_login(self, SecurityContext: Mock, ClientSession: Mock):
+    async def test_login(self, SecurityContext: Mock, _):
         client_ctx = SecurityContext.return_value
         client_ctx.step.return_value = b"faketoken"
         api = AsyncErrataAPI("https://errata.example.com")
-        get_event_loop().run_until_complete(api.login())
+        await api.login()
         client_ctx.step.assert_called_once_with(b"")
         self.assertEqual(api._headers["Authorization"], 'Negotiate ' + base64.b64encode(b"faketoken").decode())
 
     @patch("aiohttp.ClientSession")
-    def test_make_request(self, ClientSession: AsyncMock):
-        request = MagicMock(
-            **{
-                'request.return_value.__aenter__.return_value': AsyncMock(
-                    **{
-                        'json.return_value': {"result": "fake"},
-                        'read.return_value': b"daedbeef"
-                    }
-                )
-            }
-        )
-        ClientSession.return_value.__aenter__.return_value = request
+    async def test_make_request(self, session_mock: AsyncMock):
+        request = session_mock.return_value.request
+        fake_response = request.return_value.__aenter__.return_value
+        fake_response.json.return_value = {"result": "fake"}
+        fake_response.raise_for_status = Mock(return_value = None)
         api = AsyncErrataAPI("https://errata.example.com")
-        actual = get_event_loop().run_until_complete(api._make_request("HEAD", "/api/path"))
+        actual = await api._make_request("HEAD", "/api/path")
         self.assertEqual(actual, {"result": "fake"})
-        actual = get_event_loop().run_until_complete(api._make_request("GET", "/api/path", parse_json=False))
+
+        headers = {"X-Test-Header": "Test Value"}
+        request.reset_mock()
+        fake_response.read.return_value = b"daedbeef"
+        fake_response.raise_for_status.reset_mock()
+        actual = await api._make_request("GET", "/api/path", headers=headers, parse_json=False)
+        request.assert_called_once_with("GET", "https://errata.example.com/api/path", headers=headers)
+        fake_response.raise_for_status.assert_called_once_with()
+        fake_response.read.assert_awaited_once_with()
+        actual = await api._make_request("GET", "/api/path", parse_json=False)
         self.assertEqual(actual, b"daedbeef")
 
     @patch("aiohttp.ClientSession", autospec=True)
     @patch("elliottlib.errata_async.AsyncErrataAPI._make_request", autospec=True)
-    def test_get_advisory(self, _make_request: Mock, ClientSession: Mock):
+    async def test_get_advisory(self, _make_request: Mock, ClientSession: Mock):
         api = AsyncErrataAPI("https://errata.example.com")
         _make_request.return_value = {"result": "fake"}
 
-        actual = get_event_loop().run_until_complete(api.get_advisory(1))
+        actual = await api.get_advisory(1)
         _make_request.assert_awaited_once_with(ANY, "GET", "/api/v1/erratum/1")
         self.assertEqual(actual, {"result": "fake"})
 
         _make_request.reset_mock()
-        actual = get_event_loop().run_until_complete(api.get_advisory("RHBA-2021:0001"))
+        actual = await api.get_advisory("RHBA-2021:0001")
         _make_request.assert_awaited_once_with(ANY, "GET", "/api/v1/erratum/RHBA-2021%3A0001")
         self.assertEqual(actual, {"result": "fake"})
 
     @patch("aiohttp.ClientSession", autospec=True)
     @patch("elliottlib.errata_async.AsyncErrataAPI._make_request", autospec=True)
-    def test_get_builds(self, _make_request: Mock, ClientSession: Mock):
+    async def test_get_builds(self, _make_request: Mock, ClientSession: Mock):
         api = AsyncErrataAPI("https://errata.example.com")
         _make_request.return_value = {
             "ProductVersion1": {"builds": [{"a-1.0.0-1": {}, "b-1.0.0-1": {}}]},
             "ProductVersion2": {"builds": [{"c-1.0.0-1": {}}]}
         }
-        actual = get_event_loop().run_until_complete(api.get_builds(1))
+        actual = await api.get_builds(1)
         _make_request.assert_awaited_once_with(ANY, "GET", "/api/v1/erratum/1/builds_list")
         self.assertEqual(actual, _make_request.return_value)
 
     @patch("aiohttp.ClientSession", autospec=True)
     @patch("elliottlib.errata_async.AsyncErrataAPI._make_request", autospec=True)
-    def test_get_builds_flattened(self, _make_request: Mock, ClientSession: Mock):
+    async def test_get_builds_flattened(self, _make_request: Mock, ClientSession: Mock):
         api = AsyncErrataAPI("https://errata.example.com")
         _make_request.return_value = {
             "ProductVersion1": {"builds": [{"a-1.0.0-1": {}, "b-1.0.0-1": {}}]},
             "ProductVersion2": {"builds": [{"c-1.0.0-1": {}}]}
         }
-        actual = get_event_loop().run_until_complete(api.get_builds_flattened(1))
+        actual = await api.get_builds_flattened(1)
         _make_request.assert_awaited_once_with(ANY, "GET", "/api/v1/erratum/1/builds_list")
         self.assertEqual(actual, {"a-1.0.0-1", "b-1.0.0-1", "c-1.0.0-1"})
 
     @patch("aiohttp.ClientSession", autospec=True)
     @patch("elliottlib.errata_async.AsyncErrataAPI._make_request", autospec=True)
-    def test_get_cves(self, _make_request: Mock, ClientSession: Mock):
+    async def test_get_cves(self, _make_request: Mock, ClientSession: Mock):
         api = AsyncErrataAPI("https://errata.example.com")
         api.get_advisory = AsyncMock(return_value={
             "content": {
                 "content": {"cve": "A B C"}
             }
         })
-        actual = get_event_loop().run_until_complete(api.get_cves(1))
+        actual = await api.get_cves(1)
         api.get_advisory.assert_awaited_once_with(1)
         self.assertEqual(actual, ["A", "B", "C"])
 
     @patch("aiohttp.ClientSession", autospec=True)
     @patch("elliottlib.errata_async.AsyncErrataAPI._make_request", autospec=True)
-    def test_create_cve_package_exclusion(self, _make_request: Mock, ClientSession: Mock):
+    async def test_create_cve_package_exclusion(self, _make_request: Mock, ClientSession: Mock):
         api = AsyncErrataAPI("https://errata.example.com")
         _make_request.return_value = {"result": "fake"}
-        actual = get_event_loop().run_until_complete(api.create_cve_package_exclusion(1, "CVE-1", "a"))
+        actual = await api.create_cve_package_exclusion(1, "CVE-1", "a")
         _make_request.assert_awaited_once_with(ANY, 'POST', '/api/v1/cve_package_exclusion', json={'cve': 'CVE-1', 'errata': 1, 'package': 'a'})
         self.assertEqual(actual, {"result": "fake"})
 
     @patch("aiohttp.ClientSession", autospec=True)
     @patch("elliottlib.errata_async.AsyncErrataAPI._make_request", autospec=True)
-    def test_create_delete_cve_package_exclusion(self, _make_request: Mock, ClientSession: Mock):
+    async def test_create_delete_cve_package_exclusion(self, _make_request: Mock, ClientSession: Mock):
         api = AsyncErrataAPI("https://errata.example.com")
         _make_request.return_value = b""
-        actual = get_event_loop().run_until_complete(api.delete_cve_package_exclusion(100))
+        actual = await api.delete_cve_package_exclusion(100)
         _make_request.assert_awaited_once_with(ANY, 'DELETE', '/api/v1/cve_package_exclusion/100', parse_json=False)
         self.assertEqual(actual, None)
 
     @patch("aiohttp.ClientSession", autospec=True)
     @patch("elliottlib.errata_async.AsyncErrataAPI._make_request", autospec=True)
-    def test_get_cve_package_exclusions(self, _make_request: Mock, ClientSession: Mock):
+    async def test_get_cve_package_exclusions(self, _make_request: Mock, ClientSession: Mock):
         api = AsyncErrataAPI("https://errata.example.com")
         _make_request.side_effect = lambda _0, _1, _2, params: {
             1: {"data": [{"id": 1}, {"id": 2}, {"id": 3}]},
@@ -121,14 +122,14 @@ class TestAsyncErrataAPI(TestCase):
                 items.append(item)
             return items
 
-        actual = get_event_loop().run_until_complete(_call())
+        actual = await _call()
         _make_request.assert_awaited_with(ANY, 'GET', '/api/v1/cve_package_exclusion', params={'filter[errata_id]': '1', 'page[number]': 3, 'page[size]': 1000})
         self.assertEqual(actual, [{'id': 1}, {'id': 2}, {'id': 3}, {'id': 4}, {'id': 5}])
 
 
-class TestAsyncErrataUtils(TestCase):
+class TestAsyncErrataUtils(IsolatedAsyncioTestCase):
     @patch("elliottlib.errata_async.AsyncErrataAPI", autospec=True)
-    def test_get_advisory_cve_package_exclusions(self, FakeAsyncErrataAPI: AsyncMock):
+    async def test_get_advisory_cve_package_exclusions(self, FakeAsyncErrataAPI: AsyncMock):
         api = FakeAsyncErrataAPI.return_value
         api.get_cve_package_exclusions.return_value.__aiter__.return_value = [
             {"id": 1, "relationships": {"cve": {"name": "CVE-2099-1"}, "package": {"name": "a"}}},
@@ -139,7 +140,7 @@ class TestAsyncErrataUtils(TestCase):
             "CVE-2099-1": {"a": 1, "b": 2},
             "CVE-2099-2": {"c": 3},
         }
-        actual = get_event_loop().run_until_complete(AsyncErrataUtils.get_advisory_cve_package_exclusions(api, 1))
+        actual = await AsyncErrataUtils.get_advisory_cve_package_exclusions(api, 1)
         self.assertEqual(actual, expected)
 
     def test_compute_cve_package_exclusions(self):
@@ -183,7 +184,7 @@ class TestAsyncErrataUtils(TestCase):
 
     @patch("elliottlib.errata_async.AsyncErrataUtils.get_advisory_cve_package_exclusions", autospec=True)
     @patch("elliottlib.errata_async.AsyncErrataAPI", autospec=True)
-    def test_associate_builds_with_cves(self, FakeAsyncErrataAPI: AsyncMock, fake_get_advisory_cve_package_exclusions: AsyncMock):
+    async def test_associate_builds_with_cves(self, FakeAsyncErrataAPI: AsyncMock, fake_get_advisory_cve_package_exclusions: AsyncMock):
         api = FakeAsyncErrataAPI.return_value
         api.get_cves.return_value = ["CVE-2099-1", "CVE-2099-2", "CVE-2099-3"]
         attached_builds = ["a-1.0.0-1.el8", "a-1.0.0-1.el7", "b-1.0.0-1.el8", "c-1.0.0-1.el8", "d-1.0.0-1.el8", "e-1.0.0-1.el7"]
@@ -197,7 +198,7 @@ class TestAsyncErrataUtils(TestCase):
             "CVE-2099-2": {"a": 3, "b": 4, "d": 5},
             "CVE-2099-3": {}
         }
-        actual = get_event_loop().run_until_complete(AsyncErrataUtils.associate_builds_with_cves(api, 1, attached_builds, cve_components, dry_run=False))
+        actual = await AsyncErrataUtils.associate_builds_with_cves(api, 1, attached_builds, cve_components, dry_run=False)
         api.delete_cve_package_exclusion.assert_any_await(2)
         api.create_cve_package_exclusion.assert_any_await(1, "CVE-2099-1", "e")
         api.create_cve_package_exclusion.assert_any_await(1, "CVE-2099-3", "e")

--- a/tests/test_exectools.py
+++ b/tests/test_exectools.py
@@ -6,6 +6,7 @@ Test functions related to controlled command execution
 import asyncio
 import unittest
 
+import asynctest
 from flexmock import flexmock
 import mock
 
@@ -148,7 +149,7 @@ class TestCmdExec(unittest.TestCase):
         self.assertRaises(IOError, exectools.cmd_assert, "/usr/bin/false", 3, 1)
 
 
-class TestGather(unittest.TestCase):
+class TestGather(asynctest.TestCase):
     """
     """
 
@@ -230,8 +231,7 @@ class TestGather(unittest.TestCase):
         self.assertEqual(stdout, stdout_expected)
         self.assertEqual(stderr, stderr_expected)
 
-    def test_cmd_gather_async(self):
-        loop = asyncio.get_event_loop()
+    async def test_cmd_gather_async(self):
         cmd = ["uname", "-a"]
         fake_cwd = "/foo/bar"
         fake_stdout = b"fake_stdout"
@@ -242,20 +242,21 @@ class TestGather(unittest.TestCase):
             proc.returncode = 0
             proc.communicate.return_value = (fake_stdout, fake_stderr)
 
-            rc, out, err = loop.run_until_complete(exectools.cmd_gather_async(cmd, text_mode=True))
-            create_subprocess_exec.assert_called_once_with(*cmd, cwd=fake_cwd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
+            rc, out, err = await exectools.cmd_gather_async(cmd, text_mode=True)
+            create_subprocess_exec.assert_called_once_with(*cmd, cwd=fake_cwd, stdout=asyncio.subprocess.PIPE,
+                                                           stderr=asyncio.subprocess.PIPE)
             self.assertEqual(rc, 0)
             self.assertEqual(out, fake_stdout.decode("utf-8"))
             self.assertEqual(err, fake_stderr.decode("utf-8"))
 
             create_subprocess_exec.reset_mock()
-            rc, out, err = loop.run_until_complete(exectools.cmd_gather_async(cmd, text_mode=False))
-            create_subprocess_exec.assert_called_once_with(*cmd, cwd=fake_cwd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
+            rc, out, err = await exectools.cmd_gather_async(cmd, text_mode=False)
+            create_subprocess_exec.assert_called_once_with(*cmd, cwd=fake_cwd, stdout=asyncio.subprocess.PIPE,
+                                                           stderr=asyncio.subprocess.PIPE)
             self.assertEqual(rc, 0)
             self.assertEqual(out, fake_stdout)
             self.assertEqual(err, fake_stderr)
 
 
 if __name__ == "__main__":
-
     unittest.main()


### PR DESCRIPTION
Probably due to https://github.com/openshift/elliott/pull/441, we occasionally get this exception while promoting a release:

```
ConnectionError(err, request=request)
requests.exceptions.ConnectionError: ('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer'))
```

This happened systematically while promoting a new RC, a task that usually involves sending multiple asynchronous requests to the Errata API. By leaving the client session open during the CLI execution, we should not incur into these server side errors anymore.