### PR TITLE
Fix an issue in bug cutoff timestamps estimate

### DIFF
--- a/elliottlib/bzutil.py
+++ b/elliottlib/bzutil.py
@@ -1128,8 +1128,8 @@ async def approximate_cutoff_timestamp(basis_event: int, koji_api: ClientSession
     """ Calculate an approximate sweep cutoff timestamp from the given basis event
     """
     basis_timestamp = koji_api.getEvent(basis_event)["ts"]
-    builds: List[Dict] = await asyncio.gather(*[exectools.to_thread(meta.get_latest_build, complete_before_event=basis_event, honor_is=False) for meta in metas])
-    nvrs = [b["nvr"] for b in builds]
+    builds: List[Dict] = await asyncio.gather(*[exectools.to_thread(meta.get_latest_build, default=None, complete_before_event=basis_event, honor_is=False) for meta in metas])
+    nvrs = [b["nvr"] for b in builds if b]
     rebase_timestamp_strings = filter(None, [isolate_timestamp_in_release(nvr) for nvr in nvrs])  # the timestamp in the release field of NVR is the approximate rebase time
     # convert to UNIX timestamps
     rebase_timestamps = [datetime.strptime(ts, "%Y%m%d%H%M%S").replace(tzinfo=timezone.utc).timestamp()


### PR DESCRIPTION
Elliott uses timestamps encoded in image NVRs to estimate the bug cutoff timestamp when sweeping bugs with a Brew event.

When there is a new image added to ocp-build-data, the build might not exist at the moment of the Brew event. Then we will see an error like:

```
OSError: No builds detected for using prefix: 'nmstate-console-plugin-container-v4.13.', extra_pattern: '*', assembly: 'stream', build_state: 'COMPLETE', el_target: 'None'
```

We need to update `bzutil.approximate_cutoff_timestamp` to ignore non-existent builds when estimating cutoff timestamps.