### PR TITLE
Reuse advisory object instead of refetching it 

### DIFF
--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -16,6 +16,7 @@ from datetime import datetime, timezone
 from time import sleep
 from typing import Dict, Iterable, List, Optional
 from jira import JIRA, Issue
+from errata_tool import Erratum
 from errata_tool.jira_issue import JiraIssue as ErrataJira
 from errata_tool.bug import Bug as ErrataBug
 from bugzilla.bug import Bug
@@ -374,7 +375,8 @@ class BugTracker:
     def remove_bugs(self, advisory_obj, bugids: List, noop=False):
         raise NotImplementedError
 
-    def attach_bugs(self, advisory_id: int, bugids: List, noop=False, verbose=False):
+    def attach_bugs(self, bugids: List, advisory_id: int = 0, advisory_obj: Erratum = None, noop=False,
+                    verbose=False):
         raise NotImplementedError
 
     def add_comment(self, bugid, comment: str, private: bool, noop=False):
@@ -667,8 +669,11 @@ class JIRABugTracker(BugTracker):
         advisory_obj.removeJIRAIssues(bugids)
         advisory_obj.commit()
 
-    def attach_bugs(self, advisory_id: int, bugids: List, noop=False, verbose=False):
-        return errata.add_jira_bugs_with_retry(advisory_id, bugids, noop=noop)
+    def attach_bugs(self, bugids: List, advisory_id: int = 0, advisory_obj: Erratum = None, noop=False,
+                    verbose=False):
+        if not advisory_obj:
+            advisory_obj = Erratum(errata_id=advisory_id)
+        return errata.add_jira_bugs_with_retry(advisory_obj, bugids, noop=noop)
 
     def filter_bugs_by_cutoff_event(self, bugs: Iterable, desired_statuses: Iterable[str],
                                     sweep_cutoff_timestamp: float, verbose=False) -> List:
@@ -770,8 +775,10 @@ class BugzillaBugTracker(BugTracker):
         advisory_id = advisory_obj.errata_id
         return errata.remove_multi_bugs(advisory_id, bugids)
 
-    def attach_bugs(self, advisory_id: int, bugids: List, noop=False, verbose=False):
-        return errata.add_bugzilla_bugs_with_retry(advisory_id, bugids, noop=noop)
+    def attach_bugs(self, bugids: List, advisory_id: int = 0, advisory_obj: Erratum = None, noop=False, verbose=False):
+        if not advisory_obj:
+            advisory_obj = Erratum(errata_id=advisory_id)
+        return errata.add_bugzilla_bugs_with_retry(advisory_obj, bugids, noop=noop)
 
     def create_bug(self, title, description, target_status, keywords: List, noop=False) -> BugzillaBug:
         create_info = self._client.build_createbug(

--- a/elliottlib/cli/attach_bugs_cli.py
+++ b/elliottlib/cli/attach_bugs_cli.py
@@ -82,4 +82,4 @@ def attach_bugs(runtime, advisory, bug_ids, report, output, noop, bug_tracker):
         print_report(bugs, output=output)
 
     if advisory:
-        bug_tracker.attach_bugs(advisory, [b.id for b in bugs], noop=noop)
+        bug_tracker.attach_bugs([b.id for b in bugs], advisory_id=advisory, noop=noop)

--- a/elliottlib/cli/attach_cve_flaws_cli.py
+++ b/elliottlib/cli/attach_cve_flaws_cli.py
@@ -148,10 +148,11 @@ def _update_advisory(runtime, advisory, flaw_bugs, bug_tracker, noop):
 
     flaw_ids = [flaw_bug.id for flaw_bug in flaw_bugs]
     runtime.logger.info(f'Attaching {len(flaw_ids)} flaw bugs')
-    bug_tracker.attach_bugs(advisory_id, flaw_ids, noop)
+    bug_tracker.attach_bugs(flaw_ids, advisory_obj=advisory, noop=noop)
 
 
-async def associate_builds_with_cves(errata_api: AsyncErrataAPI, advisory: Erratum, flaw_bugs: Iterable[Bug], attached_tracker_bugs: List[Bug], tracker_flaws: Dict[int, Iterable], dry_run: bool):
+async def associate_builds_with_cves(errata_api: AsyncErrataAPI, advisory: Erratum, flaw_bugs: Iterable[Bug],
+                                     attached_tracker_bugs: List[Bug], tracker_flaws: Dict[int, Iterable], dry_run: bool):
     attached_builds = [b for pv in advisory.errata_builds.values() for b in pv]
     cve_components_mapping: Dict[str, Set[str]] = {}
     for tracker in attached_tracker_bugs:
@@ -167,7 +168,8 @@ async def associate_builds_with_cves(errata_api: AsyncErrataAPI, advisory: Errat
             cve = flaw_id_bugs[flaw_id].alias[0]
             cve_components_mapping.setdefault(cve, set()).add(component_name)
 
-    await AsyncErrataUtils.associate_builds_with_cves(errata_api, advisory.errata_id, attached_builds, cve_components_mapping, dry_run=dry_run)
+    await AsyncErrataUtils.associate_builds_with_cves(errata_api, advisory.errata_id, attached_builds,
+                                                      cve_components_mapping, dry_run=dry_run)
 
 
 def get_updated_advisory_rhsa(logger, cve_boilerplate: dict, advisory: Erratum, flaw_bugs):

--- a/elliottlib/cli/attach_cve_flaws_cli.py
+++ b/elliottlib/cli/attach_cve_flaws_cli.py
@@ -151,8 +151,7 @@ def _update_advisory(runtime, advisory, flaw_bugs, bug_tracker, noop):
     bug_tracker.attach_bugs(flaw_ids, advisory_obj=advisory, noop=noop)
 
 
-async def associate_builds_with_cves(errata_api: AsyncErrataAPI, advisory: Erratum, flaw_bugs: Iterable[Bug],
-                                     attached_tracker_bugs: List[Bug], tracker_flaws: Dict[int, Iterable], dry_run: bool):
+async def associate_builds_with_cves(errata_api: AsyncErrataAPI, advisory: Erratum, flaw_bugs: Iterable[Bug], attached_tracker_bugs: List[Bug], tracker_flaws: Dict[int, Iterable], dry_run: bool):
     attached_builds = [b for pv in advisory.errata_builds.values() for b in pv]
     cve_components_mapping: Dict[str, Set[str]] = {}
     for tracker in attached_tracker_bugs:
@@ -168,8 +167,7 @@ async def associate_builds_with_cves(errata_api: AsyncErrataAPI, advisory: Errat
             cve = flaw_id_bugs[flaw_id].alias[0]
             cve_components_mapping.setdefault(cve, set()).add(component_name)
 
-    await AsyncErrataUtils.associate_builds_with_cves(errata_api, advisory.errata_id, attached_builds,
-                                                      cve_components_mapping, dry_run=dry_run)
+    await AsyncErrataUtils.associate_builds_with_cves(errata_api, advisory.errata_id, attached_builds, cve_components_mapping, dry_run=dry_run)
 
 
 def get_updated_advisory_rhsa(logger, cve_boilerplate: dict, advisory: Erratum, flaw_bugs):

--- a/elliottlib/cli/create_placeholder_cli.py
+++ b/elliottlib/cli/create_placeholder_cli.py
@@ -64,4 +64,4 @@ def create_placeholder(kind, advisory_id, bug_tracker, noop):
         raise ElliottFatalError(f"Error: Could not locate advisory {advisory_id}")
 
     click.echo("Attaching bug to advisory...")
-    bug_tracker.attach_bugs(advisory_id, [newbug.id])
+    bug_tracker.attach_bugs([newbug.id], advisory_obj=advisory)

--- a/elliottlib/cli/create_textonly_cli.py
+++ b/elliottlib/cli/create_textonly_cli.py
@@ -111,7 +111,7 @@ def create_textonly(runtime, errata_type, date, assigned_to, manager, package_ow
         bug = bug_tracker.create_textonly(bug_title, bug_description)
         click.echo(f"Created placeholder bug: {bug.id} {bug.webur}")
         click.echo("Attaching placeholder bug...")
-        bug_tracker.attach_bugs(erratum.errata_id, [bug.id])
+        bug_tracker.attach_bugs([bug.id], advisory_obj=erratum)
     else:
         green_prefix("Would have created advisory: ")
         click.echo("")

--- a/elliottlib/cli/find_bugs_sweep_cli.py
+++ b/elliottlib/cli/find_bugs_sweep_cli.py
@@ -214,7 +214,7 @@ def find_and_attach_bugs(runtime: Runtime, advisory_id, default_advisory_type, m
     # `--add ADVISORY_NUMBER` should respect the user's wish
     # and attach all available bugs to whatever advisory is specified.
     if advisory_id and not default_advisory_type:
-        bug_tracker.attach_bugs(advisory_id, [b.id for b in bugs], noop=noop, verbose=runtime.debug)
+        bug_tracker.attach_bugs([b.id for b in bugs], advisory_id=advisory_id, noop=noop, verbose=runtime.debug)
         return bugs
 
     if not advisory_ids:
@@ -225,7 +225,8 @@ def find_and_attach_bugs(runtime: Runtime, advisory_id, default_advisory_type, m
     for advisory_type in sorted(advisory_types_to_attach):
         kind_bugs = bugs_by_type.get(advisory_type)
         if kind_bugs:
-            bug_tracker.attach_bugs(advisory_ids[advisory_type], [b.id for b in kind_bugs], noop=noop, verbose=runtime.debug)
+            bug_tracker.attach_bugs([b.id for b in kind_bugs], advisory_id=advisory_ids[advisory_type], noop=noop,
+                                    verbose=runtime.debug)
     return bugs
 
 

--- a/tests/test_find_bugs_sweep_cli.py
+++ b/tests/test_find_bugs_sweep_cli.py
@@ -7,11 +7,8 @@ from elliottlib.cli.find_bugs_sweep_cli import FindBugsMode
 from elliottlib.bzutil import BugzillaBugTracker, JIRABugTracker
 from elliottlib.cli.find_bugs_sweep_cli import extras_bugs, get_assembly_bug_ids, categorize_bugs_by_type
 from elliottlib.cli.common import cli, Runtime
-import xmlrpc.client
 import elliottlib.cli.find_bugs_sweep_cli as sweep_cli
-import elliottlib.bzutil as bzutil
 from elliottlib import errata
-from elliottlib.cli import common
 import traceback
 
 
@@ -127,7 +124,7 @@ class FindBugsSweepTestCase(unittest.TestCase):
         flexmock(JIRABugTracker).should_receive("get_config").and_return({'target_release': ['4.6.z']})
         flexmock(JIRABugTracker).should_receive("login")
         flexmock(JIRABugTracker).should_receive("search").and_return(bugs)
-        flexmock(JIRABugTracker).should_receive("attach_bugs").with_args(advisory_id, [b.id for b in bugs],
+        flexmock(JIRABugTracker).should_receive("attach_bugs").with_args([b.id for b in bugs], advisory_id=advisory_id,
                                                                          noop=False, verbose=False)
         flexmock(JIRABugTracker).should_receive("filter_attached_bugs").and_return([])
 
@@ -135,7 +132,7 @@ class FindBugsSweepTestCase(unittest.TestCase):
         flexmock(BugzillaBugTracker).should_receive("get_config").and_return({'target_release': ['4.6.z']})
         flexmock(BugzillaBugTracker).should_receive("login").and_return(None)
         flexmock(BugzillaBugTracker).should_receive("search").and_return(bugs)
-        flexmock(BugzillaBugTracker).should_receive("attach_bugs").with_args(advisory_id, [b.id for b in bugs],
+        flexmock(BugzillaBugTracker).should_receive("attach_bugs").with_args([b.id for b in bugs], advisory_id=advisory_id,
                                                                              noop=False, verbose=False)
         flexmock(BugzillaBugTracker).should_receive("filter_attached_bugs").and_return([])
 
@@ -168,8 +165,9 @@ class FindBugsSweepTestCase(unittest.TestCase):
         flexmock(BugzillaBugTracker).should_receive("get_config").and_return({'target_release': ['4.6.z']})
         flexmock(BugzillaBugTracker).should_receive("login")
         flexmock(BugzillaBugTracker).should_receive("search").and_return(bugs)
-        flexmock(BugzillaBugTracker).should_receive("attach_bugs").with_args(123, ['BZ1'], noop=False, verbose=False)
         flexmock(BugzillaBugTracker).should_receive("filter_attached_bugs").and_return([])
+        flexmock(BugzillaBugTracker).should_receive("attach_bugs").with_args(['BZ1'], advisory_id=123, noop=False,
+                                                                             verbose=False)
 
         result = runner.invoke(cli, ['-g', 'openshift-4.6', 'find-bugs:sweep', '--use-default-advisory', 'image'])
         if result.exit_code != 0:


### PR DESCRIPTION
I noticed when working with GA advisories - some commands
were taking a lot of time. In cases when we want to attach bugs
we were refetching the advisory in the attach method. Instead 
have an advisory_obj param and use that if we have advisory fetched.