### PR TITLE
ART-6054 Add blocking errata API calls

### DIFF
--- a/elliottlib/errata.py
+++ b/elliottlib/errata.py
@@ -766,12 +766,12 @@ def is_advisory_impact_smaller_than(advisory, impact):
     return i.index(advisory.security_impact) < i.index(impact)
 
 
-def set_blocking_errata(target_advisory_id, blocking_advisory_id, blocking_state):
+def set_blocking_errata(target_advisory_id, blocking_advisory_id, blocking_state="SHIPPED_LIVE") -> dict:
     """Set a blocker advisory (at blocking state) for given target advisory
 
     :param target_advisory_id: advisory number of the target
     :param blocking_advisory_id: advisory number of the blocker
-    :param blocking_state: a valid advisory state like "SHIPPED_LIVE"
+    :param blocking_state: a valid advisory state like "SHIPPED_LIVE" (default to "SHIPPED_LIVE")
     """
     response = ErrataConnector()._post(f'/api/v1/erratum/{target_advisory_id}/add_blocking_errata', data={"blocking_errata": blocking_advisory_id})
     if response.status_code != requests.codes.created:

--- a/elliottlib/errata.py
+++ b/elliottlib/errata.py
@@ -14,11 +14,11 @@ import re
 import click
 import requests
 from elliottlib import exceptions, constants, brew, logutil
-from elliottlib.util import green_prefix, green_print, exit_unauthenticated, chunk
+from elliottlib.util import green_print, chunk
 from elliottlib import bzutil
 from requests_gssapi import HTTPSPNEGOAuth
 from errata_tool import Erratum, ErrataException, ErrataConnector
-from typing import List
+from typing import List, Optional
 
 
 import xmlrpc.client
@@ -791,8 +791,9 @@ def set_blocking_advisory(target_advisory_id, blocking_advisory_id, blocking_sta
     return response.json()
 
 
-def get_blocking_advisories(advisory_id) -> list:
+def get_blocking_advisories(advisory_id) -> Optional[List]:
     """Get a list of blocking advisory ids for a given advisory
+    if blocking_advisories are not found in ET response, None is returned
 
     :param advisory_id: advisory number
     :return: a list of advisory ids

--- a/elliottlib/errata.py
+++ b/elliottlib/errata.py
@@ -781,7 +781,7 @@ def set_blocking_errata(target_advisory_id, blocking_advisory_id, blocking_state
         raise IOError(f'Failed to set blocking advisory {blocking_advisory_id} for advisory {target_advisory_id} with error: {response.text} status code: {response.status_code}')
     return response.json()
 
-def get_blocking_errata(advisory_id) -> dict:
+def get_blocking_errata(advisory_id) -> list:
     """Get a list of blocking advisory ids for a given advisory
     
     :param advisory_id: advisory number

--- a/elliottlib/errata.py
+++ b/elliottlib/errata.py
@@ -774,11 +774,13 @@ def set_blocking_errata(target_advisory_id, blocking_advisory_id, blocking_state
     :param blocking_state: a valid advisory state like "SHIPPED_LIVE"
     """
     response = ErrataConnector()._post(f'/api/v1/erratum/{target_advisory_id}/add_blocking_errata', data={"blocking_errata": blocking_advisory_id})
-    if response.status_code != requests.codes.ok:
-        raise IOError(f'Failed to set blocking advisory {blocking_advisory_id} for advisory {target_advisory_id} with error: {response.text} status code: {response.status_code}')
-    data = {"blocking_errata": blocking_advisory_id, "blocking_state": blocking_state}
+    if response.status_code != requests.codes.created:
+        # This can 404 if the advisory is already in the list
+        if not "Advisory already listed" in response.text:
+            logger.warning(f'Failed to set blocking advisory {blocking_advisory_id} for advisory {target_advisory_id} with error: {response.text} status code: {response.status_code}')
+    data = {"blocking_errata": blocking_advisory_id, "blocker_state": blocking_state}
     response = ErrataConnector()._post(f'/api/v1/erratum/{target_advisory_id}/set_blocker_state_for_blocking_errata', data=data)
-    if response.status_code != requests.codes.ok:
+    if response.status_code != requests.codes.created:
         raise IOError(f'Failed to set blocking advisory {blocking_advisory_id} for advisory {target_advisory_id} with error: {response.text} status code: {response.status_code}')
     return response.json()
 

--- a/elliottlib/errata.py
+++ b/elliottlib/errata.py
@@ -765,6 +765,7 @@ def is_advisory_impact_smaller_than(advisory, impact):
     i = [None] + constants.SECURITY_IMPACT
     return i.index(advisory.security_impact) < i.index(impact)
 
+
 def set_blocking_errata(target_advisory_id, blocking_advisory_id, blocking_state):
     """Set a blocker advisory (at blocking state) for given target advisory
 
@@ -781,9 +782,10 @@ def set_blocking_errata(target_advisory_id, blocking_advisory_id, blocking_state
         raise IOError(f'Failed to set blocking advisory {blocking_advisory_id} for advisory {target_advisory_id} with error: {response.text} status code: {response.status_code}')
     return response.json()
 
+
 def get_blocking_errata(advisory_id) -> list:
     """Get a list of blocking advisory ids for a given advisory
-    
+
     :param advisory_id: advisory number
     :return: a list of advisory ids
     """


### PR DESCRIPTION
https://issues.redhat.com/browse/ART-6054
This is to enable prepare_release.py to set advisory dependencies (read story for details)

To test, in elliott dir, open python shell
```python3
from elliottlib.errata import get_blocking_errata, set_blocking_errata
set_blocking_errata(110351,110349,"SHIPPED_LIVE")
get_blocking_errata(110351)
```
then unset it at https://errata.devel.redhat.com/errata/edit_depends_on/110351

Keep in mind errata endpoints are weird
- The /erratum/{id} response doesn't mention blocking state
- The /blocking_errata_for/{id} response gives advisory in a weird format `{ "2023:0778": "SHIPPED_LIVE"}`. So I'm content to check just the advisory ids from erratum endpoint and trust that the state would be correct.
- The set blocker errata and set blocker state for advisory endpoints are extremely sensitive - the first one 404s if advisory is already listed (?) and second one 500s if advisory isn't added - not mentioning the fact that they are 2 separate endpoints.

So in prepare_release, we'll call get_blocking_errata for rpm, metadata, check image and extra ids are present - if not add them. 



