### PR TITLE
Fix CWE-502: Deserialization of Untrusted Data

### DIFF
--- a/elliottlib/cli/verify_attached_operators_cli.py
+++ b/elliottlib/cli/verify_attached_operators_cli.py
@@ -124,7 +124,7 @@ def _download_appregistry_image_references(appregistry_build):
                 with z.open(filename) as csv_file:
                     if csv:
                         raise ElliottFatalError(f"found more than one CSV in {appregistry_build['nvr']}?!? {filename}")
-                    csv = yaml.full_load(csv_file)
+                    csv = yaml.safe_load(csv_file)
 
     if not csv:
         raise ElliottFatalError(f"could not find the csv for appregistry {appregistry_build['nvr']}")

--- a/elliottlib/gitdata.py
+++ b/elliottlib/gitdata.py
@@ -222,7 +222,7 @@ class GitData(object):
                                 raw_text = raw_text.format(**replace_vars)
                             except KeyError as e:
                                 raise ValueError(f'{data_file} contains template key `{e.args[0]}` but no value was provided')
-                        data = yaml.full_load(raw_text)
+                        data = yaml.safe_load(raw_text)
                         use = True
                         if exclude and base_name in exclude:
                             use = False


### PR DESCRIPTION
This issue is reported by Snyk. Use `yaml.safe_load` instead.
