### PR TITLE
Fix version detection error on pip installations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ cover
 *.egg-info
 .tox
 
+# Ignore _version.py created by setuptools_scm
+_version.py
 
 # Ignore emacs backup files
 *~

--- a/elliottlib/__init__.py
+++ b/elliottlib/__init__.py
@@ -1,15 +1,16 @@
 import os
 import sys
-from setuptools_scm import get_version
 
 if sys.version_info < (3, 8):
     sys.exit('Sorry, Python < 3.8 is no longer supported.')
-from .runtime import Runtime
+
+from elliottlib.runtime import Runtime
 
 
 def version():
-    return get_version(
-        root=os.path.abspath(
-            os.path.join(os.path.dirname(__file__), '..')
-        )
-    )
+    try:
+        from ._version import version
+    except ImportError:
+        from setuptools_scm import get_version
+        version = get_version()
+    return version

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,9 @@ setup(
     name="rh-elliott",
     author="AOS ART Team",
     author_email="aos-team-art@redhat.com",
-    use_scm_version=True,
+    use_scm_version={
+        'write_to': 'elliottlib/_version.py',
+    },
     setup_requires=['setuptools_scm'],
     description="CLI tool for managing and automating Red Hat software releases",
     long_description=open('README.md').read(),


### PR DESCRIPTION
Fix the following error when invoking `elliott --version` on an installation without the source git repository:

```
LookupError: setuptools-scm was unable to detect version for /usr/local/lib/python3.11/site-packages.
```

Steps to reproduce:

```sh
pip install .

elliott --version
```

This can be solved by introducting setuptools_scm to write a file containing the to-be-installed version.