### PR TITLE
Ignore on_qa bugs when checking for regression

### DIFF
--- a/elliottlib/cli/verify_attached_bugs_cli.py
+++ b/elliottlib/cli/verify_attached_bugs_cli.py
@@ -346,12 +346,12 @@ class BugValidator:
         return k
 
     def _verify_blocking_bugs(self, blocking_bugs_for):
-        # complain about blocker bugs that aren't verified or shipped
+        # complain about blocking bugs that aren't verified or shipped
         for bug, blockers in blocking_bugs_for.items():
             for blocker in blockers:
                 message = str()
                 if blocker.status not in ['VERIFIED', 'RELEASE_PENDING', 'CLOSED', 'Release Pending', 'Verified',
-                                          'Closed']:
+                                          'Closed'] and not (blocker.status == bug.status == "ON_QA"):
                     if self.output == 'text':
                         message = f"Regression possible: {bug.status} bug {bug.id} is a backport of bug " \
                             f"{blocker.id} which has status {blocker.status}"

--- a/tests/test_verify_attached_bugs_cli.py
+++ b/tests/test_verify_attached_bugs_cli.py
@@ -38,7 +38,7 @@ class VerifyAttachedBugs(asynctest.TestCase):
                      status='ON_QA', is_ocp_bug=lambda: True, is_tracker_bug=lambda: False, is_cve_in_summary=lambda: False)
         ]
         depend_on_bugs = [
-            flexmock(id="OCPBUGS-3", target_release=['4.7.z'], status='ON_QA',
+            flexmock(id="OCPBUGS-3", target_release=['4.7.z'], status='MODIFIED',
                      is_ocp_bug=lambda: True, is_tracker_bug=lambda: False, is_cve_in_summary=lambda: False),
             flexmock(id="OCPBUGS-4", target_release=['4.7.z'], status='Release Pending',
                      is_ocp_bug=lambda: True, is_tracker_bug=lambda: False, is_cve_in_summary=lambda: False)
@@ -54,7 +54,8 @@ class VerifyAttachedBugs(asynctest.TestCase):
 
         result = runner.invoke(cli, ['-g', 'openshift-4.6', '--assembly=4.6.6', 'verify-bugs'])
         self.assertEqual(result.exit_code, 1)
-        self.assertIn('Regression possible: ON_QA bug OCPBUGS-2 is a backport of bug OCPBUGS-3 which has status ON_QA', result.output)
+        self.assertIn('Regression possible: ON_QA bug OCPBUGS-2 is a backport of bug OCPBUGS-3 which has status MODIFIED',
+                      result.output)
 
     @async_patch('elliottlib.cli.verify_attached_bugs_cli.BugValidator.verify_bugs_multiple_advisories')
     @async_patch('elliottlib.errata_async.AsyncErrataAPI.login')
@@ -76,7 +77,7 @@ class VerifyAttachedBugs(asynctest.TestCase):
                      status='ON_QA', is_ocp_bug=lambda: True, is_tracker_bug=lambda: False, is_cve_in_summary=lambda: False)
         ]
         depend_on_bugs = [
-            flexmock(id="OCPBUGS-3", target_release=['4.7.z'], status='ON_QA',
+            flexmock(id="OCPBUGS-3", target_release=['4.7.z'], status='MODIFIED',
                      is_ocp_bug=lambda: True, is_tracker_bug=lambda: False, is_cve_in_summary=lambda: False),
             flexmock(id="OCPBUGS-4", target_release=['4.7.z'], status='Release Pending',
                      is_ocp_bug=lambda: True, is_tracker_bug=lambda: False, is_cve_in_summary=lambda: False)
@@ -98,8 +99,8 @@ class VerifyAttachedBugs(asynctest.TestCase):
         #     t = "\n".join(traceback.format_exception(exc_type, exc_value, exc_traceback))
         #     self.fail(t)
         self.assertEqual(result.exit_code, 1)
-        self.assertIn('Regression possible: ON_QA bug OCPBUGS-2 is a backport of bug OCPBUGS-3 which has status ON_QA',
-                      result.output)
+        self.assertIn('Regression possible: ON_QA bug OCPBUGS-2 is a backport of bug OCPBUGS-3 which has status '
+                      'MODIFIED', result.output)
 
     @async_patch('elliottlib.cli.verify_attached_bugs_cli.BugValidator.verify_bugs_multiple_advisories')
     @async_patch('elliottlib.errata_async.AsyncErrataAPI.login')


### PR DESCRIPTION
Often times, we would complain about on_qa to on_qa bugs
when checking for regression, which creates confusion 
when it is posted on #forum-release as part of check-bugs
(https://redhat-internal.slack.com/archives/CJARLA942/p1677594929245159)

But this case is not regression, 
(regression would be if the blocking bug (e.g. 4.11) status is modified, 
and blocked bug (backported bug e.g. 4.10) is on_qa). So ignore this case
