### PR TITLE
fix snyk import error

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -32,7 +32,7 @@
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
 	// Uncomment the next line to run commands after the container is created - for example installing git.
-	"postCreateCommand": "sudo chown -R dev: /workspaces/elliott-working-dir && pip3 install --user -r requirements-dev.txt -e .",
+	"postCreateCommand": "sudo chown -R dev: /workspaces/elliott-working-dir && pip3 install --user -r requirements-dev.txt -r requirements.txt -e .",
 	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"ms-python.python",

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: venv tox lint test
 
 install:
-	./venv/bin/pip install -r requirements-dev.txt
+	./venv/bin/pip install -r requirements-dev.txt -r requirements.txt
 
 venv:
 	python3.8 -m venv venv

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,4 @@
 pip>=20.3.3
-
--rrequirements.txt
-
 # test reqs
 flexmock
 mock>=4.0.3

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,9 @@
 envlist = py38
 
 [testenv]
-deps = -rrequirements-dev.txt
+deps =
+    -r requirements-dev.txt
+    -r requirements.txt
 passenv = *
 setenv =
     PYTHONPATH={toxinidir}/elliottlib


### PR DESCRIPTION
according to https://app.snyk.io/org/openshift-art-build-bot/import-log/latest snyk require requirement-dev.txt follow the syntax that pkg should be in a list
test passed with
```
$./snyk test --file=requirements-dev.txt --package-manager=pip --command=python3

Testing ./ximhan/elliott...

Tested 76 dependencies for known issues, found 16 issues, 39 vulnerable paths.


Issues to fix by upgrading dependencies:

  Upgrade future@0.18.2 to future@0.18.3 to fix
  ✗ Regular Expression Denial of Service (ReDoS) [High Severity][https://security.snyk.io/vuln/SNYK-PYTHON-FUTURE-3180414] in future@0.18.2
    introduced by future@0.18.2

  Upgrade setuptools@58.0.4 to setuptools@65.5.1 to fix
  ✗ Regular Expression Denial of Service (ReDoS) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-SETUPTOOLS-3180412] in setuptools@58.0.4
    introduced by setuptools@58.0.4 and 1 other path(s)

  Pin certifi@2022.9.14 to certifi@2022.12.7 to fix
  ✗ Insufficient Verification of Data Authenticity [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-CERTIFI-3164749] in certifi@2022.9.14
    introduced by requests@2.28.1 > certifi@2022.9.14 and 10 other path(s)

  Pin cryptography@38.0.1 to cryptography@39.0.1 to fix
  ✗ Denial of Service (DoS) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-CRYPTOGRAPHY-3172287] in cryptography@38.0.1
    introduced by requests-kerberos@0.14.0 > cryptography@38.0.1 and 1 other path(s)
  ✗ Expected Behavior Violation (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-CRYPTOGRAPHY-3314966] in cryptography@38.0.1
    introduced by requests-kerberos@0.14.0 > cryptography@38.0.1 and 1 other path(s)
  ✗ Use After Free (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-CRYPTOGRAPHY-3315324] in cryptography@38.0.1
    introduced by requests-kerberos@0.14.0 > cryptography@38.0.1 and 1 other path(s)
  ✗ Timing Attack (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-CRYPTOGRAPHY-3315331] in cryptography@38.0.1
    introduced by requests-kerberos@0.14.0 > cryptography@38.0.1 and 1 other path(s)
  ✗ Denial of Service (DoS) (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-CRYPTOGRAPHY-3315452] in cryptography@38.0.1
    introduced by requests-kerberos@0.14.0 > cryptography@38.0.1 and 1 other path(s)
  ✗ Denial of Service (DoS) (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-CRYPTOGRAPHY-3315972] in cryptography@38.0.1
    introduced by requests-kerberos@0.14.0 > cryptography@38.0.1 and 1 other path(s)
  ✗ Denial of Service (DoS) (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-CRYPTOGRAPHY-3315975] in cryptography@38.0.1
    introduced by requests-kerberos@0.14.0 > cryptography@38.0.1 and 1 other path(s)
  ✗ Denial of Service (DoS) (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-CRYPTOGRAPHY-3316038] in cryptography@38.0.1
    introduced by requests-kerberos@0.14.0 > cryptography@38.0.1 and 1 other path(s)
  ✗ Buffer Overflow [High Severity][https://security.snyk.io/vuln/SNYK-PYTHON-CRYPTOGRAPHY-3112177] in cryptography@38.0.1
    introduced by requests-kerberos@0.14.0 > cryptography@38.0.1 and 1 other path(s)
  ✗ Buffer Overflow [High Severity][https://security.snyk.io/vuln/SNYK-PYTHON-CRYPTOGRAPHY-3112180] in cryptography@38.0.1
    introduced by requests-kerberos@0.14.0 > cryptography@38.0.1 and 1 other path(s)
  ✗ Access of Resource Using Incompatible Type ('Type Confusion') (new) [High Severity][https://security.snyk.io/vuln/SNYK-PYTHON-CRYPTOGRAPHY-3315328] in cryptography@38.0.1
    introduced by requests-kerberos@0.14.0 > cryptography@38.0.1 and 1 other path(s)
  ✗ Denial of Service (DoS) (new) [High Severity][https://security.snyk.io/vuln/SNYK-PYTHON-CRYPTOGRAPHY-3316211] in cryptography@38.0.1
    introduced by requests-kerberos@0.14.0 > cryptography@38.0.1 and 1 other path(s)

  Pin oauthlib@3.2.1 to oauthlib@3.2.2 to fix
  ✗ Denial of Service (DoS) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-OAUTHLIB-3021142] in oauthlib@3.2.1
    introduced by jira@3.4.1 > requests-oauthlib@1.3.1 > oauthlib@3.2.1
```
