### PR TITLE
fix verify-attached-bugs cli

### DIFF
--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -1115,17 +1115,10 @@ def is_first_fix_any(bugtracker, flaw_bug, current_target_release):
 
     # filter tracker bugs by OCP product
     tracker_bugs = []
-    for tracker_id in tracker_ids:
-        try:
-            b = bugtracker.get_bug(tracker_id)
-        except Exception as e:
-            # first-fix tracker bug might be not visible but not break here
-            if "not authorized" in e:
-                logger.warning(f"We are not authorized to access bug #{tracker_id}, need manually check if it's permission issue")
-            logger.warning(f"Failed to get tracker bug {tracker_id} info from bugtracker API")
-        else:
-            if b.product == constants.BUGZILLA_PRODUCT_OCP and b.is_tracker_bug():
-                tracker_bugs.append(b)
+    bugs = bugtracker.get_bugs(tracker_ids)
+    for b in bugs:
+        if b.product == constants.BUGZILLA_PRODUCT_OCP and b.is_tracker_bug():
+            tracker_bugs.append(b)
 
     if not tracker_bugs:
         # No OCP trackers found

--- a/elliottlib/cli/advisory_drop_cli.py
+++ b/elliottlib/cli/advisory_drop_cli.py
@@ -24,13 +24,16 @@ def advisory_drop_cli(advisory):
         click.echo(f'Advisory {advisory} is already dropped')
         return
 
+    # move advisory status to NEW_FILES
+    if adv.errata_state != "NEW_FILES":
+        adv.setState("NEW_FILES")
+        adv.commit()
+
     # Remove bugs and builds before dropping the advisory
     all_bugs = adv.errata_bugs
     all_jiras = adv.jira_issues
     all_builds = list(set(itertools.chain.from_iterable(adv.errata_builds.values())))
     if all_bugs or all_jiras or all_builds:
-        if adv.errata_state != "NEW_FILES":
-            adv.setState("NEW_FILES")
         if all_bugs:
             adv.removeBugs(all_bugs)
         if all_jiras:
@@ -44,7 +47,8 @@ def advisory_drop_cli(advisory):
     data = 'utf8=%E2%9C%93&reason=Dropping+unused+advisory%21&commit=Dropping+unused+advisory'
     headers = {"Content-Type": "text/plain"}
     r = requests.post(url, auth=HTTPSPNEGOAuth(), data=data, headers=headers)
-    if not r.ok:
+    adv.refresh()
+    if adv.errata_state != "DROPPED_NO_SHIP":
         raise ElliottFatalError(f'Failed to drop advisory {advisory}. Got status code {r.status_code}. Are you the owner of advisory {advisory}?')
 
     click.echo(f'Successfully dropped advisory {advisory}')

--- a/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliottlib/cli/find_bugs_sweep_cli.py
@@ -264,7 +264,7 @@ def categorize_bugs_by_type(bugs: List[Bug], advisory_id_map: Dict[str, int], ma
 
     warning_bug = [b.id for b in non_tracker_bugs if b.is_cve_in_summary()]
     if warning_bug:
-        logger.warn(f"Bug {warning_bug} has CVE number in summary but does not have tracker keywords")
+        logger.warning(f"Bug {warning_bug} has CVE number in summary but does not have tracker keywords")
 
     if not advisory_id_map:
         logger.info("Skipping sorting/attaching Tracker Bugs. Advisories with attached builds must be given to "

--- a/elliottlib/errata_async.py
+++ b/elliottlib/errata_async.py
@@ -34,9 +34,9 @@ class AsyncErrataAPI:
     async def _make_request(self, method: str, path: str, parse_json: bool = True, **kwargs) -> Union[Dict, bytes]:
         if "headers" not in kwargs:
             kwargs["headers"] = self._headers
-        async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(limit=32, force_close=True)) as session:
+        await self.login()
+        async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(limit=32, force_close=True), timeout=aiohttp.ClientTimeout(total=60 * 60)) as session:
             async with session.request(method, self._errata_url + path, **kwargs) as resp:
-                resp.raise_for_status()
                 result = await (resp.json() if parse_json else resp.read())
         return result
 

--- a/tests/test_bzutil.py
+++ b/tests/test_bzutil.py
@@ -503,8 +503,8 @@ class TestBZUtil(unittest.TestCase):
             .should_receive("query")
             .and_return(tracker_bug_objs))
         (bzapi
-            .should_receive("get_bug")
-            .and_return(bug_a))
+            .should_receive("get_bugs")
+            .and_return([bug_a]))
 
         expected = True
         actual = bzutil.is_first_fix_any(bzapi, flaw_bug, tr)
@@ -533,11 +533,7 @@ class TestBZUtil(unittest.TestCase):
         (bzapi
             .should_receive("query")
             .and_return(tracker_bug_objs))
-        (bzapi
-            .should_receive("get_bug")
-            .with_args(1)
-            .and_return(bug_a))
-        (bzapi.should_receive("get_bug").with_args(2).and_return(bug_a))
+        (bzapi.should_receive("get_bugs").and_return([bug_a]))
 
         expected = False
         actual = bzutil.is_first_fix_any(bzapi, flaw_bug, tr)
@@ -574,8 +570,7 @@ class TestBZUtil(unittest.TestCase):
         (bzapi
             .should_receive("query")
             .and_return(tracker_bug_objs))
-        (bzapi.should_receive("get_bug").with_args(1).and_return(bug_a))
-        (bzapi.should_receive("get_bug").with_args(2).and_return(bug_b))
+        (bzapi.should_receive("get_bugs").and_return([bug_a, bug_b]))
 
         expected = True
         actual = bzutil.is_first_fix_any(bzapi, flaw_bug, tr)
@@ -613,8 +608,8 @@ class TestBZUtil(unittest.TestCase):
             .should_receive("query")
             .and_return(tracker_bug_objs))
         (bzapi
-            .should_receive("get_bug")
-            .and_return(bug_a))
+            .should_receive("get_bugs")
+            .and_return([bug_a, bug_b]))
 
         expected = False
         actual = bzutil.is_first_fix_any(bzapi, flaw_bug, tr)
@@ -659,11 +654,8 @@ class TestBZUtil(unittest.TestCase):
             .should_receive("query")
             .and_return(tracker_bug_objs))
         (bzapi
-            .should_receive("get_bug")
-            .with_args(1)
-            .and_return(bug_a))
-        (bzapi.should_receive("get_bug").with_args(2).and_return(bug_b))
-        (bzapi.should_receive("get_bug").with_args(3).and_return(bug_c))
+            .should_receive("get_bugs")
+            .and_return([bug_a, bug_b, bug_c]))
 
         expected = True
         actual = bzutil.is_first_fix_any(bzapi, flaw_bug, tr)


### PR DESCRIPTION
the issue is due to the API init too early, and is_first_fix check get bugs one by one which takes over 30 mins for RC.
In this pr:
- replace get_bug with get_bugs in is_first_fix check
- use Erratum replace some get advisory API
- move login check to request function for cve_package_exclusions API

test build: https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/ximhan/job/build%252Foperator-sdk_sync/52/console